### PR TITLE
Added missing job result types to map

### DIFF
--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/functions/ParseTypedAsyncJob.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/functions/ParseTypedAsyncJob.java
@@ -39,10 +39,12 @@ import org.jclouds.cloudstack.domain.Network;
 import org.jclouds.cloudstack.domain.PortForwardingRule;
 import org.jclouds.cloudstack.domain.PublicIPAddress;
 import org.jclouds.cloudstack.domain.SecurityGroup;
+import org.jclouds.cloudstack.domain.Snapshot;
 import org.jclouds.cloudstack.domain.Template;
 import org.jclouds.cloudstack.domain.TemplateExtraction;
 import org.jclouds.cloudstack.domain.User;
 import org.jclouds.cloudstack.domain.VirtualMachine;
+import org.jclouds.cloudstack.domain.Volume;
 import org.jclouds.domain.JsonBall;
 import org.jclouds.json.Json;
 import org.jclouds.logging.Logger;
@@ -73,7 +75,10 @@ public class ParseTypedAsyncJob implements Function<AsyncJob<Map<String, JsonBal
       .put("network", Network.class)
       .put("ipaddress", PublicIPAddress.class)
       .put("virtualmachine", VirtualMachine.class)
-      .put("loadbalancer", LoadBalancerRule.class).build();
+      .put("loadbalancer", LoadBalancerRule.class)
+      .put("snapshot", Snapshot.class)
+      .put("template", Template.class)
+      .put("volume", Volume.class).build();
    private final Json json;
 
    @Inject


### PR DESCRIPTION
In response to this test failure:

testListAsyncJobs(org.jclouds.cloudstack.features.AsyncJobClientLiveTest)  Time elapsed: 0.079 sec  <<< FAILURE!
java.lang.AssertionError: AsyncJob{accountId=-1, cmd='null', created=null, id=1673, instanceId=-1, instanceType='null', progress
=0, result=null, resultCode=SUCCESS, resultType='null', status=IN_PROGRESS, userId=-1, error=null}
    at org.jclouds.cloudstack.features.AsyncJobClientLiveTest.testListAsyncJobs(AsyncJobClientLiveTest.java:54)
