### PR TITLE
Issue 158: Test to get the datacenters where CloudLayer Computing Instances are available.

### DIFF
--- a/sandbox-providers/softlayer/src/test/java/org/jclouds/softlayer/features/ProductPackageClientLiveTest.java
+++ b/sandbox-providers/softlayer/src/test/java/org/jclouds/softlayer/features/ProductPackageClientLiveTest.java
@@ -18,14 +18,18 @@
  */
 package org.jclouds.softlayer.features;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableSet;
 import org.jclouds.softlayer.domain.Datacenter;
 import org.jclouds.softlayer.domain.ProductItem;
 import org.jclouds.softlayer.domain.ProductItemPrice;
 import org.jclouds.softlayer.domain.ProductPackage;
 import org.testng.annotations.BeforeGroups;
 import org.testng.annotations.Test;
+
+import java.util.Set;
 
 /**
  * Tests behavior of {@code ProductPackageClient}
@@ -65,6 +69,29 @@ public class ProductPackageClientLiveTest extends BaseSoftLayerClientLiveTest {
          }
       }
    }
+
+    @Test
+    public void testDatacentersForCloudLayer() {
+        ProductPackage productPackage = context.getApi().getProductPackageClient().getProductPackage(getCloudLayerPackageId());
+
+        ImmutableSet.Builder<Datacenter> builder = ImmutableSet.builder();
+        builder.add(Datacenter.builder().id(3).name("dal01").longName("Dallas").build());
+        builder.add(Datacenter.builder().id(18171).name("sea01").longName("Seattle").build());
+        builder.add(Datacenter.builder().id(37473).name("wdc01").longName("Washington, DC").build());
+        builder.add(Datacenter.builder().id(138124).name("dal05").longName("Dallas 5").build());
+        builder.add(Datacenter.builder().id(168642).name("sjc01").longName("San Jose 1").build());
+
+        Set<Datacenter> expected = builder.build();
+
+        Set<Datacenter> datacenters = productPackage.getDatacenters();
+        assertEquals(datacenters.size(), expected.size());
+        assertTrue(datacenters.containsAll(expected));
+    }
+
+    // TODO The packageId will be obtained via a search call later.
+    private int getCloudLayerPackageId() {
+        return 46;
+    }
 
    private void checkProductItem(ProductItem item) {
       assert item.getId() > 0 : item;


### PR DESCRIPTION
Note that I check the size of the sets and that the result contains all the expected. Did that so the test will not break if the returned order changes later. There is a TODO to get the cloud layer instances via a seperate api call which will be added later.
