### PR TITLE
Add override-credentials-with template optio to clojure api

### DIFF
--- a/compute/src/main/clojure/org/jclouds/compute.clj
+++ b/compute/src/main/clojure/org/jclouds/compute.clj
@@ -396,10 +396,12 @@ See http://code.google.com/p/jclouds for details."
    (make-option-map
     kw-memfn-1arg
     [:run-script :install-private-key :authorize-public-key
+     :override-credentials-with :override-login-user-with
+     :override-login-credential-with
      ;; aws ec2 options
      :spot-price :spot-options :placement-group :subnet-id
      :block-device-mappings :unmapDeviceNamed :security-groups
-     :key-pair :user-data :override-credentials-with])
+     :key-pair :user-data])
    (make-option-map kw-memfn-varargs [:inbound-ports])
    (make-option-map
     kw-memfn-2arg

--- a/compute/src/main/clojure/org/jclouds/compute2.clj
+++ b/compute/src/main/clojure/org/jclouds/compute2.clj
@@ -349,11 +349,12 @@ Here's an example of creating and running a small linux node in the group webser
     (make-option-map
       kw-memfn-1arg
       [:run-script :install-private-key :authorize-public-key
+       :override-credentials-with :override-login-user-with
+       :override-login-credential-with
        ;; aws ec2 options
        :spot-price :spot-options :placement-group :subnet-id
        :block-device-mappings :unmapDeviceNamed :security-groups
-       :key-pair :user-data
-       :override-credentials-with])
+       :key-pair :user-data])
     (make-option-map kw-memfn-varargs [:inbound-ports])
     (make-option-map
       kw-memfn-2arg

--- a/compute/src/test/clojure/org/jclouds/compute2_test.clj
+++ b/compute/src/test/clojure/org/jclouds/compute2_test.clj
@@ -128,7 +128,27 @@ list, Alan Dipert and MeikelBrandmeyer."
     (testing "one arg"
       (is (> (-> (build-template service {:min-ram 512})
                  bean :hardware bean :ram)
-             512)))
+             512))
+      (let [credentials (org.jclouds.domain.Credentials. "user" "pwd")
+            f (juxt #(.identity %) #(.credential %))
+            template (build-template
+                      service
+                      {:override-credentials-with credentials})
+            node (create-node service "something" template)]
+        (is (= (-> node bean :credentials f)
+               (f credentials)))
+        (let [credentials (org.jclouds.domain.Credentials. "user" "pwd")
+            f #(.identity %)
+            template (build-template service {:override-login-user-with "fred"})
+            node (create-node service "something" template)]
+        (is (= (-> node bean :credentials f)
+               (f credentials))))
+        (let [credential "fred"
+              f #(.credential %)
+              template (build-template
+                        service {:override-login-credential-with credential})
+              node (create-node service "something" template)]
+          (is (= (-> node bean :credentials f) credential)))))
     (testing "enumerated"
       (is (= OsFamily/CENTOS
              (-> (build-template service {:os-family :centos})

--- a/compute/src/test/clojure/org/jclouds/compute_test.clj
+++ b/compute/src/test/clojure/org/jclouds/compute_test.clj
@@ -99,7 +99,25 @@ list, Alan Dipert and MeikelBrandmeyer."
     (testing "one arg"
       (is (> (-> (build-template service {:min-ram 512})
                  bean :hardware bean :ram)
-             512)))
+             512))
+      (let [credentials (org.jclouds.domain.Credentials. "user" "pwd")
+            f (juxt #(.identity %) #(.credential %))
+            template (build-template
+                      service {:override-credentials-with credentials})
+            node (create-node "something" template service)]
+        (is (= (-> node bean :credentials f)
+               (f credentials))))
+      (let [user "fred"
+            f #(.identity %)
+            template (build-template service {:override-login-user-with user})
+            node (create-node "something" template service)]
+        (is (= (-> node bean :credentials f) user)))
+      (let [credential "fred"
+            f #(.credential %)
+            template (build-template
+                      service {:override-login-credential-with credential})
+            node (create-node "something" template service)]
+        (is (= (-> node bean :credentials f) credential))))
     (testing "enumerated"
       (is (= OsFamily/CENTOS
              (-> (build-template service {:os-family :centos})


### PR DESCRIPTION
Hi,

This adds override-credentials-with to the template options in the clojure api.  Would be great if it went into 1.0.x too, should there be another release planned for that.
