### PR TITLE
Issue 550: Added support to retrieve ISO 3166 codes from ProviderMetadata.

### DIFF
--- a/core/src/main/java/org/jclouds/providers/BaseProviderMetadata.java
+++ b/core/src/main/java/org/jclouds/providers/BaseProviderMetadata.java
@@ -49,6 +49,7 @@ public abstract class BaseProviderMetadata implements ProviderMetadata {
       String credentialName = getCredentialName();
       String type = getType();
       Set<String> linkedServices = getLinkedServices();
+      Set<String> iso3166Codes = getIso3166Codes();
 
       result = prime * result + ((console == null) ? 0 : console.hashCode());
       result = prime * result + ((homepage == null) ? 0 : homepage.hashCode());
@@ -59,6 +60,7 @@ public abstract class BaseProviderMetadata implements ProviderMetadata {
       result = prime * result + ((credentialName == null) ? 0 : credentialName.hashCode());
       result = prime * result + ((type == null) ? 0 : type.hashCode());
       result = prime * result + ((linkedServices == null) ? 0 : linkedServices.hashCode());
+      result = prime * result + ((iso3166Codes == null) ? 0 : iso3166Codes.hashCode());
 
       return result;
    }
@@ -77,6 +79,7 @@ public abstract class BaseProviderMetadata implements ProviderMetadata {
       String tCredentialName = getCredentialName();
       String tType = getType();
       Set<String> tLinkedServices = getLinkedServices();
+      Set<String> tIso3166Codes = getIso3166Codes();
 
       if (this == obj)
          return true;
@@ -95,6 +98,7 @@ public abstract class BaseProviderMetadata implements ProviderMetadata {
       String oCredentialName = other.getCredentialName();
       String oType = other.getType();
       Set<String> oLinkedServices = other.getLinkedServices();
+      Set<String> oIso3166Codes = other.getIso3166Codes();
 
       if (tConsole == null) {
          if (oConsole != null)
@@ -141,6 +145,11 @@ public abstract class BaseProviderMetadata implements ProviderMetadata {
             return false;
       } else if (!tLinkedServices.equals(oLinkedServices))
          return false;
+      if (tIso3166Codes == null) {
+         if (oIso3166Codes != null)
+            return false;
+      } else if (!tIso3166Codes.equals(oIso3166Codes))
+         return false;
       return true;
    }
 
@@ -148,7 +157,8 @@ public abstract class BaseProviderMetadata implements ProviderMetadata {
    public String toString() {
       return "[id=" + getId() + ", type=" + getType() + ", name=" + getName() + ", identityName=" + getIdentityName()
                + ", credentialName=" + getCredentialName() + ", homePage=" + getHomepage() + ", console="
-               + getConsole() + ", apiDocs=" + getApiDocumentation() + ", linkedServices=" + getLinkedServices() + "]";
+               + getConsole() + ", apiDocs=" + getApiDocumentation() + ", linkedServices=" + getLinkedServices() +
+               ", iso3166Codes=" + getIso3166Codes() + "]";
    }
 
    @Override

--- a/core/src/main/java/org/jclouds/providers/ProviderMetadata.java
+++ b/core/src/main/java/org/jclouds/providers/ProviderMetadata.java
@@ -93,4 +93,10 @@ public interface ProviderMetadata {
     * @return all known services linked to the same account on this provider
     */
    public Set<String> getLinkedServices();
+
+   /**
+    * 
+    * @return all known region/location ISO 3166 codes
+    */
+   public Set<String> getIso3166Codes();
 }

--- a/core/src/test/java/org/jclouds/providers/JcloudsTestBlobStoreProviderMetadata.java
+++ b/core/src/test/java/org/jclouds/providers/JcloudsTestBlobStoreProviderMetadata.java
@@ -18,7 +18,10 @@
  */
 package org.jclouds.providers;
 
+import com.google.common.collect.ImmutableSet;
+
 import java.net.URI;
+import java.util.Set;
 
 /**
  * Implementation of @ link org.jclouds.types.ProviderMetadata} for testing.
@@ -89,6 +92,14 @@ public class JcloudsTestBlobStoreProviderMetadata extends BaseProviderMetadata {
    @Override
    public URI getApiDocumentation() {
       return URI.create("http://jclouds.org/documentation");
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public Set<String> getIso3166Codes() {
+      return ImmutableSet.of("US-VA", "US-CA");
    }
 
 }

--- a/core/src/test/java/org/jclouds/providers/JcloudsTestComputeProviderMetadata.java
+++ b/core/src/test/java/org/jclouds/providers/JcloudsTestComputeProviderMetadata.java
@@ -18,7 +18,10 @@
  */
 package org.jclouds.providers;
 
+import com.google.common.collect.ImmutableSet;
+
 import java.net.URI;
+import java.util.Set;
 
 /**
  * Implementation of @ link org.jclouds.types.ProviderMetadata} for testing.
@@ -89,6 +92,14 @@ public class JcloudsTestComputeProviderMetadata extends BaseProviderMetadata {
    @Override
    public URI getApiDocumentation() {
       return URI.create("http://jclouds.org/documentation");
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public Set<String> getIso3166Codes() {
+      return ImmutableSet.of("US-VA", "US-CA");
    }
 
 }

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/AWSEC2ProviderMetadata.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/AWSEC2ProviderMetadata.java
@@ -18,13 +18,13 @@
  */
 package org.jclouds.aws.ec2;
 
+import com.google.common.collect.ImmutableSet;
+
 import java.net.URI;
 import java.util.Set;
 
 import org.jclouds.providers.BaseProviderMetadata;
 import org.jclouds.providers.ProviderMetadata;
-
-import com.google.common.collect.ImmutableSet;
 
 /**
  * Implementation of {@ link org.jclouds.types.ProviderMetadata} for Amazon's
@@ -103,6 +103,14 @@ public class AWSEC2ProviderMetadata extends BaseProviderMetadata {
    @Override
    public Set<String> getLinkedServices() {
       return ImmutableSet.of("aws-s3", "aws-ec2", "aws-elb", "aws-simpledb");
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public Set<String> getIso3166Codes() {
+      return ImmutableSet.of("US-VA", "US-CA", "IE", "SG", "JP-13");
    }
 
 }

--- a/providers/aws-s3/src/main/java/org/jclouds/aws/s3/AWSS3ProviderMetadata.java
+++ b/providers/aws-s3/src/main/java/org/jclouds/aws/s3/AWSS3ProviderMetadata.java
@@ -18,13 +18,13 @@
  */
 package org.jclouds.aws.s3;
 
+import com.google.common.collect.ImmutableSet;
+
 import java.net.URI;
 import java.util.Set;
 
 import org.jclouds.providers.BaseProviderMetadata;
 import org.jclouds.providers.ProviderMetadata;
-
-import com.google.common.collect.ImmutableSet;
 
 /**
  * Implementation of @ link org.jclouds.types.ProviderMetadata} for Amazon's Simple Storage Service
@@ -104,6 +104,14 @@ public class AWSS3ProviderMetadata extends BaseProviderMetadata {
    @Override
    public Set<String> getLinkedServices() {
       return ImmutableSet.of("aws-s3", "aws-ec2", "aws-elb", "aws-simpledb");
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public Set<String> getIso3166Codes() {
+      return ImmutableSet.of("US", "US-CA", "IE", "SG", "JP-13");
    }
 
 }

--- a/providers/trmk-ecloud/src/main/java/org/jclouds/vcloud/terremark/TerremarkECloudProviderMetadata.java
+++ b/providers/trmk-ecloud/src/main/java/org/jclouds/vcloud/terremark/TerremarkECloudProviderMetadata.java
@@ -18,7 +18,10 @@
  */
 package org.jclouds.vcloud.terremark;
 
+import com.google.common.collect.ImmutableSet;
+
 import java.net.URI;
+import java.util.Set;
 
 import org.jclouds.providers.BaseProviderMetadata;
 import org.jclouds.providers.ProviderMetadata;
@@ -92,6 +95,14 @@ public class TerremarkECloudProviderMetadata extends BaseProviderMetadata {
    @Override
    public URI getApiDocumentation() {
       return URI.create("http://support.theenterprisecloud.com/kb/default.asp?id=533&Lang=1&SID=");
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public Set<String> getIso3166Codes() {
+      return ImmutableSet.of("US-FL");
    }
 
 }

--- a/providers/trmk-vcloudexpress/src/main/java/org/jclouds/vcloud/terremark/TerremarkVCloudExpressProviderMetadata.java
+++ b/providers/trmk-vcloudexpress/src/main/java/org/jclouds/vcloud/terremark/TerremarkVCloudExpressProviderMetadata.java
@@ -18,7 +18,10 @@
  */
 package org.jclouds.vcloud.terremark;
 
+import com.google.common.collect.ImmutableSet;
+
 import java.net.URI;
+import java.util.Set;
 
 import org.jclouds.providers.BaseProviderMetadata;
 import org.jclouds.providers.ProviderMetadata;
@@ -92,6 +95,14 @@ public class TerremarkVCloudExpressProviderMetadata extends BaseProviderMetadata
    @Override
    public URI getApiDocumentation() {
       return URI.create("https://community.vcloudexpress.terremark.com/en-us/product_docs/m/vcefiles/2342.aspx");
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public Set<String> getIso3166Codes() {
+      return ImmutableSet.of("US-FL");
    }
 
 }


### PR DESCRIPTION
Issue 550: Added support to retrieve ISO 3166 codes from ProviderMetadata.

[in core/src/main/java/org/jclouds]
- providers/BaseProviderMetadata.java
  (equals, hashCode): Updated for the iso 3166 codes.
- providers/ProviderMetadata.java
  (getIso3166Codes): Added.

[in core/src/main/test/org/jclouds]
- providers/JcloudsTestBlobStoreProviderMetadata.java,
  providers/JcloudsTestComputeProviderMetadata.java
  (getIso3166Codes): Added.

[in providers/aws-ec2/src/main/java/org/jclouds]
- aws/ec2/AWSEC2ProviderMetadata.java
  (getIso3166Codes): Added.

[in providers/aws-s3/src/main/java/org/jclouds]
- aws/s3/AWSS3ProviderMetadata.java
  (getIso3166Codes): Added.

[in providers/trmk-ecloud/src/main/java/org/jclouds]
- vcloud/terremark/TerremarkECloudProviderMetadata.java
  (getIso3166Codes): Added.

[in providers/trmk-vcloudexpress/src/main/java/org/jclouds]
- vcloud/terremark/TerremarkVCloudExpressProviderMetadata.java
  (getIso3166Codes): Added.
