### PR TITLE
Core plumbing for ServiceLoader-based plugin system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ test-output/
 *.iml
 *.ipr
 *.iws
+TAGS

--- a/core/src/main/java/org/jclouds/providers/ProviderMetadata.java
+++ b/core/src/main/java/org/jclouds/providers/ProviderMetadata.java
@@ -1,0 +1,69 @@
+/**
+ *
+ * Copyright (C) 2011 Cloud Conscious, LLC. <info@cloudconscious.com>
+ *
+ * ====================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ====================================================================
+ */
+package org.jclouds.providers;
+
+import java.net.URI;
+
+/**
+ * The ProviderMetadata interface allows jclouds to provide a plugin framework
+ * for gathering cloud provider metadata.
+ *
+ * @author Jeremy Whitlock <jwhitlock@apache.org>
+ */
+public interface ProviderMetadata {
+
+   public static final String BLOBSTORE_TYPE = "blobstore";
+   public static final String COMPUTE_TYPE = "compute";
+
+  /**
+   * Returns an identifier unique to the provider.
+   *
+   * @return the provider's unique identifier
+   */
+  public String getId();
+
+  /**
+   * Returns the provider type.
+   *
+   * @return the provider's type
+   */
+  public String getType();
+
+  /**
+   * Returns the name of the provider.
+   *
+   * @return the name (display name) of the provider
+   */
+  public String getName();
+
+  /**
+   * Returns the URI to the provider's homepage.
+   *
+   * @return the url for the provider's homepage
+   */
+  public URI getHomepage();
+
+  /**
+   * Returns the URI to the provider's console.
+   *
+   * @return the url for the provider's console
+   */
+  public URI getConsole();
+
+}

--- a/core/src/main/java/org/jclouds/providers/ProviderPredicates.java
+++ b/core/src/main/java/org/jclouds/providers/ProviderPredicates.java
@@ -1,0 +1,100 @@
+/**
+ *
+ * Copyright (C) 2011 Cloud Conscious, LLC. <info@cloudconscious.com>
+ *
+ * ====================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ====================================================================
+ */
+package org.jclouds.providers;
+
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+
+import org.jclouds.util.Preconditions2;
+
+/**
+ * Container for provider filters (predicates).
+ *
+ * @author Jeremy Whitlock <jwhitlock@apache.org>
+ */
+public class ProviderPredicates {
+
+   /**
+    * Returns all providers available to jclouds regardless of type.
+    *
+    * @return all available providers
+    */
+   public static Predicate<ProviderMetadata> all() {
+      return Predicates.<ProviderMetadata> alwaysTrue();
+   }
+
+   /**
+    * Returns all providers with the given id.
+    *
+    * @param id
+    *           the id of the provider to return
+    *
+    * @return the providers with the given id
+    */
+   public static Predicate<ProviderMetadata> id(final String id) {
+      Preconditions2.checkNotEmpty(id, "id must be defined");
+      return new Predicate<ProviderMetadata>() {
+         /**
+          * {@see com.google.common.base.Predicate#apply(T)
+          */
+         @Override
+         public boolean apply(ProviderMetadata providerMetadata) {
+            return providerMetadata.getId().equals(id);
+         }
+
+         /**
+          * {@see java.lang.Object#toString()
+          */
+         @Override
+         public String toString() {
+            return "id(" + id + ")";
+         }
+      };
+   }
+
+   /**
+    * Returns all providers with the given type.
+    *
+    * @param type
+    *           the type of the provider to return
+    *
+    * @return the providers with the given type
+    */
+   public static Predicate<ProviderMetadata> type(final String type) {
+      Preconditions2.checkNotEmpty(type, "type must be defined");
+      return new Predicate<ProviderMetadata>() {
+         /**
+          * {@see com.google.common.base.Predicate#apply(T)
+          */
+         @Override
+         public boolean apply(ProviderMetadata providerMetadata) {
+            return providerMetadata.getType().equals(type);
+         }
+
+         /**
+          * {@see java.lang.Object#toString()
+          */
+         @Override
+         public String toString() {
+            return "type(" + type + ")";
+         }
+      };
+   }
+
+}

