### PR TITLE
Allow user to specify instance ID as an option for CloudWatch

### DIFF
--- a/apis/cloudwatch/src/main/java/org/jclouds/cloudwatch/CloudWatchAsyncClient.java
+++ b/apis/cloudwatch/src/main/java/org/jclouds/cloudwatch/CloudWatchAsyncClient.java
@@ -28,6 +28,7 @@ import javax.ws.rs.Path;
 import org.jclouds.aws.filters.FormSigner;
 import org.jclouds.cloudwatch.domain.Datapoint;
 import org.jclouds.cloudwatch.functions.ISO8601Format;
+import org.jclouds.cloudwatch.options.GetMetricStatisticsOptions;
 import org.jclouds.cloudwatch.xml.GetMetricStatisticsResponseHandler;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.location.functions.RegionToEndpointOrProviderIfNull;
@@ -67,6 +68,8 @@ public interface CloudWatchAsyncClient {
          @FormParam("MetricName") String metricName,
          @FormParam("Namespace") String namespace,
          @FormParam("StartTime") @ParamParser(ISO8601Format.class) Date startTime,
-         @FormParam("EndTime") @ParamParser(ISO8601Format.class) Date endTime, @FormParam("Period") int period,
-         @FormParam("Statistics.member.1") String statistics);
+         @FormParam("EndTime") @ParamParser(ISO8601Format.class) Date endTime,
+         @FormParam("Period") int period,
+         @FormParam("Statistics.member.1") String statistics,
+         GetMetricStatisticsOptions... options);
 }

--- a/apis/cloudwatch/src/main/java/org/jclouds/cloudwatch/CloudWatchClient.java
+++ b/apis/cloudwatch/src/main/java/org/jclouds/cloudwatch/CloudWatchClient.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.jclouds.cloudwatch.domain.Datapoint;
+import org.jclouds.cloudwatch.options.GetMetricStatisticsOptions;
 import org.jclouds.concurrent.Timeout;
 import org.jclouds.javax.annotation.Nullable;
 
@@ -41,6 +42,7 @@ public interface CloudWatchClient {
    /**
     * This call returns data for one or more statistics of given a metric. For more information, see
     * Statistic and Metric.
+    *
     * <p/>
     * <h3>Note</h3> The maximum number of datapoints that the Amazon CloudWatch service will return
     * in a single GetMetricStatistics request is 1,440. If a request is made that would generate
@@ -71,8 +73,10 @@ public interface CloudWatchClient {
     *           The granularity (in seconds) of the returned datapoints.
     * @param statistics
     *           The statistics to be returned for the given metric. ex. Average
+    * @param options
+    *          more filtering options (e.g. instance ID)
     */
    Set<Datapoint> getMetricStatisticsInRegion(@Nullable String region, String metricName, String namespace,
-            Date startTime, Date endTime, int period, String statistics);
+            Date startTime, Date endTime, int period, String statistics, GetMetricStatisticsOptions... options);
 
 }

--- a/apis/cloudwatch/src/main/java/org/jclouds/cloudwatch/options/GetMetricStatisticsOptions.java
+++ b/apis/cloudwatch/src/main/java/org/jclouds/cloudwatch/options/GetMetricStatisticsOptions.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.cloudwatch.options;
+
+import org.jclouds.aws.util.AWSUtils;
+import org.jclouds.http.options.BaseHttpRequestOptions;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Options used to control metric statistics are returned
+ *
+ * @author Andrei Savu
+ * @see <a
+ *      href="http://docs.amazonwebservices.com/AmazonCloudWatch/latest/APIReference/index.html?API_GetMetricStatistics.html"
+ *      />
+ */
+public class GetMetricStatisticsOptions extends BaseHttpRequestOptions {
+
+   public static final GetMetricStatisticsOptions NONE = new GetMetricStatisticsOptions();
+
+   /**
+    * @param instanceId filter metrics by instance Id
+    */
+   public GetMetricStatisticsOptions instanceId(String instanceId) {
+      String[] parts = AWSUtils.parseHandle(instanceId);
+      this.formParameters.put("Dimensions.member.1.Name", "InstanceId");
+      this.formParameters.put("Dimensions.member.1.Value", checkNotNull(parts[1]));
+      return this;
+   }
+
+   public static class Builder {
+
+      /**
+       * @see GetMetricStatisticsOptions#instanceId
+       */
+      public static GetMetricStatisticsOptions instanceId(String instanceId) {
+         GetMetricStatisticsOptions options = new GetMetricStatisticsOptions();
+         return options.instanceId(instanceId);
+      }
+   }
+}

--- a/apis/cloudwatch/src/test/java/org/jclouds/cloudwatch/CloudWatchAsyncClientTest.java
+++ b/apis/cloudwatch/src/test/java/org/jclouds/cloudwatch/CloudWatchAsyncClientTest.java
@@ -33,6 +33,7 @@ import org.jclouds.Constants;
 import org.jclouds.aws.domain.Region;
 import org.jclouds.aws.filters.FormSigner;
 import org.jclouds.cloudwatch.config.CloudWatchRestClientModule;
