### PR TITLE
Updates to blobstore2

### DIFF
--- a/blobstore/src/main/clojure/org/jclouds/blobstore2.clj
+++ b/blobstore/src/main/clojure/org/jclouds/blobstore2.clj
@@ -47,7 +47,8 @@ See http://code.google.com/p/jclouds for details."
            [org.jclouds.blobstore
             AsyncBlobStore domain.BlobBuilder BlobStore BlobStoreContext
             BlobStoreContextFactory domain.BlobMetadata domain.StorageMetadata
-            domain.Blob domain.internal.BlobBuilderImpl
+            domain.Blob domain.internal.BlobBuilderImpl options.PutOptions
+            options.PutOptions$Builder
             options.CreateContainerOptions options.ListContainerOptions]
            org.jclouds.io.Payloads
            java.util.Arrays
@@ -225,9 +226,10 @@ Options can also be specified for extension modules
 (defn put-blob
   "Put a blob.  Metadata in the blob determines location."
   [^BlobStore blobstore container-name blob & {:keys [multipart?]}]
-  (if multipart?
-    (.putBlobMultipart blobstore container-name blob)
-    (.putBlob blobstore container-name blob)))
+  (let [options (if multipart?
+                  (PutOptions$Builder/multipart)
+                  (PutOptions.))]
+    (.putBlob blobstore container-name blob options)))
 
 (defn blob-metadata
   "Get metadata from given path"

--- a/blobstore/src/test/clojure/org/jclouds/blobstore2_test.clj
+++ b/blobstore/src/test/clojure/org/jclouds/blobstore2_test.clj
@@ -107,6 +107,14 @@
   (is (= "blob2" (Strings2/toStringAndClose (get-blob-stream *blobstore*
                                                              "blob" "blob2")))))
 
+(deftest put-blob-test
+  ;; Check multipart works
+  (is (create-container *blobstore* "blobs"))
+  (is (put-blob *blobstore* "blobs"
+                (blob "blob1" :payload "blob1")
+                :multipart? true))
+  (is (= 1 (count (blobs *blobstore* "blobs")))))
+
 (deftest sign-get-test
   (let [request (sign-get *blobstore* "container" "path")]
     (is (= "http://localhost/container/path" (str (.getEndpoint request))))


### PR DESCRIPTION
Added the ability to create a container publicly readable to create-container, and made the location parameter be given as a keyword arg. Also added multipart upload support to put-blob. 
