### PR TITLE
fixes clojure's blobstore clear-container wrapper fn

### DIFF
--- a/blobstore/src/main/clojure/org/jclouds/blobstore2.clj
+++ b/blobstore/src/main/clojure/org/jclouds/blobstore2.clj
@@ -223,7 +223,7 @@ Options can also be specified for extension modules
 
 (defn clear-container
   "Clear a container."
-  [^BlobStore container-name]
+  [^BlobStore blobstore container-name]
   (.clearContainer blobstore container-name))
 
 (defn delete-container


### PR DESCRIPTION
`blobstore` was not made an argument but the compiler didn't catch it becuase `blobstore` is bound to a function in the same `ns`.