--- a/core/src/main/java/org/jclouds/providers/Providers.java
+++ b/core/src/main/java/org/jclouds/providers/Providers.java
@@ -1,0 +1,101 @@
+/**
+ *
+ * Copyright (C) 2011 Cloud Conscious, LLC. <info@cloudconscious.com>
+ *
+ * ====================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ====================================================================
+ */
+package org.jclouds.providers;
+
+import static com.google.common.collect.Iterables.filter;
+import static com.google.common.collect.Iterables.find;
+
+import java.util.NoSuchElementException;
+import java.util.ServiceLoader;
+
+/**
+ * The Providers class provides static methods for accessing providers.
+ *
+ * @author Jeremy Whitlock <jwhitlock@apache.org>
+ */
+public class Providers {
+
+   /**
+    * Returns the providers located on the classpath via
+    * {@link java.util.ServiceLoader}.
+    *
+    * @return all available providers loaded from classpath via ServiceLoader
+    */
+   private static Iterable<ProviderMetadata> fromServiceLoader() {
+      return ServiceLoader.load(ProviderMetadata.class);
+   }
+
+   /**
+    * Returns all available providers.
+    *
+    * @return all available providers
+    */
+   public static Iterable<ProviderMetadata> all() {
+      return fromServiceLoader();
+   }
+
+   /**
+    * Returns the first provider with the provided id
+    *
+    * @param id
+    *           the id of the provider to return
+    *
+    * @return the provider with the given id
+    *
+    * @throws NoSuchElementException
+    *           whenever there are no providers with the provided id
+    */
+   public static ProviderMetadata withId(String id)
+      throws NoSuchElementException {
+      return find(all(), ProviderPredicates.id(id));
+   }
+
+   /**
+    * Returns the providers that are of type
+    * {@link org.jclouds.providers.ProviderMetadata#BLOBSTORE_TYPE}.
+    *
+    * @return the blobstore providers
+    */
+   public static Iterable<ProviderMetadata> allBlobStore() {
+      return filter(all(), ProviderPredicates.type(ProviderMetadata.BLOBSTORE_TYPE));
+   }
+
+   /**
+    * Returns the providers that are of type
+    * {@link org.jclouds.providers.ProviderMetadata#COMPUTE_TYPE}.
+    *
+    * @return the compute service providers
+    */
+   public static Iterable<ProviderMetadata> allCompute() {
+      return filter(all(), ProviderPredicates.type(ProviderMetadata.COMPUTE_TYPE));
+   }
+
+   /**
+    * Returns the providers that are of the provided type.
+    *
+    * @param type
+    *           the type to providers to return
+    *
+    * @return the providers of the provided type
+    */
+   public static Iterable<ProviderMetadata> ofType(String type) {
+      return filter(all(), ProviderPredicates.type(type));
+   }
+
+}

--- a/core/src/test/java/org/jclouds/providers/JcloudsTestBlobStoreProviderMetadata.java
+++ b/core/src/test/java/org/jclouds/providers/JcloudsTestBlobStoreProviderMetadata.java
@@ -1,0 +1,70 @@
+/**
+ *
+ * Copyright (C) 2011 Cloud Conscious, LLC. <info@cloudconscious.com>
+ *
+ * ====================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ====================================================================
+ */
+package org.jclouds.providers;
+
+import java.net.URI;
+
+/**
+ * Implementation of {@ link org.jclouds.types.ProviderMetadata} for testing.
+ *
+ * @author Jeremy Whitlock <jwhitlock@apache.org>
+ */
+public class JcloudsTestBlobStoreProviderMetadata implements ProviderMetadata {
+
+   /**
+    * {@ see org.jclouds.types.ProviderMetadata#getId()}
+    */
+   @Override
+   public String getId() {
+      return "test-blobstore-provider";
+   }
+
+   /**
+    * {@ see org.jclouds.types.ProviderMetadata#getType()}
+    */
+   @Override
+   public String getType() {
+      return ProviderMetadata.BLOBSTORE_TYPE;
+   }
+
+   /**
+    * {@ see org.jclouds.types.ProviderMetadata#getName()}
+    */
+   @Override
+   public String getName() {
+      return "Test Blobstore Provider";
+   }
+
+   /**
+    * {@ see org.jclouds.types.ProviderMetadata#getHomepage()}
+    */
+   @Override
+   public URI getHomepage() {
+      return URI.create("http://jclouds.org");
+   }
+
+   /**
+    * {@ see org.jclouds.types.ProviderMetadata#getConsole()}
+    */
+   @Override
+   public URI getConsole() {
+      return URI.create("http://jclouds.org/console");
+   }
+
+}

