### PR TITLE
Issue 550: Added support for finding providers that are in a particular "location" as identified by an ISO 3166 code.

### DIFF
--- a/core/src/main/java/org/jclouds/providers/ProviderPredicates.java
+++ b/core/src/main/java/org/jclouds/providers/ProviderPredicates.java
@@ -18,6 +18,7 @@
  */
 package org.jclouds.providers;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 
@@ -51,7 +52,7 @@ public class ProviderPredicates {
       Preconditions2.checkNotEmpty(id, "id must be defined");
       return new Predicate<ProviderMetadata>() {
          /**
-          * {@see com.google.common.base.Predicate#apply(T)
+          * {@inheritDoc}
           */
          @Override
          public boolean apply(ProviderMetadata providerMetadata) {
@@ -59,7 +60,7 @@ public class ProviderPredicates {
          }
 
          /**
-          * {@see java.lang.Object#toString()
+          * {@inheritDoc}
           */
          @Override
          public String toString() {
@@ -80,7 +81,7 @@ public class ProviderPredicates {
       Preconditions2.checkNotEmpty(type, "type must be defined");
       return new Predicate<ProviderMetadata>() {
          /**
-          * {@see com.google.common.base.Predicate#apply(T)
+          * {@inheritDoc}
           */
          @Override
          public boolean apply(ProviderMetadata providerMetadata) {
@@ -88,7 +89,7 @@ public class ProviderPredicates {
          }
 
          /**
-          * {@see java.lang.Object#toString()
+          * {@inheritDoc}
           */
          @Override
          public String toString() {
@@ -97,4 +98,42 @@ public class ProviderPredicates {
       };
    }
 
+   /**
+    * Returns all providers that are "in" the given ISO 3166 code.
+    * 
+    * @param iso3166Code the ISO 3166 code for the location/region to search for
+    * 
+    * @return the providers "in" the given ISO 3166 code
+    */
+   public static Predicate<ProviderMetadata> inIso3166Code(final String iso3166Code) {
+      Preconditions.checkNotNull(iso3166Code, "iso3166Code must not be null");
+
+      return new Predicate<ProviderMetadata>() {
+          /**
+           * {@inheritDoc}
+           */
+          @Override
+          public boolean apply(ProviderMetadata providerMetadata) {
+             for (String availCode : providerMetadata.getIso3166Codes()) {
+                if(iso3166Code.indexOf('-') == -1) {
+                   if (availCode.startsWith(iso3166Code + "-")) {
+                      return true;
+                   }
+                } else if (availCode.equals(iso3166Code)) {
+                   return true;
+                }
+             }
+
+             return false;
+          }
+
+          /**
+           * {@inheritDoc}
+           */
+          @Override
+          public String toString() {
+             return "iso3166Code(" + iso3166Code + ")";
+          }
+      };
+   }
 }

--- a/core/src/main/java/org/jclouds/providers/Providers.java
+++ b/core/src/main/java/org/jclouds/providers/Providers.java
@@ -126,4 +126,15 @@ public class Providers {
       return filter(all(), ProviderPredicates.type(type));
    }
 
+   /**
+    * Returns the providers that have the given ISO 3166 code regardless of type.
+    * 
+    * @param isoCode
+    *                the ISO 3166 code to filter providers by
+    * 
+    * @return the providers with the given ISO 3166 code
+    */
+   public static Iterable<ProviderMetadata> withIso3166Code(String iso3166Code) {
+       return filter(all(), ProviderPredicates.inIso3166Code(iso3166Code));
+   }
 }

--- a/core/src/test/java/org/jclouds/providers/JcloudsTestBlobStoreProviderMetadata.java
+++ b/core/src/test/java/org/jclouds/providers/JcloudsTestBlobStoreProviderMetadata.java
@@ -99,7 +99,7 @@ public class JcloudsTestBlobStoreProviderMetadata extends BaseProviderMetadata {
     */
    @Override
    public Set<String> getIso3166Codes() {
-      return ImmutableSet.of("US-VA", "US-CA");
+      return ImmutableSet.of("US-VA", "US-CA", "US-FL");
    }
 
 }

--- a/core/src/test/java/org/jclouds/providers/ProvidersTest.java
+++ b/core/src/test/java/org/jclouds/providers/ProvidersTest.java
@@ -21,6 +21,8 @@ package org.jclouds.providers;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.NoSuchElementException;
 
 import org.testng.annotations.Test;
@@ -82,6 +84,30 @@ public class ProvidersTest {
          } else {
             assertEquals(testComputeProvider, providerMetadata);
          }
+      }
+   }
+
+   @Test
+   public void testWithIso3166Code() {
+      @SuppressWarnings("serial")
+      Map<String, Integer> expectedResults = new HashMap<String, Integer>() {{
+         put("US-CA", 2);
+         put("US-FL", 1);
+         put("US", 2);
+         put("SOME-FAKE-CODE", 0);
+      }};
+
+      for (Map.Entry<String, Integer> result : expectedResults.entrySet()) {
+         Iterable<ProviderMetadata> providersMetadata = Providers.withIso3166Code(result.getKey());
+         int providersFound = 0;
+
+         for (ProviderMetadata providerMetadata : providersMetadata) {
+            if (providerMetadata != null) {
+               providersFound++;
+            }
+         }
+
+         assertEquals(providersFound, result.getValue().intValue());
       }
    }
 


### PR DESCRIPTION
Issue 550: Added support for finding providers that are in a
particular "location" as identified by an ISO 3166 code.

[in core/src/main/java/org/jclouds]
- providers/ProviderPredicates.java (inIso3166Code),
  providers/Providers.java (withIso3166Code): Added.

[in core/src/test/java/org/jclouds]
- providers/JcloudsTestBlobStoreProviderMetadata.java
  (getIso3166Codes): Updated to list a different code than the other
  test ProviderMetadata to test the new filtering capabilities.
- providers/ProvidersTest.java (testWithIso3166Code): Added.
