### PR TITLE
Reduced log levels for compute parsing methods

### DIFF
--- a/apis/cloudservers/src/main/java/org/jclouds/cloudservers/compute/functions/ServerToNodeMetadata.java
+++ b/apis/cloudservers/src/main/java/org/jclouds/cloudservers/compute/functions/ServerToNodeMetadata.java
@@ -123,7 +123,7 @@ public class ServerToNodeMetadata implements Function<Server, NodeMetadata> {
       try {
          return Iterables.find(hardwares.get(), new FindHardwareForServer(from));
       } catch (NoSuchElementException e) {
-         logger.warn("could not find a matching hardware for server %s", from);
+         logger.debug("could not find a matching hardware for server %s", from);
       }
       return null;
    }
@@ -132,7 +132,7 @@ public class ServerToNodeMetadata implements Function<Server, NodeMetadata> {
       try {
          return Iterables.find(images.get(), new FindImageForServer(from)).getOperatingSystem();
       } catch (NoSuchElementException e) {
-         logger.warn("could not find a matching image for server %s in location %s", from, location.get());
+         logger.debug("could not find a matching image for server %s in location %s", from, location.get());
       }
       return null;
    }

--- a/apis/deltacloud/src/main/java/org/jclouds/deltacloud/compute/functions/InstanceToNodeMetadata.java
+++ b/apis/deltacloud/src/main/java/org/jclouds/deltacloud/compute/functions/InstanceToNodeMetadata.java
@@ -98,7 +98,7 @@ public class InstanceToNodeMetadata implements Function<Instance, NodeMetadata> 
       try {
          return Iterables.find(hardwares.get(), new FindHardwareForInstance(from));
       } catch (NoSuchElementException e) {
-         logger.warn("could not find a matching hardware for instance %s", from);
+         logger.debug("could not find a matching hardware for instance %s", from);
       }
       return null;
    }
@@ -107,7 +107,7 @@ public class InstanceToNodeMetadata implements Function<Instance, NodeMetadata> 
       try {
          return Iterables.find(images.get(), new FindImageForInstance(from)).getOperatingSystem();
       } catch (NoSuchElementException e) {
-         logger.warn("could not find a matching image for instance %s", from);
+         logger.debug("could not find a matching image for instance %s", from);
       }
       return null;
    }
@@ -129,7 +129,7 @@ public class InstanceToNodeMetadata implements Function<Instance, NodeMetadata> 
       try {
          return Iterables.find(locations.get(), new FindLocationForInstance(from));
       } catch (NoSuchElementException e) {
-         logger.warn("could not find a matching realm for instance %s", from);
+         logger.debug("could not find a matching realm for instance %s", from);
       }
       return null;
    }

--- a/apis/nova/src/main/java/org/jclouds/openstack/nova/compute/functions/ServerToNodeMetadata.java
+++ b/apis/nova/src/main/java/org/jclouds/openstack/nova/compute/functions/ServerToNodeMetadata.java
@@ -126,7 +126,7 @@ public class ServerToNodeMetadata implements Function<Server, NodeMetadata> {
       try {
          return Iterables.find(hardwares.get(), new FindHardwareForServer(from));
       } catch (NoSuchElementException e) {
-         logger.warn("could not find a matching hardware for server %s", from);
+         logger.debug("could not find a matching hardware for server %s", from);
       }
       return null;
    }
@@ -135,7 +135,7 @@ public class ServerToNodeMetadata implements Function<Server, NodeMetadata> {
       try {
          return Iterables.find(images.get(), new FindImageForServer(from));
       } catch (NoSuchElementException e) {
-         logger.warn("could not find a matching image for server %s in location %s", from, location.get());
+         logger.debug("could not find a matching image for server %s in location %s", from, location.get());
       }
       return null;
    }

--- a/labs/glesys/src/main/java/org/jclouds/glesys/compute/functions/ServerDetailsToNodeMetadata.java
+++ b/labs/glesys/src/main/java/org/jclouds/glesys/compute/functions/ServerDetailsToNodeMetadata.java
@@ -127,7 +127,7 @@ public class ServerDetailsToNodeMetadata implements Function<ServerDetails, Node
       try {
          return Iterables.find(images.get(), new FindImageForServer(from)).getOperatingSystem();
       } catch (NoSuchElementException e) {
-         logger.warn("could not find a matching image for server %s", from);
+         logger.debug("could not find a matching image for server %s", from);
       }
       return null;
    }

--- a/providers/gogrid/src/main/java/org/jclouds/gogrid/compute/functions/ServerToNodeMetadata.java
+++ b/providers/gogrid/src/main/java/org/jclouds/gogrid/compute/functions/ServerToNodeMetadata.java
@@ -124,7 +124,7 @@ public class ServerToNodeMetadata implements Function<Server, NodeMetadata> {
       try {
          image = Iterables.find(images.get(), new FindImageForServer(from));
       } catch (NoSuchElementException e) {
-         logger.warn("could not find a matching image for server %s", from);
+         logger.debug("could not find a matching image for server %s", from);
       }
       return image;
    }
@@ -134,7 +134,7 @@ public class ServerToNodeMetadata implements Function<Server, NodeMetadata> {
       try {
          hardware = Iterables.find(hardwares.get(), new FindHardwareForServer(from));
       } catch (NoSuchElementException e) {
-         logger.warn("could not find a matching hardware for server %s", from);
+         logger.debug("could not find a matching hardware for server %s", from);
       }
       return hardware;
    }

--- a/providers/rimuhosting/src/main/java/org/jclouds/rimuhosting/miro/compute/functions/ServerToNodeMetadata.java
+++ b/providers/rimuhosting/src/main/java/org/jclouds/rimuhosting/miro/compute/functions/ServerToNodeMetadata.java
@@ -129,7 +129,7 @@ public class ServerToNodeMetadata implements Function<Server, NodeMetadata> {
       try {
          return Iterables.find(images.get(), new FindImageForServer(location, from)).getOperatingSystem();
       } catch (NoSuchElementException e) {
-         logger.warn("could not find a matching image for server %s in location %s", from, location);
+         logger.debug("could not find a matching image for server %s in location %s", from, location);
       }
       return null;
    }

--- a/providers/slicehost/src/main/java/org/jclouds/slicehost/compute/functions/SliceToNodeMetadata.java
+++ b/providers/slicehost/src/main/java/org/jclouds/slicehost/compute/functions/SliceToNodeMetadata.java
@@ -129,7 +129,7 @@ public class SliceToNodeMetadata implements Function<Slice, NodeMetadata> {
       try {
          return Iterables.find(hardwares.get(), new FindHardwareForSlice(from));
       } catch (NoSuchElementException e) {
-         logger.warn("could not find a matching hardware for slice %s", from);
+         logger.debug("could not find a matching hardware for slice %s", from);
       }
       return null;
    }
@@ -138,7 +138,7 @@ public class SliceToNodeMetadata implements Function<Slice, NodeMetadata> {
       try {
          return Iterables.find(images.get(), new FindImageForSlice(from)).getOperatingSystem();
       } catch (NoSuchElementException e) {
-         logger.warn("could not find a matching image for slice %s in location %s", from, location);
+         logger.debug("could not find a matching image for slice %s in location %s", from, location);
       }
       return null;
    }


### PR DESCRIPTION
As discussed in [Issue 863](http://code.google.com/p/jclouds/issues/detail?id=863).

Further to the description in that issue, similar methods (e.g. parseHardware(...)) with similar log messages have also had their logging levels reduced to debug from warn for consistency.

I'm pretty sure I found all the occurrences in the code base!
