### PR TITLE
Compute Apis & Providers need tuning in their OSGi package imports.

### DIFF
--- a/apis/byon/pom.xml
+++ b/apis/byon/pom.xml
@@ -114,7 +114,12 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>org.jclouds.byon.*;version="${project.version}"</Export-Package>
-            <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+            <Import-Package>
+              org.jclouds.compute.internal;version="${project.version}",
+              org.jclouds.rest.internal;version="${project.version}",
+              org.jclouds.*;version="${project.version}",
+              *
+            </Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/apis/cloudservers/pom.xml
+++ b/apis/cloudservers/pom.xml
@@ -135,7 +135,12 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>org.jclouds.cloudservers.*;version="${project.version}"</Export-Package>
-            <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+            <Import-Package>
+              org.jclouds.compute.internal;version="${project.version}",
+              org.jclouds.rest.internal;version="${project.version}",
+              org.jclouds.*;version="${project.version}",
+              *
+            </Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/apis/cloudsigma/pom.xml
+++ b/apis/cloudsigma/pom.xml
@@ -121,7 +121,12 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>org.jclouds.cloudsigma.*;version="${project.version}"</Export-Package>
-            <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+            <Import-Package>
+              org.jclouds.compute.internal;version="${project.version}",
+              org.jclouds.rest.internal;version="${project.version}",
+              org.jclouds.*;version="${project.version}",
+              *
+            </Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/apis/cloudstack/pom.xml
+++ b/apis/cloudstack/pom.xml
@@ -145,7 +145,12 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>org.jclouds.cloudstack.*;version="${project.version}"</Export-Package>
-            <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+            <Import-Package>
+              org.jclouds.compute.internal;version="${project.version}",
+              org.jclouds.rest.internal;version="${project.version}",
+              org.jclouds.*;version="${project.version}",
+              *
+            </Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/apis/deltacloud/pom.xml
+++ b/apis/deltacloud/pom.xml
@@ -134,7 +134,12 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>org.jclouds.deltacloud.*;version="${project.version}"</Export-Package>
-            <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+            <Import-Package>
+              org.jclouds.compute.internal;version="${project.version}",
+              org.jclouds.rest.internal;version="${project.version}",
+              org.jclouds.*;version="${project.version}",
+              *
+            </Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/apis/ec2/pom.xml
+++ b/apis/ec2/pom.xml
@@ -129,7 +129,12 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>org.jclouds.ec2.*;version="${project.version}"</Export-Package>
-            <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+            <Import-Package>
+              org.jclouds.compute.internal;version="${project.version}",
+              org.jclouds.rest.internal;version="${project.version}",
+              org.jclouds.*;version="${project.version}",
+              *
+            </Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/apis/elasticstack/pom.xml
+++ b/apis/elasticstack/pom.xml
@@ -134,7 +134,12 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>org.jclouds.elasticstack.*;version="${project.version}"</Export-Package>
-            <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+            <Import-Package>
+              org.jclouds.compute.internal;version="${project.version}",
+              org.jclouds.rest.internal;version="${project.version}",
+              org.jclouds.*;version="${project.version}",
+              *
+            </Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/apis/eucalyptus/pom.xml
+++ b/apis/eucalyptus/pom.xml
@@ -129,7 +129,12 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>org.jclouds.eucalyptus.*;version="${project.version}"</Export-Package>
-            <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+            <Import-Package>
+              org.jclouds.compute.internal;version="${project.version}",
+              org.jclouds.rest.internal;version="${project.version}",
+              org.jclouds.*;version="${project.version}",
+              *
+            </Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/apis/vcloud/pom.xml
+++ b/apis/vcloud/pom.xml
@@ -132,7 +132,12 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>org.jclouds.vcloud.*;version="${project.version}"</Export-Package>
-            <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+            <Import-Package>
+       			org.jclouds.compute.internal;version="${project.version}",
+       			org.jclouds.rest.internal;version="${project.version}",
+       			org.jclouds.*;version="${project.version}",
+ 				*
+			</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/providers/aws-ec2/pom.xml
+++ b/providers/aws-ec2/pom.xml
@@ -140,7 +140,12 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>org.jclouds.aws.ec2.*;version="${project.version}"</Export-Package>
-            <Import-Package>org.jclouds.*;version="${project.version}",org.jclouds.aws;version="${project.version}",*</Import-Package>
+            <Import-Package>
+              org.jclouds.compute.internal;version="${project.version}",
+              org.jclouds.rest.internal;version="${project.version}",
+              org.jclouds.*;version="${project.version}",
+              *
+            </Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/providers/bluelock-vcloud-zone01/pom.xml
+++ b/providers/bluelock-vcloud-zone01/pom.xml
@@ -129,7 +129,12 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>org.jclouds.bluelock.vcloud.zone01.*;version="${project.version}"</Export-Package>
-            <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+            <Import-Package>
+              org.jclouds.compute.internal;version="${project.version}",
+              org.jclouds.rest.internal;version="${project.version}",
+              org.jclouds.*;version="${project.version}",
+              *
+            </Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/providers/cloudservers-uk/pom.xml
+++ b/providers/cloudservers-uk/pom.xml
@@ -135,10 +135,10 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>org.jclouds.rackspace.cloudservers.*;version="${project.version}"</Export-Package>
             <Import-Package>
