### PR TITLE
Improve modularity and OSGi support

### DIFF
--- a/core/src/main/java/org/jclouds/rest/RestContextFactory.java
+++ b/core/src/main/java/org/jclouds/rest/RestContextFactory.java
@@ -35,6 +35,7 @@ import javax.inject.Inject;
 
 import org.jclouds.PropertiesBuilder;
 import org.jclouds.location.reference.LocationConstants;
+import org.jclouds.util.ClassLoadingUtils;
 import org.jclouds.util.Modules2;
 import org.jclouds.util.Strings2;
 
@@ -303,8 +304,8 @@ public class RestContextFactory {
       try {
          contextBuilderClass = Providers.resolveContextBuilderClass(providerName, props);
          propertiesBuilderClass = Providers.resolvePropertiesBuilderClass(providerName, props);
-         sync = (Class<S>) (syncClassName != null ? Class.forName(syncClassName) : null);
-         async = (Class<A>) (asyncClassName != null ? Class.forName(asyncClassName) : null);
+         sync = (Class<S>) (syncClassName != null ? ClassLoadingUtils.loadClass(getClass(), syncClassName) : null);
+         async = (Class<A>) (asyncClassName != null ? ClassLoadingUtils.loadClass(getClass(), asyncClassName) : null);
       } catch (IllegalArgumentException e) {
          throw new IllegalArgumentException(
                String.format(

--- a/core/src/main/java/org/jclouds/util/ClassLoadingUtils.java
+++ b/core/src/main/java/org/jclouds/util/ClassLoadingUtils.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.util;
+
+import java.net.URL;
+import com.google.common.io.Resources;
+
+public class ClassLoadingUtils {
+
+    public ClassLoadingUtils() {
+        //Utility Class
+    }
+
+    /**
+     * Loads a class using the class loader.
+     * 1. The class loader of the context class is being used.
+     * 2. The thread context class loader is being used.
+     * If both approaches fail, returns null.
+     *
+     * @param contextClass The name of a context class to use.
+     * @param className    The name of the class to load
+     * @return The class or null if no class loader could load the class.
+     */
+    public static Class<?> loadClass(Class<?> contextClass, String className) {
+        Class clazz = null;
+        if (contextClass.getClassLoader() != null) {
+            clazz = silentLoadClass(className, contextClass.getClassLoader());
+        }
+        if (clazz == null && Thread.currentThread().getContextClassLoader() != null) {
+            clazz = silentLoadClass(className, Thread.currentThread().getContextClassLoader());
+        }
+        return clazz;
+    }
+
+    /**
+     * Returns the url of a resource.
+     * 1. The context class is being used.
+     * 2. The thread context class loader is being used.
+     * If both approach fail, returns null.
+     *
+     * @param contextClass
+     * @param resourceName
+     * @return
+     */
+    public static URL loadResource(Class contextClass, String resourceName) {
+        URL url = null;
+        if (contextClass != null) {
+            url = Resources.getResource(contextClass, resourceName);
+
+        }
+        if (url == null && Thread.currentThread().getContextClassLoader() != null) {
+            url = Thread.currentThread().getContextClassLoader().getResource(resourceName);
+        }
+        return url;
+    }
+
+
+    /**
+     * Loads a {@link Class} from the specified {@link ClassLoader} without throwing {@ClassNotFoundException}.
+     *
+     * @param className
+     * @param classLoader
+     * @return
+     */
+    private static Class<?> silentLoadClass(String className, ClassLoader classLoader) {
+        Class clazz = null;
+        if (classLoader != null && className != null) {
+            try {
+                clazz = classLoader.loadClass(className);
+            } catch (ClassNotFoundException e) {
+                //Ignore and proceed to the next class loader.
+            }
+        }
+        return clazz;
+    }
+}

--- a/core/src/main/java/org/jclouds/util/Modules2.java
+++ b/core/src/main/java/org/jclouds/util/Modules2.java
@@ -47,12 +47,10 @@ public class Modules2 {
             @Override
             public Module apply(String from) {
                try {
-                  return (Module) Class.forName(from).newInstance();
+                  return (Module) ClassLoadingUtils.loadClass(Modules2.class, from).newInstance();
                } catch (InstantiationException e) {
                   throw new RuntimeException("error instantiating " + from, e);
                } catch (IllegalAccessException e) {
-                  throw new RuntimeException("error instantiating " + from, e);
-               } catch (ClassNotFoundException e) {
                   throw new RuntimeException("error instantiating " + from, e);
                }
             }

--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/util/Utils.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/util/Utils.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.io.CharStreams;
 import com.google.common.io.Resources;
+import org.jclouds.util.ClassLoadingUtils;
 
 /**
  * Utilities used to build init scripts.
@@ -135,8 +136,8 @@ public class Utils {
 
    public static String writeFunctionFromResource(String function, OsFamily family) {
       try {
-         String toReturn = CharStreams.toString(Resources.newReaderSupplier(Resources.getResource(Utils.class, String
-                  .format("/functions/%s.%s", function, ShellToken.SH.to(family))), Charsets.UTF_8));
+         String toReturn = CharStreams.toString(Resources.newReaderSupplier(ClassLoadingUtils.loadResource(Utils.class, String
+                 .format("/functions/%s.%s", function, ShellToken.SH.to(family))), Charsets.UTF_8));
          String lf = ShellToken.LF.to(family);
          return toReturn.endsWith(lf) ? toReturn : new StringBuilder(toReturn).append(lf).toString();
       } catch (IOException e) {


### PR DESCRIPTION
Currently jclouds uses dynamic-imports on package org.jclouds in order to be able to load classes from providers, drivers &modules. 

Among other this solution has one major issue: It is not possible to load 3rd party drivers, module & provider (unless they are packaged as org.jclouds.*). Encountered this issue with whirr (and was forced to bundle the module as a fragment, which is not really nice).

It would be good if jclouds could fall back to the thread context class loader as a last resort, in case it cannot load the class.

The current pull request does exactly this.