+import org.jclouds.cloudwatch.options.GetMetricStatisticsOptions;
 import org.jclouds.cloudwatch.xml.GetMetricStatisticsResponseHandler;
 import org.jclouds.date.DateService;
 import org.jclouds.http.HttpRequest;
@@ -62,21 +63,22 @@ public class CloudWatchAsyncClientTest extends RestClientTest<CloudWatchAsyncCli
    public void testRegisterInstancesWithMeasure() throws SecurityException, NoSuchMethodException, IOException {
       Date date = new Date(10000000l);
       Method method = CloudWatchAsyncClient.class.getMethod("getMetricStatisticsInRegion", String.class, String.class,
-            String.class, Date.class, Date.class, int.class, String.class);
-      HttpRequest request = processor.createRequest(method, (String) null, "CPUUtilization", "AWS/EC2", date, date, 60, "Average");
+            String.class, Date.class, Date.class, int.class, String.class, GetMetricStatisticsOptions[].class);
+      HttpRequest request = processor.createRequest(method, (String) null, "CPUUtilization", "AWS/EC2", date, date, 60, "Average",
+         GetMetricStatisticsOptions.Builder.instanceId("i-12312313"));
 
       assertRequestLineEquals(request, "POST https://monitoring.us-east-1.amazonaws.com/ HTTP/1.1");
       assertNonPayloadHeadersEqual(request, "Host: monitoring.us-east-1.amazonaws.com\n");
       try {
          assertPayloadEquals(
                request,
-               "Version=2010-08-01&Action=GetMetricStatistics&Statistics.member.1=Average&StartTime=1970-01-01T02%3A46%3A40Z&Namespace=AWS%2FEC2&&MetricName=CPUUtilization&EndTime=1970-01-01T02%3A46%3A40Z&Period=60",
+               "Version=2010-08-01&Action=GetMetricStatistics&Statistics.member.1=Average&StartTime=1970-01-01T02%3A46%3A40Z&Namespace=AWS%2FEC2&&MetricName=CPUUtilization&EndTime=1970-01-01T02%3A46%3A40Z&Period=60&Dimensions.member.1.Name=InstanceId&Dimensions.member.1.Value=i-12312313",
                "application/x-www-form-urlencoded", false);
       } catch (AssertionError e) {
          // mvn 3.0 osx 10.6.5 somehow sorts differently
          assertPayloadEquals(
                request,
-               "Version=2010-08-01&Action=GetMetricStatistics&Statistics.member.1=Average&Period=60&Namespace=AWS%2FEC2&MetricName=CPUUtilization&StartTime=1970-01-01T02%3A46%3A40Z&EndTime=1970-01-01T02%3A46%3A40Z",
+               "Version=2010-08-01&Action=GetMetricStatistics&Statistics.member.1=Average&Period=60&Namespace=AWS%2FEC2&MetricName=CPUUtilization&StartTime=1970-01-01T02%3A46%3A40Z&EndTime=1970-01-01T02%3A46%3A40Z&Dimensions.member.1.Name=InstanceId&Dimensions.member.1.Value=i-12312313",
                "application/x-www-form-urlencoded", false);
       }
       assertResponseParserClassEquals(method, request, ParseSax.class);

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/AWSEC2ComputeServiceLiveTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/AWSEC2ComputeServiceLiveTest.java
@@ -30,6 +30,7 @@ import org.jclouds.aws.ec2.services.AWSSecurityGroupClient;
 import org.jclouds.cloudwatch.CloudWatchAsyncClient;
 import org.jclouds.cloudwatch.CloudWatchClient;
 import org.jclouds.cloudwatch.domain.Datapoint;
+import org.jclouds.cloudwatch.options.GetMetricStatisticsOptions;
 import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.Template;
 import org.jclouds.compute.options.TemplateOptions;
@@ -155,7 +156,8 @@ public class AWSEC2ComputeServiceLiveTest extends EC2ComputeServiceLiveTest {
 
          try {
             Set<Datapoint> datapoints = monitoringContext.getApi().getMetricStatisticsInRegion(instance.getRegion(),
-                     "CPUUtilization", "AWS/EC2", before, new Date(), 60, "Average");
+                     "CPUUtilization", "AWS/EC2", before, new Date(), 60, "Average",
+                     GetMetricStatisticsOptions.Builder.instanceId(instance.getId()));
             assert datapoints != null && datapoints.size() > 0;
 
          } finally {


### PR DESCRIPTION
This is still work in progress. I get the following error when running the test:

org.jclouds.aws.AWSResponseException: request POST https://monitoring.sa-east-1.amazonaws.com/ HTTP/1.1 failed with code 400, error: AWSError{requestId='b9b8d270-2be8-11e1-9ee9-d1ef7d4fdf9f', requestToken='null', code='MalformedInput', message='Unexpected complex element termination', context='{Type=Sender, ErrorResponse=}'}

Any ideas? I am a bit new to AWS in jclouds. 
