### PR TITLE
Issue 550: Added ProviderMetadata for CloudOne Storage.

### DIFF
--- a/providers/cloudonestorage/src/main/java/org/jclouds/cloudonestorage/CloudOneStorageProviderMetadata.java
+++ b/providers/cloudonestorage/src/main/java/org/jclouds/cloudonestorage/CloudOneStorageProviderMetadata.java
@@ -1,0 +1,108 @@
+/**
+ *
+ * Copyright (C) 2011 Cloud Conscious, LLC. <info@cloudconscious.com>
+ *
+ * ====================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ====================================================================
+ */
+package org.jclouds.cloudonestorage;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.net.URI;
+import java.util.Set;
+
+import org.jclouds.providers.BaseProviderMetadata;
+
+/**
+ * Implementation of {@ link org.jclouds.types.ProviderMetadata} for PEER1's
+ * CloudOne Storage provider.
+ *
+ * @author Jeremy Whitlock <jwhitlock@apache.org>
+ */
+public class CloudOneStorageProviderMetadata extends BaseProviderMetadata {
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public String getId() {
+      return "cloudonestorage";
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public String getType() {
+      return BLOBSTORE_TYPE;
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public String getName() {
+      return "PEER1 CloudOne Storage";
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public String getIdentityName() {
+      return "Subtenant ID";
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public String getCredentialName() {
+      return "Shared Secret";
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public URI getHomepage() {
+      return URI.create("http://www.peer1.com/hosting/cloudone-storage.php");
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public URI getConsole() {
+      return URI.create("https://mypeer1.com/");
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public URI getApiDocumentation() {
+      return URI.create("http://www.peer1.com/sites/default/files/pdf/Atmos_System_Management_API_Guide_1.3.0A.pdf");
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public Set<String> getIso3166Codes() {
+      return ImmutableSet.of("US-GA", "US-TX");
+   }
+
+}

--- a/providers/cloudonestorage/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
+++ b/providers/cloudonestorage/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
@@ -1,0 +1,1 @@
+org.jclouds.cloudonestorage.CloudOneStorageProviderMetadata

--- a/providers/cloudonestorage/src/test/java/org/jclouds/cloudonestorage/CloudOneStorageProviderTest.java
+++ b/providers/cloudonestorage/src/test/java/org/jclouds/cloudonestorage/CloudOneStorageProviderTest.java
@@ -1,0 +1,37 @@
+/**
+ *
+ * Copyright (C) 2011 Cloud Conscious, LLC. <info@cloudconscious.com>
+ *
+ * ====================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ====================================================================
+ */
+package org.jclouds.cloudonestorage;
+
+import org.jclouds.providers.BaseProviderMetadataTest;
+import org.jclouds.providers.ProviderMetadata;
+import org.testng.annotations.Test;
+
+/**
+ * The CloudOneStorageProviderTest tests the {@link CloudOneStorageProviderMetadata} class.
+ * 
+ * @author Jeremy Whitlock <jwhitlock@apache.org>
+ */
+@Test(groups = "unit", testName = "CloudOneStorageProviderTest")
+public class CloudOneStorageProviderTest extends BaseProviderMetadataTest {
+
+   public CloudOneStorageProviderTest() {
+      super(new CloudOneStorageProviderMetadata(), ProviderMetadata.BLOBSTORE_TYPE);
+   }
+
+}


### PR DESCRIPTION
Issue 550: Added ProviderMetadata for CloudOne Storage.

[in providers/cloudonestorage/src]
- main/java/org/jclouds/cloudonestorage/CloudOneStorageProviderMetadata.java,
  main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata,
  test/java/org/jclouds/cloudonestorage/CloudOneStorageProviderTest.java: Added.
