### PR TITLE
Class loading issue in JcloudsVersion prevents jclouds 1.3.0 to work under OSGi

### DIFF
--- a/core/src/main/java/org/jclouds/JcloudsVersion.java
+++ b/core/src/main/java/org/jclouds/JcloudsVersion.java
@@ -65,7 +65,7 @@ public class JcloudsVersion {
     private static String readVersionPropertyFromClasspath() {
         Properties versionProperties = new Properties();
         try {
-            versionProperties.load(checkNotNull(Thread.currentThread().getContextClassLoader().getResourceAsStream(VERSION_RESOURCE_FILE), VERSION_RESOURCE_FILE));
+            versionProperties.load(checkNotNull(JcloudsVersion.class.getClassLoader().getResourceAsStream(VERSION_RESOURCE_FILE), VERSION_RESOURCE_FILE));
         } catch (IOException exception) {
             throw new IllegalStateException(format("Unable to load version resource file '%s'", VERSION_RESOURCE_FILE), exception);
         }


### PR DESCRIPTION
JcloudsVersion uses the maven metadata in order to identify the version of jclouds. It uses the Thread Context ClassLoader in order to load the maven metadata resources.

This works fine when using flat / hirerachical classloaders since the classloader has broad visibility. However, this doesn't work at all under OSGi and causes an NPE.

Since we are interesting in a specific artifact (jclouds-core) and the loading is taken care by JcloudsVersion class (part of the artifact) the ideal way, would be to use the class loader that is responsible for load JcloudsVersion class.

This tiny little patch does exactly this.
