### PR TITLE
Use the domain admin client to remove the vlan network

### DIFF
--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/NetworkClientLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/NetworkClientLiveTest.java
@@ -121,9 +121,9 @@ public class NetworkClientLiveTest extends BaseCloudStackClientLiveTest {
          Logger.getAnonymousLogger().log(Level.SEVERE, "couldn't create a network, skipping test", e);
       } finally {
          if (network != null) {
-            Long jobId = client.getNetworkClient().deleteNetwork(network.getId());
+            Long jobId = adminClient.getNetworkClient().deleteNetwork(network.getId());
             if (jobId != null)
-               jobComplete.apply(jobId);
+               adminJobComplete.apply(jobId);
          }
       }
    }


### PR DESCRIPTION
Only a domain admin can create and remove a VLAN. This change is only fixing an inconsistency - we are creating the network as domain admin but trying to remove it as a regular user. 
