### PR TITLE
Capacity domain object was missing a toString() implementation

### DIFF
--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/domain/Capacity.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/domain/Capacity.java
@@ -230,6 +230,20 @@ public class Capacity implements Comparable<Capacity> {
    }
 
    @Override
+   public String toString() {
+      return "[" +
+         "podId=" + podId +
+         ", podName='" + podName + '\'' +
+         ", zoneId=" + zoneId +
+         ", zoneName='" + zoneName + '\'' +
+         ", type=" + type +
+         ", capacityUsed=" + capacityUsed +
+         ", capacityTotal=" + capacityTotal +
+         ", percentUsed=" + percentUsed +
+         ']';
+   }
+
+   @Override
    public int compareTo(Capacity other) {
       int comparison = Long.valueOf(this.zoneId).compareTo(other.zoneId);
       if (comparison != 0) return comparison;


### PR DESCRIPTION
One of these days I'll get the hang of the different tasks needed to add a Cloudstack API, and I'll be able to make a single commit that does everything in one go.
