### PR TITLE
Update Javadoc plugin version. Removes noisy maven Javadoc messages.

### DIFF
--- a/project/pom.xml
+++ b/project/pom.xml
@@ -371,7 +371,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.7</version>
                 <executions>
                     <execution>
                         <id>javadoc</id>
@@ -535,6 +534,10 @@ pageTracker._trackPageview();
                             <_nouses>true</_nouses>
                        </instructions>
                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.8</version>
                 </plugin>
             </plugins>            
         </pluginManagement>
@@ -743,7 +746,6 @@ pageTracker._trackPageview();
                     </plugin>
                     <plugin>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.7</version>
                         <configuration>
                             <encoding>${project.build.sourceEncoding}</encoding>
                             <quiet>true</quiet>
@@ -822,7 +824,6 @@ pageTracker._trackPageview();
                                     </plugin>
                                     <plugin>
                                         <artifactId>maven-javadoc-plugin</artifactId>
-                                        <version>2.7</version>
                                         <configuration>
                                             <encoding>${project.build.sourceEncoding}</encoding>
                                             <quiet>true</quiet>


### PR DESCRIPTION
This should improve performance on builds and clean up maven build output considerably. Specifically related to these issues: 
http://jira.codehaus.org/browse/MJAVADOC-284
http://jira.codehaus.org/browse/MJAVADOC-286