--- a/core/src/test/java/org/jclouds/providers/JcloudsTestComputeProviderMetadata.java
+++ b/core/src/test/java/org/jclouds/providers/JcloudsTestComputeProviderMetadata.java
@@ -1,0 +1,70 @@
+/**
+ *
+ * Copyright (C) 2011 Cloud Conscious, LLC. <info@cloudconscious.com>
+ *
+ * ====================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ====================================================================
+ */
+package org.jclouds.providers;
+
+import java.net.URI;
+
+/**
+ * Implementation of {@ link org.jclouds.types.ProviderMetadata} for testing.
+ *
+ * @author Jeremy Whitlock <jwhitlock@apache.org>
+ */
+public class JcloudsTestComputeProviderMetadata implements ProviderMetadata {
+
+   /**
+    * {@ see org.jclouds.types.ProviderMetadata#getId()}
+    */
+   @Override
+   public String getId() {
+      return "test-compute-provider";
+   }
+
+   /**
+    * {@ see org.jclouds.types.ProviderMetadata#getType()}
+    */
+   @Override
+   public String getType() {
+      return ProviderMetadata.COMPUTE_TYPE;
+   }
+
+   /**
+    * {@ see org.jclouds.types.ProviderMetadata#getName()}
+    */
+   @Override
+   public String getName() {
+      return "Test Compute Provider";
+   }
+
+   /**
+    * {@ see org.jclouds.types.ProviderMetadata#getHomepage()}
+    */
+   @Override
+   public URI getHomepage() {
+      return URI.create("http://jclouds.org");
+   }
+
+   /**
+    * {@ see org.jclouds.types.ProviderMetadata#getConsole()}
+    */
+   @Override
+   public URI getConsole() {
+      return URI.create("http://jclouds.org/console");
+   }
+
+}

