### PR TITLE
ScriptBuilder fixes for classloader issues

### DIFF
--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/util/Utils.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/util/Utils.java
@@ -134,8 +134,8 @@ public class Utils {
 
    public static String writeFunctionFromResource(String function, OsFamily family) {
       try {
-         return CharStreams.toString(Resources.newReaderSupplier(Resources.getResource(String
-                  .format("functions/%s.%s", function, ShellToken.SH.to(family))), Charsets.UTF_8));
+         return CharStreams.toString(Resources.newReaderSupplier(Resources.getResource(Utils.class, String
+                  .format("/functions/%s.%s", function, ShellToken.SH.to(family))), Charsets.UTF_8));
       } catch (IOException e) {
          throw new FunctionNotFoundException(function, family, e);
       }


### PR DESCRIPTION
This seems to fix issues with any container that has funky classloaders such as OSGi, Jenkins Plugins, and probably others.  Not sure if this is totally kosher, but it does not cause test failures on existing test cases.
