### PR TITLE
Fix list blobs: lazification and optional prefix

### DIFF
--- a/blobstore/src/main/clojure/org/jclouds/blobstore.clj
+++ b/blobstore/src/main/clojure/org/jclouds/blobstore.clj
@@ -141,8 +141,10 @@ Options can also be specified for extension modules
 
 (defn- list-blobs-chunk [container prefix #^BlobStore blobstore & [marker]]
   (apply list-container blobstore container
-         :in-directory prefix (when (string? marker)
-                                [:after-marker marker])))
+         (concat (when prefix
+                   [:in-directory prefix])
+                 (when (string? marker)
+                   [:after-marker marker]))))
 
 (defn- list-blobs-chunks [container prefix #^BlobStore blobstore marker]
   (when marker
@@ -161,7 +163,9 @@ Note: (apply concat coll) or (lazy-cat coll) are not lazy wrt coll itself."
 (defn list-blobs
   "Returns a lazy seq of all blobs in the given container."
   ([container prefix #^BlobStore blobstore]
-     (concat-elements (list-blobs-chunks container prefix blobstore :start))))
+     (concat-elements (list-blobs-chunks container prefix blobstore :start)))
+  ([container #^BlobStore blobstore]
+     (list-blobs container nil blobstore)))
 
 (defn locations
   "Retrieve the available container locations for the blobstore context."


### PR DESCRIPTION
In the current master branch, blobstore/list-blobs is not lazy even though it claims that it is.
 The first commit in this request fixes that.

Also, list-blobs requires a prefix argument, meaning you cannot actually request all blobs in a container.
  The second commit in this request makes the prefix argument optional.

Tested on S3 with ~ 350,000 fairly large blobs, where the original list-blobs will run out of memory.

Cheers,
Joost Diepenmaat
Zeekat Softwareontwikkeling.
