### PR TITLE
Clojure bindings have invalid namespace imports

### DIFF
--- a/apis/ec2/src/main/clojure/org/jclouds/ec2/ebs.clj
+++ b/apis/ec2/src/main/clojure/org/jclouds/ec2/ebs.clj
@@ -25,20 +25,20 @@
   (:use (clojure.contrib def core))
   (:import org.jclouds.aws.domain.Region
     org.jclouds.compute.domain.NodeMetadata
-    (org.jclouds.aws.ec2.domain Volume Volume$Status Snapshot Snapshot$Status AvailabilityZone)
-    (org.jclouds.aws.ec2.options DescribeSnapshotsOptions DetachVolumeOptions CreateSnapshotOptions)))
+    (org.jclouds.ec2.domain Volume Volume$Status Snapshot Snapshot$Status AvailabilityZoneInfo)
+    (org.jclouds.ec2.options DescribeSnapshotsOptions DetachVolumeOptions CreateSnapshotOptions)))
 
 (defn snapshot?
-  "Returns true iff the argument is a org.jclouds.aws.ec2.domain.Snapshot."
+  "Returns true iff the argument is a org.jclouds.ec2.domain.Snapshot."
   [s]
   (instance? Snapshot s))
 
 (defn volume?
-  "Returns true iff the argument is a org.jclouds.aws.ec2.domain.Volume."
+  "Returns true iff the argument is a org.jclouds.ec2.domain.Volume."
   [v]
   (instance? Volume v))
 
-(defn #^org.jclouds.aws.ec2.services.ElasticBlockStoreClient
+(defn #^org.jclouds.ec2.services.ElasticBlockStoreClient
   ebs-service
   "Returns the synchronous ElasticBlockStoreClient associated with
    the specified compute service, or compute/*compute* as bound by with-compute-service."
@@ -74,7 +74,7 @@
                    (str "Can't obtain volume id from argument of type " (class v))))))
 
 (defn volumes
-  "Returns a set of org.jclouds.aws.ec2.domain.Volume instances corresponding to the
+  "Returns a set of org.jclouds.ec2.domain.Volume instances corresponding to the
    volumes in the specified region (defaulting to your account's default region).
 
    e.g. (with-compute-service [compute] (volumes))
@@ -172,7 +172,7 @@
 (defn get-zone
   [v]
   (cond
-    (instance? AvailabilityZone v) v
+    (instance? AvailabilityZoneInfo v) (.getZone  v)
     (instance? NodeMetadata v) (compute/location #^NodeMetadata v)
     (string? v) v
     (keyword? v) (name v)
@@ -225,14 +225,14 @@
 (defn create-volume
   "Creates a new volume given a set of options:
 
-   - one of :zone (keyword, string, or AvailabilityZone) or :node (NodeMetadata)
+   - one of :zone (keyword, string, or AvailabilityZoneInfo) or :node (NodeMetadata)
    - one or both of :snapshot (keyword, string, or Snapshot instance) or :size
      (string, keyword, or number)
    - :device (string or keyword) provided *only* when you want to attach the new volume to
      the :node you specified!
 
-   Returns a vector of [created org.jclouds.aws.ec2.domain.Volume,
-                        optional org.jclouds.aws.ec2.domain.Attachment]
+   Returns a vector of [created org.jclouds.ec2.domain.Volume,
+                        optional org.jclouds.ec2.domain.Attachment]
 
    Note that specifying :node instead of :zone will only attach the created volume
    :device is also provided.  Otherwise, the node is only used to obtain the desired

--- a/apis/ec2/src/main/clojure/org/jclouds/ec2/elastic_ip.clj
+++ b/apis/ec2/src/main/clojure/org/jclouds/ec2/elastic_ip.clj
@@ -22,12 +22,12 @@
      :doc "A clojure binding for the jclouds AWS elastic IP address interface."}
   org.jclouds.ec2.elastic-ip
   (:require (org.jclouds [compute :as compute])
-    [org.jclouds.aws.ebs :as ebs])
+    [org.jclouds.ec2.ebs :as ebs])
   (:use (clojure.contrib def core))
   (:import org.jclouds.compute.domain.NodeMetadata
-    (org.jclouds.aws.ec2.domain PublicIpInstanceIdPair)))
+    (org.jclouds.ec2.domain PublicIpInstanceIdPair)))
 
-(defn #^org.jclouds.aws.ec2.services.ElasticIPAddressClient
+(defn #^org.jclouds.ec2.services.ElasticIPAddressClient
   eip-service
   "Returns the synchronous ElasticIPAddressClient associated with
    the specified compute service, or compute/*compute* as bound by with-compute-service."


### PR DESCRIPTION
Caused by commit eedc94948e354f1e8b6d90981598aec677cdb741 (Issue 440:
moved ec2 into its own api module)
