### PR TITLE
Udpdated Fragment definitions so that they are compatible with OSGi 4.3.

### DIFF
--- a/blobstore/pom.xml
+++ b/blobstore/pom.xml
@@ -99,7 +99,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>org.jclouds.blobstore.*;version="${project.version}"</Export-Package>
                         <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
-                        <Fragment-Host>jclouds-core;version="${project.version}"</Fragment-Host>
+                        <Fragment-Host>jclouds-core;bundle-version="[1.3,2)"</Fragment-Host>
                     </instructions>
                 </configuration>
             </plugin>

--- a/compute/pom.xml
+++ b/compute/pom.xml
@@ -75,7 +75,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>org.jclouds.compute.*;version="${project.version}",org.jclouds.cim.*;version="${project.version}",org.jclouds.ovf.*;version="${project.version}",org.jclouds.ssh.*;version="${project.version}"</Export-Package>
                         <Import-Package>!org.jclouds.compute.*;org.jclouds.*;version="${project.version}",*</Import-Package>
-                        <Fragment-Host>jclouds-core;version="${project.version}"</Fragment-Host>
+                        <Fragment-Host>jclouds-core;bundle-version="[1.3,2)"</Fragment-Host>
                     </instructions>
                 </configuration>
             </plugin>

--- a/loadbalancer/pom.xml
+++ b/loadbalancer/pom.xml
@@ -91,7 +91,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>org.jclouds.loadbalancer.*;version="${project.version}"</Export-Package>
                         <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
-                        <Fragment-Host>jclouds-core;version="${project.version}"</Fragment-Host>
+                        <Fragment-Host>jclouds-core;bundle-version="[1.3,2)"</Fragment-Host>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
In OSGi 4.3 the current definition of fragment will not work. This change will allow jclouds to work on both 4.2 and 4.3 versions of the OSGi spec.
