### PR TITLE
Issue 406

### DIFF
--- a/aws/core/src/main/java/org/jclouds/aws/ec2/compute/functions/RunningInstanceToNodeMetadata.java
+++ b/aws/core/src/main/java/org/jclouds/aws/ec2/compute/functions/RunningInstanceToNodeMetadata.java
@@ -101,9 +101,20 @@ public class RunningInstanceToNodeMetadata implements Function<RunningInstance, 
       builder.imageId(instance.getRegion() + "/" + instance.getImageId());
 
       // extract the operating system from the image
-      Image image = instanceToImage.get(new RegionAndName(instance.getRegion(), instance.getImageId()));
-      if (image != null)
-         builder.operatingSystem(image.getOperatingSystem());
+      RegionAndName regionAndName = new RegionAndName(instance.getRegion(), instance.getImageId());
+      try {
+         Image image = instanceToImage.get(regionAndName);
+          if (image != null)
+              builder.operatingSystem(image.getOperatingSystem());
+      }
+      catch (NullPointerException e) {
+          // The instanceToImage Map may throw NullPointerException (actually subclass NullOutputException) if the
+          // computing Function returns a null value.
+          //
+          // See the following for more information:
+          // MapMaker.makeComputingMap()
+          // RegionAndIdToImage.apply()
+      }
 
       return builder.build();
    }


### PR DESCRIPTION
Fixed issue 406 (http://code.google.com/p/jclouds/issues/detail?id=406).

The solution handles the NPE using a try-catch.

An alternative solution would be to return some kind of Null-Object from the apply() method in RegionAndIdToImage. This would however require more work.
