### PR TITLE
missing cloudloadbalancers-uk module

### DIFF
--- a/providers/pom.xml
+++ b/providers/pom.xml
@@ -49,6 +49,7 @@
         <module>cloudfiles-us</module>
         <module>cloudfiles-uk</module>
         <module>cloudloadbalancers-us</module>
+        <module>cloudloadbalancers-uk</module>
         <module>bluelock-vcloud-zone01</module>
         <module>stratogen-vcloud-mycloud</module>
         <module>trmk-ecloud</module>


### PR DESCRIPTION
Adrian rightly caught that the cloudloadbalancers API entry was missing, but the new UK provider was also missing...
