### PR TITLE
Added an abstract ProviderMetadata object to allow for overriding the equals and hashCode methods.

### DIFF
--- a/core/src/main/java/org/jclouds/providers/BaseProviderMetadata.java
+++ b/core/src/main/java/org/jclouds/providers/BaseProviderMetadata.java
@@ -1,0 +1,101 @@
+/**
+ *
+ * Copyright (C) 2011 Cloud Conscious, LLC. <info@cloudconscious.com>
+ *
+ * ====================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ====================================================================
+ */
+package org.jclouds.providers;
+
+import java.net.URI;
+
+/**
+ * The BaseProviderMetadata class is an abstraction of {@link ProviderMetadata} to be extended
+ * by those implementing ProviderMetadata.
+ *
+ * @author Jeremy Whitlock <jwhitlock@apache.org>
+ */
+public abstract class BaseProviderMetadata implements ProviderMetadata {
+
+   /**
+    * @see java.lang.Object#hashCode()
+    */
+   @Override
+   public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      URI console = getConsole();
+      URI homepage = getHomepage();
+      String id = getId();
+      String name = getName();
+      String type = getType();
+
+      result = prime * result + ((console == null) ? 0 : console.hashCode());
+      result = prime * result
+              + ((homepage == null) ? 0 : homepage.hashCode());
+      result = prime * result + ((id == null) ? 0 : id.hashCode());
+      result = prime * result + ((name == null) ? 0 : name.hashCode());
+      result = prime * result + ((type == null) ? 0 : type.hashCode());
+      return result;
+    }
+
+   /**
+    * @see java.lang.Object#equals(java.lang.Object)
+    */
+   @Override
+   public boolean equals(Object obj) {
+      URI console = getConsole();
+      URI homepage = getHomepage();
+      String id = getId();
+      String name = getName();
+      String type = getType();
+
+      if (this == obj)
+         return true;
+      if (obj == null)
+         return false;
+      if (getClass() != obj.getClass())
+         return false;
+
+      ProviderMetadata other = (ProviderMetadata) obj;
+
+      if (console == null) {
+         if (other.getConsole() != null)
+            return false;
+      } else if (!console.equals(other.getConsole()))
+         return false;
+      if (homepage == null) {
+         if (other.getHomepage() != null)
+            return false;
+      } else if (!homepage.equals(other.getHomepage()))
+         return false;
+      if (id == null) {
+         if (other.getId() != null)
+            return false;
+      } else if (!id.equals(other.getId()))
+         return false;
+      if (name == null) {
+         if (other.getName() != null)
+            return false;
+      } else if (!name.equals(other.getName()))
+         return false;
+      if (type == null) {
+         if (other.getType() != null)
+            return false;
+      } else if (!type.equals(other.getType()))
+         return false;
+      return true;
+   }
+
+}

--- a/core/src/main/java/org/jclouds/providers/ProviderMetadata.java
+++ b/core/src/main/java/org/jclouds/providers/ProviderMetadata.java
@@ -31,39 +31,39 @@ public interface ProviderMetadata {
    public static final String BLOBSTORE_TYPE = "blobstore";
    public static final String COMPUTE_TYPE = "compute";
 
-  /**
-   * Returns an identifier unique to the provider.
-   *
-   * @return the provider's unique identifier
-   */
-  public String getId();
+   /**
+    * Returns an identifier unique to the provider.
+    *
+    * @return the provider's unique identifier
+    */
+   public String getId();
 
-  /**
-   * Returns the provider type.
-   *
-   * @return the provider's type
-   */
-  public String getType();
+   /**
+    * Returns the provider type.
+    *
+    * @return the provider's type
+    */
+   public String getType();
 
-  /**
-   * Returns the name of the provider.
-   *
-   * @return the name (display name) of the provider
-   */
-  public String getName();
+   /**
+    * Returns the name of the provider.
+    *
+    * @return the name (display name) of the provider
+    */
+   public String getName();
 
-  /**
-   * Returns the URI to the provider's homepage.
-   *
-   * @return the url for the provider's homepage
-   */
-  public URI getHomepage();
+   /**
+    * Returns the URI to the provider's homepage.
+    *
+    * @return the url for the provider's homepage
+    */
+   public URI getHomepage();
 
-  /**
-   * Returns the URI to the provider's console.
-   *
-   * @return the url for the provider's console
-   */
-  public URI getConsole();
+   /**
+    * Returns the URI to the provider's console.
+    *
+    * @return the url for the provider's console
+    */
+   public URI getConsole();
 
 }

--- a/core/src/test/java/org/jclouds/providers/JcloudsTestBlobStoreProviderMetadata.java
+++ b/core/src/test/java/org/jclouds/providers/JcloudsTestBlobStoreProviderMetadata.java
@@ -25,7 +25,7 @@ import java.net.URI;
  *
  * @author Jeremy Whitlock <jwhitlock@apache.org>
  */
