### PR TITLE
Issue 550: Added ProviderMetadata for Eucalyptus Partner Cloud S3.

### DIFF
--- a/providers/googlestorage/src/main/java/org/jclouds/googlestorage/GoogleStorageProviderMetadata.java
+++ b/providers/googlestorage/src/main/java/org/jclouds/googlestorage/GoogleStorageProviderMetadata.java
@@ -1,0 +1,108 @@
+/**
+ *
+ * Copyright (C) 2011 Cloud Conscious, LLC. <info@cloudconscious.com>
+ *
+ * ====================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ====================================================================
+ */
+package org.jclouds.googlestorage;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.net.URI;
+import java.util.Set;
+
+import org.jclouds.providers.BaseProviderMetadata;
+
+/**
+ * Implementation of {@ link org.jclouds.types.ProviderMetadata} for Google's
+ * Storage provider.
+ *
+ * @author Jeremy Whitlock <jwhitlock@apache.org>
+ */
+public class GoogleStorageProviderMetadata extends BaseProviderMetadata {
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public String getId() {
+      return "googlestorage";
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public String getType() {
+      return BLOBSTORE_TYPE;
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public String getName() {
+      return "Google Storage";
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public String getIdentityName() {
+      return "Access Key";
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public String getCredentialName() {
+      return "Secret Key";
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public URI getHomepage() {
+      return URI.create("http://code.google.com/apis/storage/");
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public URI getConsole() {
+      return URI.create("https://code.google.com/apis/console#:storage:access");
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public URI getApiDocumentation() {
+      return URI.create("http://code.google.com/apis/storage/docs/reference-guide.html");
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public Set<String> getIso3166Codes() {
+      return ImmutableSet.of("US");
+   }
+
+}

--- a/providers/googlestorage/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
+++ b/providers/googlestorage/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
@@ -1,0 +1,1 @@
+org.jclouds.googlestorage.GoogleStorageProviderMetadata

--- a/providers/googlestorage/src/test/java/org/jclouds/googlestorage/GoogleStorageProviderTest.java
+++ b/providers/googlestorage/src/test/java/org/jclouds/googlestorage/GoogleStorageProviderTest.java
@@ -1,0 +1,37 @@
+/**
+ *
+ * Copyright (C) 2011 Cloud Conscious, LLC. <info@cloudconscious.com>
+ *
+ * ====================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ====================================================================
+ */
+package org.jclouds.googlestorage;
+
+import org.jclouds.providers.BaseProviderMetadataTest;
+import org.jclouds.providers.ProviderMetadata;
+import org.testng.annotations.Test;
+
+/**
+ * The GoogleStorageProviderTest tests the {@link GoogleStorageProviderMetadata} class.
+ * 
+ * @author Jeremy Whitlock <jwhitlock@apache.org>
+ */
+@Test(groups = "unit", testName = "GoogleStorageProviderTest")
+public class GoogleStorageProviderTest extends BaseProviderMetadataTest {
+
+   public GoogleStorageProviderTest() {
+      super(new GoogleStorageProviderMetadata(), ProviderMetadata.BLOBSTORE_TYPE);
+   }
+
+}


### PR DESCRIPTION
Issue 550: Added ProviderMetadata for Eucalyptus Partner Cloud S3.

[in providers/googlestorage/src]
- main/java/org/jclouds/googlestorage/GoogleStorageProviderMetadata.java,
  main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata,
  test/java/org/jclouds/googlestorage/GoogleStorageProviderTest.java: Added.
