### PR TITLE
Do not fail test if we have only the ROOT domain

### DIFF
--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/DomainDomainClientLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/DomainDomainClientLiveTest.java
@@ -50,7 +50,7 @@ public class DomainDomainClientLiveTest extends BaseCloudStackClientLiveTest {
       assertEquals(root.getLevel(), 0);
       assertEquals(root.getParentDomainId(), 0);
       assertNull(root.getParentDomainName());
-      if (allDomains.size() > 0) {
+      if (allDomains.size() > 1) {
          assertTrue(root.hasChild());
       }
 


### PR DESCRIPTION
With this change all tests from DomainDomainClientLiveTest are now passing. 
