### PR TITLE
Increase backoff period from 100 to 500

### DIFF
--- a/core/src/test/java/org/jclouds/http/handlers/BackoffLimitedRetryHandlerTest.java
+++ b/core/src/test/java/org/jclouds/http/handlers/BackoffLimitedRetryHandlerTest.java
@@ -61,7 +61,7 @@ public class BackoffLimitedRetryHandlerTest {
 
    @Test
    void testExponentialBackoffDelayDefaultMaxInterval500() throws InterruptedException {
-      long period = 100;
+      long period = 500;
       long acceptableDelay = period - 1;
 
       long startTime = System.nanoTime();


### PR DESCRIPTION
This increases the overall test execution time but makes it less likely to fail on slow test machines.
