### PR TITLE
fixed small typo in clojure's blobstore implementation to create a blob-last-modified accessor

### DIFF
--- a/blobstore/src/main/clojure/org/jclouds/blobstore.clj
+++ b/blobstore/src/main/clojure/org/jclouds/blobstore.clj
@@ -454,7 +454,7 @@ container, name, string -> etag"
   (download-blob container-name name (FileOutputStream. target) blobstore))
 
 (define-accessors StorageMetadata "blob" type id name
-  location-id uri last-modfied)
+  location-id uri last-modified)
 (define-accessors BlobMetadata "blob" content-type)
 
 (defn blob-etag [blob]

--- a/blobstore/src/main/clojure/org/jclouds/blobstore2.clj
+++ b/blobstore/src/main/clojure/org/jclouds/blobstore2.clj
@@ -341,7 +341,7 @@ Options can also be specified for extension modules
        (.build blob-builder))))
 
 (define-accessors StorageMetadata "blob" type id name
-  location-id uri last-modfied)
+  location-id uri last-modified)
 (define-accessors BlobMetadata "blob" content-type)
 
 (defn blob-etag [blob]


### PR DESCRIPTION
"last-modfied" -> "last-modified"  (missing an "i")