-                org.jclouds.compute.internal;version="${project.version}",
-                org.jclouds.rest.internal;version="${project.version}",
-                org.jclouds.*;version="${project.version}",
-                *
+              org.jclouds.compute.internal;version="${project.version}",
+              org.jclouds.rest.internal;version="${project.version}",
+              org.jclouds.*;version="${project.version}",
+              *
             </Import-Package>
           </instructions>
         </configuration>

--- a/providers/cloudservers-us/pom.xml
+++ b/providers/cloudservers-us/pom.xml
@@ -136,10 +136,10 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>org.jclouds.rackspace.cloudservers.*;version="${project.version}"</Export-Package>
             <Import-Package>
-                org.jclouds.compute.internal;version="${project.version}",
-                org.jclouds.rest.internal;version="${project.version}",
-                org.jclouds.*;version="${project.version}",
-                *
+              org.jclouds.compute.internal;version="${project.version}",
+              org.jclouds.rest.internal;version="${project.version}",
+              org.jclouds.*;version="${project.version}",
+              *
             </Import-Package>
           </instructions>
         </configuration>

--- a/providers/cloudsigma-lvs/pom.xml
+++ b/providers/cloudsigma-lvs/pom.xml
@@ -129,7 +129,12 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>org.jclouds.cloudsigma.*;version="${project.version}"</Export-Package>
-            <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+            <Import-Package>
+              org.jclouds.compute.internal;version="${project.version}",
+              org.jclouds.rest.internal;version="${project.version}",
+              org.jclouds.*;version="${project.version}",
+              *
+            </Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/providers/cloudsigma-zrh/pom.xml
+++ b/providers/cloudsigma-zrh/pom.xml
@@ -129,7 +129,12 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>org.jclouds.cloudsigma.*;version="${project.version}"</Export-Package>
-            <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+            <Import-Package>
+              org.jclouds.compute.internal;version="${project.version}",
+              org.jclouds.rest.internal;version="${project.version}",
+              org.jclouds.*;version="${project.version}",
+              *
+            </Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/providers/elastichosts-lax-p/pom.xml
+++ b/providers/elastichosts-lax-p/pom.xml
@@ -125,7 +125,12 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>org.jclouds.elastichosts.*;version="${project.version}"</Export-Package>
-                        <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+                        <Import-Package>
+                            org.jclouds.compute.internal;version="${project.version}",
+                            org.jclouds.rest.internal;version="${project.version}",
+                            org.jclouds.*;version="${project.version}",
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/providers/elastichosts-lon-b/pom.xml
+++ b/providers/elastichosts-lon-b/pom.xml
@@ -125,7 +125,12 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>org.jclouds.elastichosts.*;version="${project.version}"</Export-Package>
-                        <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+                        <Import-Package>
+                            org.jclouds.compute.internal;version="${project.version}",
+                            org.jclouds.rest.internal;version="${project.version}",
+                            org.jclouds.*;version="${project.version}",
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/providers/elastichosts-lon-p/pom.xml
+++ b/providers/elastichosts-lon-p/pom.xml
@@ -125,7 +125,12 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>org.jclouds.elastichosts.*;version="${project.version}"</Export-Package>
-                        <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+                        <Import-Package>
+                            org.jclouds.compute.internal;version="${project.version}",
+                            org.jclouds.rest.internal;version="${project.version}",
+                            org.jclouds.*;version="${project.version}",
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/providers/elastichosts-sat-p/pom.xml
+++ b/providers/elastichosts-sat-p/pom.xml
@@ -125,7 +125,12 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>org.jclouds.elastichosts.*;version="${project.version}"</Export-Package>
-                        <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+                        <Import-Package>
+                            org.jclouds.compute.internal;version="${project.version}",
+                            org.jclouds.rest.internal;version="${project.version}",
+                            org.jclouds.*;version="${project.version}",
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/providers/elastichosts-tor-p/pom.xml
+++ b/providers/elastichosts-tor-p/pom.xml
@@ -125,7 +125,12 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>org.jclouds.elastichosts.*;version="${project.version}"</Export-Package>
-                        <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+                        <Import-Package>
+                            org.jclouds.compute.internal;version="${project.version}",
+                            org.jclouds.rest.internal;version="${project.version}",
+                            org.jclouds.*;version="${project.version}",
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/providers/eucalyptus-partnercloud-ec2/pom.xml
+++ b/providers/eucalyptus-partnercloud-ec2/pom.xml
@@ -141,7 +141,12 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>org.jclouds.epc.*;version="${project.version}"</Export-Package>
-                        <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+                        <Import-Package>
+                            org.jclouds.compute.internal;version="${project.version}",
+                            org.jclouds.rest.internal;version="${project.version}",
+                            org.jclouds.*;version="${project.version}",
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/providers/eucalyptus-partnercloud-s3/pom.xml
+++ b/providers/eucalyptus-partnercloud-s3/pom.xml
@@ -138,7 +138,12 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>org.jclouds.epc.*;version="${project.version}"</Export-Package>
-                        <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+                        <Import-Package>
+                            org.jclouds.compute.internal;version="${project.version}",
+                            org.jclouds.rest.internal;version="${project.version}",
+                            org.jclouds.*;version="${project.version}",
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/providers/go2cloud-jhb1/pom.xml
+++ b/providers/go2cloud-jhb1/pom.xml
@@ -125,7 +125,12 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>org.jclouds.go2cloud.*;version="${project.version}"</Export-Package>
-                        <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+                        <Import-Package>
+                            org.jclouds.compute.internal;version="${project.version}",
+                            org.jclouds.rest.internal;version="${project.version}",
+                            org.jclouds.*;version="${project.version}",
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/providers/gogrid/pom.xml
+++ b/providers/gogrid/pom.xml
@@ -118,7 +118,12 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>org.jclouds.gogrid.*;version="${project.version}"</Export-Package>
-                        <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+                        <Import-Package>
+                            org.jclouds.compute.internal;version="${project.version}",
+                            org.jclouds.rest.internal;version="${project.version}",
+                            org.jclouds.*;version="${project.version}",
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/providers/greenhousedata-element-vcloud/pom.xml
+++ b/providers/greenhousedata-element-vcloud/pom.xml
@@ -129,7 +129,12 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>org.jclouds.greenhousedata.element.vcloud.*;version="${project.version}"</Export-Package>
-                        <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+                        <Import-Package>
+                            org.jclouds.compute.internal;version="${project.version}",
+                            org.jclouds.rest.internal;version="${project.version}",
+                            org.jclouds.*;version="${project.version}",
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/providers/ninefold-compute/pom.xml
+++ b/providers/ninefold-compute/pom.xml
@@ -130,7 +130,12 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>org.jclouds.ninefold.compute.*;version="${project.version}"</Export-Package>
-            <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+            <Import-Package>
+              org.jclouds.compute.internal;version="${project.version}",
+              org.jclouds.rest.internal;version="${project.version}",
+              org.jclouds.*;version="${project.version}",
+              *
+            </Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/providers/openhosting-east1/pom.xml
+++ b/providers/openhosting-east1/pom.xml
@@ -125,7 +125,12 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>org.jclouds.openhosting.*;version="${project.version}"</Export-Package>
-                        <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+                        <Import-Package>
+                            org.jclouds.compute.internal;version="${project.version}",
+                            org.jclouds.rest.internal;version="${project.version}",
+                            org.jclouds.*;version="${project.version}",
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/providers/rimuhosting/pom.xml
+++ b/providers/rimuhosting/pom.xml
@@ -125,7 +125,12 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>org.jclouds.rimuhosting.miro.*;version="${project.version}"</Export-Package>
-                        <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+                        <Import-Package>
+                            org.jclouds.compute.internal;version="${project.version}",
+                            org.jclouds.rest.internal;version="${project.version}",
+                            org.jclouds.*;version="${project.version}",
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/providers/savvis-symphonyvpdc/pom.xml
+++ b/providers/savvis-symphonyvpdc/pom.xml
@@ -142,7 +142,12 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>org.jclouds.savvis.vpdc.*;version="${project.version}"</Export-Package>
-                        <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+                        <Import-Package>
+                            org.jclouds.compute.internal;version="${project.version}",
+                            org.jclouds.rest.internal;version="${project.version}",
+                            org.jclouds.*;version="${project.version}",
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/providers/serverlove-z1-man/pom.xml
+++ b/providers/serverlove-z1-man/pom.xml
@@ -125,7 +125,12 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>org.jclouds.serverlove.*;version="${project.version}"</Export-Package>
-                        <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+                        <Import-Package>
+                            org.jclouds.compute.internal;version="${project.version}",
+                            org.jclouds.rest.internal;version="${project.version}",
+                            org.jclouds.*;version="${project.version}",
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/providers/skalicloud-sdg-my/pom.xml
+++ b/providers/skalicloud-sdg-my/pom.xml
@@ -125,7 +125,12 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>org.jclouds.skalicloud.*;version="${project.version}"</Export-Package>
-                        <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+                        <Import-Package>
+                            org.jclouds.compute.internal;version="${project.version}",
+                            org.jclouds.rest.internal;version="${project.version}",
+                            org.jclouds.*;version="${project.version}",
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/providers/slicehost/pom.xml
+++ b/providers/slicehost/pom.xml
@@ -117,7 +117,12 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>org.jclouds.slicehost.*;version="${project.version}"</Export-Package>
-                        <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+                        <Import-Package>
+                            org.jclouds.compute.internal;version="${project.version}",
+                            org.jclouds.rest.internal;version="${project.version}",
+                            org.jclouds.*;version="${project.version}",
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/providers/softlayer/pom.xml
+++ b/providers/softlayer/pom.xml
@@ -134,7 +134,12 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>org.jclouds.softlayer.*;version="${project.version}"</Export-Package>
-            <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+              <Import-Package>
+                  org.jclouds.compute.internal;version="${project.version}",
+                  org.jclouds.rest.internal;version="${project.version}",
+                  org.jclouds.*;version="${project.version}",
+                  *
+              </Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/providers/stratogen-vcloud-mycloud/pom.xml
+++ b/providers/stratogen-vcloud-mycloud/pom.xml
@@ -129,7 +129,12 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>org.jclouds.stratogen.vcloud.mycloud.*;version="${project.version}"</Export-Package>
-                        <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+                        <Import-Package>
+                            org.jclouds.compute.internal;version="${project.version}",
+                            org.jclouds.rest.internal;version="${project.version}",
+                            org.jclouds.*;version="${project.version}",
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/providers/trmk-ecloud/pom.xml
+++ b/providers/trmk-ecloud/pom.xml
@@ -128,7 +128,12 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>org.jclouds.trmk.ecloud.*;version="${project.version}"</Export-Package>
-                        <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+                        <Import-Package>
+                            org.jclouds.compute.internal;version="${project.version}",
+                            org.jclouds.rest.internal;version="${project.version}",
+                            org.jclouds.*;version="${project.version}",
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/providers/trmk-vcloudexpress/pom.xml
+++ b/providers/trmk-vcloudexpress/pom.xml
@@ -126,7 +126,12 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>org.jclouds.trmk.ecloud.*;version="${project.version}"</Export-Package>
-                        <Import-Package>org.jclouds.*;version="${project.version}",*</Import-Package>
+                        <Import-Package>
+                            org.jclouds.compute.internal;version="${project.version}",
+                            org.jclouds.rest.internal;version="${project.version}",
+                            org.jclouds.*;version="${project.version}",
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
The issue descried by isssue 794 (see [1](http://code.google.com/p/jclouds/issues/detail?id=794)) also applies to most of the compute apis & providers

The whole problem lies to the fact that most compute providers and apis require classes from packages that are not directly refereneced in the code. As a result the maven bundle plugin, will not identify the packages are required and thus will not added them to the generated package imports.

A solution is to explicitly state those packages in the plugin configuration. This pull request does exactly that.
