### PR TITLE
Allow to parse parameters with @ParamParser before binding

### DIFF
--- a/core/src/main/java/org/jclouds/rest/internal/RestAnnotationProcessor.java
+++ b/core/src/main/java/org/jclouds/rest/internal/RestAnnotationProcessor.java
@@ -944,6 +944,7 @@ public class RestAnnotationProcessor<T> {
 
    public GeneratedHttpRequest<T> decorateRequest(GeneratedHttpRequest<T> request) throws NegativeArraySizeException,
             ExecutionException {
+      Cache<Integer, Set<Annotation>> indexToParamExtractor = methodToIndexOfParamToParamParserAnnotations.get(request.getJavaMethod()); 
       OUTER: for (Entry<Integer, Set<Annotation>> entry : concat(//
                filterValues(methodToIndexOfParamToBinderParamAnnotation.get(request.getJavaMethod()).asMap(), notEmpty)
                         .entrySet(), //
@@ -978,7 +979,17 @@ public class RestAnnotationProcessor<T> {
                }
             }
             if (input != null) {
-               request = binder.bindToRequest(request, input);
+               // Allow the input parameter to be parsed by the ParamParser before binding
+               Set<Annotation> extractors = indexToParamExtractor.get(entry.getKey());
+               Object parsedValue = null;
+               if (extractors != null && extractors.size() > 0) {
+                   ParamParser extractor = (ParamParser) extractors.iterator().next();
+                   parsedValue = injector.getInstance(extractor.value()).apply(input);
+               } else {
+                   parsedValue = input;
+               }
+
+               request = binder.bindToRequest(request, parsedValue);
             }
             if (shouldBreak)
                break OUTER;

--- a/core/src/test/java/org/jclouds/rest/internal/RestAnnotationProcessorTest.java
+++ b/core/src/test/java/org/jclouds/rest/internal/RestAnnotationProcessorTest.java
@@ -2537,6 +2537,48 @@ public class RestAnnotationProcessorTest extends BaseRestClientTest {
       assertEquals(domain.getElem(), "Hello World");
    }
 
+   public static class AppendTextParser implements Function<Object, String> {
+       @Override
+       public String apply(Object input)
+       {
+           return input.toString() + "PARSED";
+       }
+   }
+
+   public interface TestBindWithParamParser {
+       @GET
+       @Path("/foo")
+       public ListenableFuture<String> bindWithoutParsing(
+           @BinderParam(BindToStringPayload.class) String param);
+
+       @GET
+       @Path("/bar")
+       public ListenableFuture<String> bindAfterParsing(
+           @BinderParam(BindToStringPayload.class) @ParamParser(AppendTextParser.class) String param);
+   }
+
+   @Test
+   public void testBindWithoutParamParser() throws SecurityException, NoSuchMethodException, IOException {
+       RestAnnotationProcessor<TestBindWithParamParser> processor = factory(TestBindWithParamParser.class);
+       Method method = TestBindWithParamParser.class.getMethod("bindWithoutParsing", String.class);
+       GeneratedHttpRequest<TestBindWithParamParser> request = processor.createRequest(method, "test");
+
+       assertRequestLineEquals(request, "GET http://localhost:9999/foo HTTP/1.1");
+       assertNonPayloadHeadersEqual(request, "");
+       assertPayloadEquals(request, "test", "application/unknown", false);
+   }
+
+   @Test
+   public void testBindWithParamParser() throws SecurityException, NoSuchMethodException, IOException {
+       RestAnnotationProcessor<TestBindWithParamParser> processor = factory(TestBindWithParamParser.class);
+       Method method = TestBindWithParamParser.class.getMethod("bindAfterParsing", String.class);
+       GeneratedHttpRequest<TestBindWithParamParser> request = processor.createRequest(method, "test");
+
+       assertRequestLineEquals(request, "GET http://localhost:9999/bar HTTP/1.1");
+       assertNonPayloadHeadersEqual(request, "");
+       assertPayloadEquals(request, "testPARSED", "application/unknown", false);
+   }
+
    @Test(expectedExceptions = NullPointerException.class)
    public void testAddHostNullWithHost() throws Exception{
        assertNull(RestAnnotationProcessor.addHostIfMissing(null,null));


### PR DESCRIPTION
Allow to parse parameters using the @ParamParser before binding them to the request.

Currently only QueryParams, PathParams, etc, are parsed by the @ParamParser classes. It would be nice to  parse the parameters the same way before sending them to the binders.
