### PR TITLE
One should be able to define adminPass when creating server

### DIFF
--- a/apis/nova/src/main/java/org/jclouds/openstack/nova/options/CreateServerOptions.java
+++ b/apis/nova/src/main/java/org/jclouds/openstack/nova/options/CreateServerOptions.java
@@ -78,6 +78,7 @@ public class CreateServerOptions implements MapBinder {
       final String name;
       final String imageRef;
       final String flavorRef;
+      String adminPass;
       Map<String, String> metadata;
       List<File> personality;
       String key_name;
@@ -96,6 +97,7 @@ public class CreateServerOptions implements MapBinder {
    private List<File> files = Lists.newArrayList();
    private Set<String> securityGroups = Sets.newHashSet();
    private String keyName;
+   private String adminPass;
 
    @Override
    public <R extends HttpRequest> R bindToRequest(R request, Map<String, String> postParams) {
@@ -115,6 +117,9 @@ public class CreateServerOptions implements MapBinder {
         	  group.setName(groupName);
         	  server.securityGroups.add(group);
     	  }
+      }
+      if (adminPass != null) {
+    	  server.adminPass = adminPass;
       }
 
       return bindToRequest(request, ImmutableMap.of("server", server));
@@ -139,6 +144,12 @@ public class CreateServerOptions implements MapBinder {
       checkState(files.size() < 5, "maximum number of files allowed is 5");
       files.add(new File(path, contents));
       return this;
+   }
+   
+   public CreateServerOptions withAdminPass(String adminPass) {
+	   checkNotNull(adminPass, "adminPass");
+	   this.adminPass = adminPass;
+	   return this;
    }
 
    /**
@@ -197,6 +208,11 @@ public class CreateServerOptions implements MapBinder {
          CreateServerOptions options = new CreateServerOptions();
          return options.withFile(path, contents);
       }
+      
+      public static CreateServerOptions withAdminPass(String adminPass) {
+          CreateServerOptions options = new CreateServerOptions();
+          return options.withAdminPass(adminPass);
+       }
 
       /**
        * @see CreateServerOptions#withMetadata(Map<String, String>)

--- a/apis/nova/src/test/java/org/jclouds/openstack/nova/NovaAsyncClientTest.java
+++ b/apis/nova/src/test/java/org/jclouds/openstack/nova/NovaAsyncClientTest.java
@@ -156,6 +156,26 @@ public class NovaAsyncClientTest extends RestClientTest<NovaAsyncClient> {
 	      checkFilters(request);
    }
    
+   @Test
+   public void testCreateServerWithAdminPass() throws Exception {
+	   Method method = NovaAsyncClient.class.getMethod("createServer", String.class, String.class, String.class,
+	            createServerOptionsVarargsClass);
+	      HttpRequest request = processor.createRequest(method, "ralphie", 2, 1,
+	            withMetadata(ImmutableMap.of("foo", "bar")).withAdminPass("mypass"));
+
+	      assertRequestLineEquals(request, "POST http://endpoint/vapi-version/servers?format=json HTTP/1.1");
+	      assertNonPayloadHeadersEqual(request, "Accept: application/json\n");
+	      assertPayloadEquals(request,
+	            "{\"server\":{\"name\":\"ralphie\",\"imageRef\":\"2\",\"flavorRef\":\"1\",\"adminPass\":\"mypass\",\"metadata\":{\"foo\":\"bar\"}}}",
+	            "application/json", false);
+
+	      assertResponseParserClassEquals(method, request, UnwrapOnlyJsonValue.class);
+	      assertSaxResponseParserClassEquals(method, null);
+	      assertExceptionParserClassEquals(method, null);
+
+	      checkFilters(request);
+   }
+   
    public void testDeleteImage() throws IOException, SecurityException, NoSuchMethodException {
       Method method = NovaAsyncClient.class.getMethod("deleteImage", int.class);
       HttpRequest request = processor.createRequest(method, 2);

--- a/apis/nova/src/test/java/org/jclouds/openstack/nova/options/CreateServerOptionsTest.java
+++ b/apis/nova/src/test/java/org/jclouds/openstack/nova/options/CreateServerOptionsTest.java
@@ -30,6 +30,7 @@ import java.net.URI;
 
 import static org.jclouds.openstack.nova.options.CreateServerOptions.Builder.withFile;
 import static org.jclouds.openstack.nova.options.CreateServerOptions.Builder.withSecurityGroup;
+import static org.jclouds.openstack.nova.options.CreateServerOptions.Builder.withAdminPass;
 import static org.testng.Assert.assertEquals;
 
 /**
@@ -87,6 +88,15 @@ public class CreateServerOptionsTest {
 		assertEquals(
 				request.getPayload().getRawContent(),
 				"{\"server\":{\"name\":\"foo\",\"imageRef\":\"1\",\"flavorRef\":\"2\",\"security_groups\":[{\"id\":0,\"name\":\"myothergroup\"},{\"id\":0,\"name\":\"mygroup\"}]}}");
+   }
+   
+   @Test
+   public void testWithAdminPass() {
+	   CreateServerOptions options =  withAdminPass("mypassword");
+	   HttpRequest request = buildRequest(options);
+		assertEquals(
+				request.getPayload().getRawContent(),
+				"{\"server\":{\"name\":\"foo\",\"imageRef\":\"1\",\"flavorRef\":\"2\",\"adminPass\":\"mypassword\"}}");
    }
 
    private void assertFile(HttpRequest request) {


### PR DESCRIPTION
Hi,

Just added the adminPass parameter when creating server so that user can specify the password instead of getting the one returned from nova.
