### PR TITLE
fix for bug where unclosed open braces in shell scripts banjax parsing

### DIFF
--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/util/Utils.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/util/Utils.java
@@ -62,7 +62,9 @@ public class Utils {
       }
    }
 
-   private static final Pattern pattern = Pattern.compile("\\{(.+?)\\}");
+   /** matches any expression inside curly braces (where the expression does not including an open curly brace) */
+   private static final Pattern pattern = Pattern.compile("\\{([^\\{]+?)\\}");
+
 
    /**
     * replaces tokens that are expressed as <code>{token}</code>

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/util/UtilsTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/util/UtilsTest.java
@@ -23,6 +23,7 @@ import static org.testng.Assert.assertEquals;
 import java.io.UnsupportedEncodingException;
 
 import org.jclouds.scriptbuilder.domain.OsFamily;
+import org.jclouds.scriptbuilder.domain.ShellToken;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -78,6 +79,11 @@ public class UtilsTest {
    public void testWriteUnsetVariablesWindows() {
       assertEquals(Utils.writeUnsetVariables(ImmutableList.of("host", "port"), OsFamily.WINDOWS),
                "set HOST=\r\nset PORT=\r\n");
+   }
+
+   public void testSingleCurlyBraceDoesntBreakLfTokenReplacement() {
+      assertEquals(Utils.replaceTokens("{{lf}", ShellToken.tokenValueMap(OsFamily.UNIX)),
+            "{\n");
    }
 
 }


### PR DESCRIPTION
fix for bug where unclosed open braces in shell scripts (and other places where scriptbuilder Utils does its replacements) banjax parsing; as per email on dev list
