### PR TITLE
jsch upgrade

### DIFF
--- a/antcontrib/pom.xml
+++ b/antcontrib/pom.xml
@@ -63,7 +63,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
         </dependency>
     </dependencies>
 

--- a/apis/byon/pom.xml
+++ b/apis/byon/pom.xml
@@ -76,7 +76,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/apis/cloudservers/pom.xml
+++ b/apis/cloudservers/pom.xml
@@ -82,7 +82,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/apis/ec2/pom.xml
+++ b/apis/ec2/pom.xml
@@ -85,7 +85,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/apis/elasticstack/pom.xml
+++ b/apis/elasticstack/pom.xml
@@ -72,7 +72,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/apis/eucalyptus/pom.xml
+++ b/apis/eucalyptus/pom.xml
@@ -77,7 +77,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/apis/vcloud/pom.xml
+++ b/apis/vcloud/pom.xml
@@ -83,7 +83,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/apis/vcloudexpress/pom.xml
+++ b/apis/vcloudexpress/pom.xml
@@ -83,7 +83,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/drivers/jsch/pom.xml
+++ b/drivers/jsch/pom.xml
@@ -73,7 +73,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -197,6 +197,11 @@
                 <artifactId>jetty-ssl</artifactId>
                 <version>7.0.0.pre5</version>
             </dependency>
+            <dependency>
+                <groupId>com.jcraft</groupId>
+                <artifactId>jsch</artifactId>
+                <version>0.1.44-1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>

--- a/providers/aws-ec2/pom.xml
+++ b/providers/aws-ec2/pom.xml
@@ -88,7 +88,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/providers/bluelock-vcdirector/pom.xml
+++ b/providers/bluelock-vcdirector/pom.xml
@@ -90,7 +90,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/providers/cloudservers-uk/pom.xml
+++ b/providers/cloudservers-uk/pom.xml
@@ -88,7 +88,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/providers/cloudservers-us/pom.xml
+++ b/providers/cloudservers-us/pom.xml
@@ -88,7 +88,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/providers/cloudsigma-zrh/pom.xml
+++ b/providers/cloudsigma-zrh/pom.xml
@@ -59,7 +59,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/providers/elastichosts-lon-b/pom.xml
+++ b/providers/elastichosts-lon-b/pom.xml
@@ -83,7 +83,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/providers/elastichosts-lon-p/pom.xml
+++ b/providers/elastichosts-lon-p/pom.xml
@@ -83,7 +83,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/providers/elastichosts-sat-p/pom.xml
+++ b/providers/elastichosts-sat-p/pom.xml
@@ -83,7 +83,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/providers/eucalyptus-partnercloud-ec2/pom.xml
+++ b/providers/eucalyptus-partnercloud-ec2/pom.xml
@@ -91,7 +91,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/providers/gogrid/pom.xml
+++ b/providers/gogrid/pom.xml
@@ -56,7 +56,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/providers/openhosting-east1/pom.xml
+++ b/providers/openhosting-east1/pom.xml
@@ -83,7 +83,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/providers/serverlove-z1-man/pom.xml
+++ b/providers/serverlove-z1-man/pom.xml
@@ -83,7 +83,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/providers/skalicloud-sdg-my/pom.xml
+++ b/providers/skalicloud-sdg-my/pom.xml
@@ -83,7 +83,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/providers/slicehost/pom.xml
+++ b/providers/slicehost/pom.xml
@@ -80,7 +80,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/providers/trmk-ecloud/pom.xml
+++ b/providers/trmk-ecloud/pom.xml
@@ -97,7 +97,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/providers/trmk-vcloudexpress/pom.xml
+++ b/providers/trmk-vcloudexpress/pom.xml
@@ -97,7 +97,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/sandbox-apis/cloudstack/pom.xml
+++ b/sandbox-apis/cloudstack/pom.xml
@@ -77,7 +77,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/sandbox-apis/deltacloud/pom.xml
+++ b/sandbox-apis/deltacloud/pom.xml
@@ -79,7 +79,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/sandbox-apis/elb/pom.xml
+++ b/sandbox-apis/elb/pom.xml
@@ -75,7 +75,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/sandbox-apis/libvirt/pom.xml
+++ b/sandbox-apis/libvirt/pom.xml
@@ -102,7 +102,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sandbox-apis/nova-ec2/pom.xml
+++ b/sandbox-apis/nova-ec2/pom.xml
@@ -77,7 +77,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/sandbox-apis/vi/pom.xml
+++ b/sandbox-apis/vi/pom.xml
@@ -95,7 +95,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sandbox-providers/aws-elb/pom.xml
+++ b/sandbox-providers/aws-elb/pom.xml
@@ -89,7 +89,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/sandbox-providers/ibmdev/pom.xml
+++ b/sandbox-providers/ibmdev/pom.xml
@@ -103,7 +103,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sandbox-providers/rimuhosting/pom.xml
+++ b/sandbox-providers/rimuhosting/pom.xml
@@ -51,7 +51,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/sandbox-providers/savvis/pom.xml
+++ b/sandbox-providers/savvis/pom.xml
@@ -93,7 +93,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
jsch 0.1.44 in maven central is corrupted, 0.1.44-1 should be used. Also centralize the version in just one place
