### PR TITLE
Bug fix for Terremark ECloud compute service

### DIFF
--- a/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/compute/functions/CreateUniqueKeyPair.java
+++ b/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/compute/functions/CreateUniqueKeyPair.java
@@ -81,6 +81,6 @@ public class CreateUniqueKeyPair implements Function<OrgAndName, KeyPair> {
    }
 
    private String getNextName(String keyPairName) {
-      return "jclouds#" + keyPairName + "#" + randomSuffix.get();
+      return "jclouds_" + keyPairName.replaceAll("-", "_") + "_" + randomSuffix.get();
    }
 }

--- a/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/compute/strategy/DeleteKeyPair.java
+++ b/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/compute/strategy/DeleteKeyPair.java
@@ -54,7 +54,7 @@ public class DeleteKeyPair {
 
    public void execute(OrgAndName orgTag) {
       for (KeyPair keyPair : terremarkClient.listKeyPairsInOrg(orgTag.getOrg())) {
-         if (keyPair.getName().matches("jclouds#" + orgTag.getName() + "#[0-9a-f]+")) {
+         if (keyPair.getName().matches("jclouds_" + orgTag.getName().replaceAll("-", "_") + "_[0-9a-f]+")) {
             logger.debug(">> deleting keyPair(%s)", keyPair.getName());
             terremarkClient.deleteKeyPair(keyPair.getId());
             // TODO: test this clear happens

--- a/common/trmk/src/test/java/org/jclouds/trmk/vcloud_0_8/compute/strategy/DeleteKeyPairTest.java
+++ b/common/trmk/src/test/java/org/jclouds/trmk/vcloud_0_8/compute/strategy/DeleteKeyPairTest.java
@@ -75,7 +75,7 @@ public class DeleteKeyPairTest {
 
       // setup expectations
       expect(strategy.terremarkClient.listKeyPairsInOrg(orgTag.getOrg())).andReturn(ImmutableSet.<KeyPair> of(keyPair));
-      expect(keyPair.getName()).andReturn("jclouds#" + orgTag.getName() + "#123").atLeastOnce();
+      expect(keyPair.getName()).andReturn("jclouds_" + orgTag.getName() + "_123").atLeastOnce();
       expect(keyPair.getId()).andReturn(URI.create("1245"));
       strategy.terremarkClient.deleteKeyPair(URI.create("1245"));
       expect(strategy.credentialsMap.remove(orgTag)).andReturn(null);
@@ -104,7 +104,7 @@ public class DeleteKeyPairTest {
 
       // setup expectations
       expect(strategy.terremarkClient.listKeyPairsInOrg(orgTag.getOrg())).andReturn(ImmutableSet.<KeyPair> of(keyPair));
-      expect(keyPair.getName()).andReturn("kclouds#" + orgTag.getName() + "-123");
+      expect(keyPair.getName()).andReturn("kclouds_" + orgTag.getName() + "_123");
 
       // replay mocks
       replay(keyPair);


### PR DESCRIPTION
Removed hashes and hyphens from KeyPair.name field for both Terremark providers, still investigating a couple of live test failures
