### PR TITLE
Don't fail when the JCE provider fails.

### DIFF
--- a/core/src/main/java/org/jclouds/encryption/internal/JCECrypto.java
+++ b/core/src/main/java/org/jclouds/encryption/internal/JCECrypto.java
@@ -63,7 +63,18 @@ public class JCECrypto implements Crypto {
 
    @Override
    public Mac hmac(String algorithm, byte[] key) throws NoSuchAlgorithmException, InvalidKeyException {
-      Mac mac = provider == null ? Mac.getInstance(algorithm) : Mac.getInstance(algorithm, provider);
+      Mac mac = null;
+      if(provider != null) {
+          try {
+          mac = Mac.getInstance(algorithm, provider);
+          } catch(Exception e) {
+              //Provider does not function.
+              //Do nothing and let it fallback to the default way.
+          }
+      }
+      if(mac == null) {
+         mac = Mac.getInstance(algorithm);
+      }
       SecretKeySpec signingKey = new SecretKeySpec(key, algorithm);
       mac.init(signingKey);
       return mac;


### PR DESCRIPTION
There is a case that the jce provider, will fail. Inside OSGi I see this happening a lot mostly due to the lack of singed bundles of bouncycastle etc.

It would be nice if in that case jclouds could fall back to not using the provider, instead of failing.

I encountered this case, when tried whirr inside OSGi and this little commit solves the problem.
