### PR TITLE
If group name can't be parsed from a group ID, try the key name

### DIFF
--- a/apis/ec2/src/test/java/org/jclouds/ec2/compute/functions/RunningInstanceToNodeMetadataTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/compute/functions/RunningInstanceToNodeMetadataTest.java
@@ -217,6 +217,20 @@ public class RunningInstanceToNodeMetadataTest {
                   .hardware(m1_small32().build()).location(provider).build());
    }
 
+   @Test
+   public void testGroupNameIsSetWhenCustomKeyNameIsSetAndSecurityGroupIsGenerated() {
+      checkGroupName(RunningInstance.builder().instanceId("id").imageId("image").instanceType("m1.small")
+              .instanceState(InstanceState.RUNNING).region("us-east-1").keyName("custom-key")
+              .groupId("jclouds#groupname#us-east-1").build());
+   }
+
+   @Test
+   public void testGroupNameIsSetWhenCustomSecurityGroupIsSetAndKeyNameIsGenerated() {
+      checkGroupName(RunningInstance.builder().instanceId("id").imageId("image").instanceType("m1.small")
+              .instanceState(InstanceState.RUNNING).region("us-east-1").groupId("custom-sec")
+              .keyName("jclouds#groupname#us-east-1#23").build());
+   }
+
    protected RunningInstance firstInstanceFromResource(String resource) {
       RunningInstance server = Iterables.get(Iterables.get(DescribeInstancesResponseHandlerTest
                .parseRunningInstances(resource), 0), 0);
@@ -237,6 +251,12 @@ public class RunningInstanceToNodeMetadataTest {
       };
       LoadingCache<RegionAndName, Image> instanceToImage = CacheBuilder.newBuilder().build(getRealImage);
       return createNodeParser(hardware, locations, credentialStore, instanceToNodeState, instanceToImage);
+   }
+
+   private void checkGroupName(RunningInstance instance) {
+      assertEquals("groupname", createNodeParser(ImmutableSet.<Hardware> of(), ImmutableSet
+            .<Location> of(), ImmutableSet.<Image> of(), ImmutableMap.<String, Credentials> of())
+            .apply(instance).getGroup());
    }
 
    private RunningInstanceToNodeMetadata createNodeParser(final ImmutableSet<Hardware> hardware,


### PR DESCRIPTION
When the security group is not generated by jclouds (e.g. when
using a custom group, or when in a VPC which generally requires
its own security groups), the group name to launch nodes into is
lost, since it is parsed from the generated security group ID.

This patch introduces a very local workaround: try to parse the
name from the key name, which if generated by jclouds has a format
that is very similar to the generated security group ID.

While probably not the ideal solution for persisting the group
name either (using user metadata might be), this fixes a blocking
issue for scenarios where you can't use a generated security group
ID (using a VPC in our case), but you can use a generated key pair
name.

Also it shouldn't interfere with existing usage: if a name can be
parsed from the security group, that is used, and if the key name
is not generated, the behaviour remains as it currently is (group
name is null if it can't be parsed from the security group).