-public class JcloudsTestBlobStoreProviderMetadata implements ProviderMetadata {
+public class JcloudsTestBlobStoreProviderMetadata extends BaseProviderMetadata {
 
    /**
     * {@ see org.jclouds.types.ProviderMetadata#getId()}

--- a/core/src/test/java/org/jclouds/providers/JcloudsTestComputeProviderMetadata.java
+++ b/core/src/test/java/org/jclouds/providers/JcloudsTestComputeProviderMetadata.java
@@ -25,7 +25,7 @@ import java.net.URI;
  *
  * @author Jeremy Whitlock <jwhitlock@apache.org>
  */
-public class JcloudsTestComputeProviderMetadata implements ProviderMetadata {
+public class JcloudsTestComputeProviderMetadata extends BaseProviderMetadata {
 
    /**
     * {@ see org.jclouds.types.ProviderMetadata#getId()}

--- a/core/src/test/java/org/jclouds/providers/ProvidersTest.java
+++ b/core/src/test/java/org/jclouds/providers/ProvidersTest.java
@@ -33,6 +33,9 @@ import org.testng.annotations.Test;
 @Test( groups = "unit" )
 public class ProvidersTest {
 
+   private final ProviderMetadata testBlobstoreProvider = new JcloudsTestBlobStoreProviderMetadata();
+   private final ProviderMetadata testComputeProvider = new JcloudsTestComputeProviderMetadata();
+
    @Test
    public void testWithId() {
       ProviderMetadata providerMetadata;
@@ -45,9 +48,9 @@ public class ProvidersTest {
          ; // Expected
       }
 
-      providerMetadata = Providers.withId("test-blobstore-provider");
+      providerMetadata = Providers.withId(testBlobstoreProvider.getId());
 
-      assertEquals("Test Blobstore Provider", providerMetadata.getName());
+      assertEquals(testBlobstoreProvider, providerMetadata);
    }
 
    @Test
@@ -55,21 +58,13 @@ public class ProvidersTest {
       Iterable<ProviderMetadata> providersMetadata = Providers.ofType(ProviderMetadata.BLOBSTORE_TYPE);
 
       for (ProviderMetadata providerMetadata : providersMetadata) {
-         assertEquals("Test Blobstore Provider", providerMetadata.getName());
-         assertEquals("test-blobstore-provider", providerMetadata.getId());
-         assertEquals(ProviderMetadata.BLOBSTORE_TYPE, providerMetadata.getType());
-         assertEquals("http://jclouds.org", providerMetadata.getHomepage().toString());
-         assertEquals("http://jclouds.org/console", providerMetadata.getConsole().toString());
+         assertEquals(testBlobstoreProvider, providerMetadata);
       }
 
       providersMetadata = Providers.ofType(ProviderMetadata.COMPUTE_TYPE);
 
       for (ProviderMetadata providerMetadata : providersMetadata) {
-         assertEquals("Test Compute Provider", providerMetadata.getName());
-         assertEquals("test-compute-provider", providerMetadata.getId());
-         assertEquals(ProviderMetadata.COMPUTE_TYPE, providerMetadata.getType());
-         assertEquals("http://jclouds.org", providerMetadata.getHomepage().toString());
-         assertEquals("http://jclouds.org/console", providerMetadata.getConsole().toString());
+         assertEquals(testComputeProvider, providerMetadata);
       }
 
       providersMetadata = Providers.ofType("fake-type");
@@ -83,16 +78,9 @@ public class ProvidersTest {
 
       for (ProviderMetadata providerMetadata : providersMetadata) {
          if (providerMetadata.getName().equals("Test Blobstore Provider")) {
-            assertEquals("test-blobstore-provider", providerMetadata.getId());
-            assertEquals(ProviderMetadata.BLOBSTORE_TYPE, providerMetadata.getType());
-            assertEquals("http://jclouds.org", providerMetadata.getHomepage().toString());
-            assertEquals("http://jclouds.org/console", providerMetadata.getConsole().toString());
+            assertEquals(testBlobstoreProvider, providerMetadata);
          } else {
-            assertEquals("Test Compute Provider", providerMetadata.getName());
-            assertEquals("test-compute-provider", providerMetadata.getId());
-            assertEquals(ProviderMetadata.COMPUTE_TYPE, providerMetadata.getType());
-            assertEquals("http://jclouds.org", providerMetadata.getHomepage().toString());
-            assertEquals("http://jclouds.org/console", providerMetadata.getConsole().toString());
+            assertEquals(testComputeProvider, providerMetadata);
          }
       }
    }


### PR DESCRIPTION
Added an abstract ProviderMetadata object to allow for overriding the equals and
hashCode methods.

[in core/src/main/java]
- org/jclouds/providers/BaseProviderMetadata.java: Added.
- org/jclouds/providers/ProviderMetadata.java: Fixed indentation to be three
  space based instead of two spaces.

[in core/src/test/java]
- org/jclouds/providers/JcloudsTestBlobStoreProviderMetadata.java,
  org/jclouds/providers/JcloudsTestComputeProviderMetadata.java: Updated to
  extend the new BaseProviderMetadata class instead of just implementing the
  ProviderMetadata interface.
- org/jclouds/providers/ProvidersTest.java
  (test*): Updated tests to check for ProviderMetadata object equality instead
  of testing each method individually.

Issue: http://code.google.com/p/jclouds/issues/detail?id=550