--- a/core/src/test/java/org/jclouds/providers/ProvidersTest.java
+++ b/core/src/test/java/org/jclouds/providers/ProvidersTest.java
@@ -1,0 +1,100 @@
+/**
+ *
+ * Copyright (C) 2011 Cloud Conscious, LLC. <info@cloudconscious.com>
+ *
+ * ====================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ====================================================================
+ */
+package org.jclouds.providers;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+import java.util.NoSuchElementException;
+
+import org.testng.annotations.Test;
+
+/**
+ * The ProvidersTest tests the org.jclouds.providers.Providers class.
+ *
+ * @author Jeremy Whitlock <jwhitlock@apache.org>
+ */
+@Test( groups = "unit" )
+public class ProvidersTest {
+
+   @Test
+   public void testWithId() {
+      ProviderMetadata providerMetadata;
+
+      try {
+         providerMetadata = Providers.withId("fake-id");
+         fail("Looking for a provider with an id that doesn't exist should " +
+              "throw an exceptoin.");
+      } catch (NoSuchElementException nsee) {
+         ; // Expected
+      }
+
+      providerMetadata = Providers.withId("test-blobstore-provider");
+
+      assertEquals("Test Blobstore Provider", providerMetadata.getName());
+   }
+
+   @Test
+   public void testOfType() {
+      Iterable<ProviderMetadata> providersMetadata = Providers.ofType(ProviderMetadata.BLOBSTORE_TYPE);
+
+      for (ProviderMetadata providerMetadata : providersMetadata) {
+         assertEquals("Test Blobstore Provider", providerMetadata.getName());
+         assertEquals("test-blobstore-provider", providerMetadata.getId());
+         assertEquals(ProviderMetadata.BLOBSTORE_TYPE, providerMetadata.getType());
+         assertEquals("http://jclouds.org", providerMetadata.getHomepage().toString());
+         assertEquals("http://jclouds.org/console", providerMetadata.getConsole().toString());
+      }
+
+      providersMetadata = Providers.ofType(ProviderMetadata.COMPUTE_TYPE);
+
+      for (ProviderMetadata providerMetadata : providersMetadata) {
+         assertEquals("Test Compute Provider", providerMetadata.getName());
+         assertEquals("test-compute-provider", providerMetadata.getId());
+         assertEquals(ProviderMetadata.COMPUTE_TYPE, providerMetadata.getType());
+         assertEquals("http://jclouds.org", providerMetadata.getHomepage().toString());
+         assertEquals("http://jclouds.org/console", providerMetadata.getConsole().toString());
+      }
+
+      providersMetadata = Providers.ofType("fake-type");
+
+      assertEquals(false, providersMetadata.iterator().hasNext());
+   }
+
+   @Test
+   public void testAll() {
+      Iterable<ProviderMetadata> providersMetadata = Providers.all();
+
+      for (ProviderMetadata providerMetadata : providersMetadata) {
+         if (providerMetadata.getName().equals("Test Blobstore Provider")) {
+            assertEquals("test-blobstore-provider", providerMetadata.getId());
+            assertEquals(ProviderMetadata.BLOBSTORE_TYPE, providerMetadata.getType());
+            assertEquals("http://jclouds.org", providerMetadata.getHomepage().toString());
+            assertEquals("http://jclouds.org/console", providerMetadata.getConsole().toString());
+         } else {
+            assertEquals("Test Compute Provider", providerMetadata.getName());
+            assertEquals("test-compute-provider", providerMetadata.getId());
+            assertEquals(ProviderMetadata.COMPUTE_TYPE, providerMetadata.getType());
+            assertEquals("http://jclouds.org", providerMetadata.getHomepage().toString());
+            assertEquals("http://jclouds.org/console", providerMetadata.getConsole().toString());
+         }
+      }
+   }
+
+}

--- a/core/src/test/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
+++ b/core/src/test/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
@@ -1,0 +1,2 @@
+org.jclouds.providers.JcloudsTestBlobStoreProviderMetadata
+org.jclouds.providers.JcloudsTestComputeProviderMetadata


### PR DESCRIPTION
Adds plumbing to the jclouds core to allow for refactoring the provider plugin
system, which initially will only be used for object metadata related to
cloud providers.
- .gitignore: Added an ignore pattern for Emacs etags file (TAGS).

[in core/src/main/java]
- org/jclouds/providers/ProviderMetadata.java: Added.
  (This file is a simple interface cloud providers will implement to be
  pluggable into this new plugin system.)
- org/jclouds/providers/ProviderPredicates.java: Added.
  (This file contains predicates that will filter Iterable<ProviderMetadata>
  objects.)
- org/jclouds/providers/Providers.java: Added.
  (This file contains "simplicity methods" for getting available cloud
  providers based on certain criteria, like by type or by id.)

[in core/src/test/java]
- org/jclouds/providers/JcloudsTestBlobStoreProviderMetadata.java,
  org/jclouds/providers/JcloudsTestComputeProviderMetadata.java: Added.
  (These files are implementations of org.jclouds.providers.ProviderMetadata
  used for testing purposes.)
- org/jclouds/providers/ProvidersTest.java: Added.
  (This file tests org.jclouds.providers.Providers.)

[in src/test/resources]
- META-INF/services/org.jclouds.providers.ProviderMetadata: Added.
  (This file is used by java.util.ServiceLoader to locate the available
  cloud provider implementations on the classpath.)
