### PR TITLE
The percentage of used capacity can be 0 in test

### DIFF
--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/GlobalCapacityClientLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/features/GlobalCapacityClientLiveTest.java
@@ -45,7 +45,7 @@ public class GlobalCapacityClientLiveTest extends BaseCloudStackClientLiveTest {
       for (Capacity capacity : response) {
          assertTrue(capacity.getCapacityTotal() > 0);
          assertTrue(capacity.getCapacityUsed() > 0);
-         assertTrue(capacity.getPercentUsed() > 0);
+         assertTrue(capacity.getPercentUsed() >= 0);
          assertTrue(capacity.getType() != Capacity.Type.UNRECOGNIZED);
          assertNotNull(capacity.getZoneName());
          count++;


### PR DESCRIPTION
In response to this test failure:

testListCapacity(org.jclouds.cloudstack.features.GlobalCapacityClientLiveTest)  Time elapsed: 0.034 sec  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
    at org.testng.Assert.fail(Assert.java:89)    at org.testng.Assert.failNotEquals(Assert.java:489)
    at org.testng.Assert.assertTrue(Assert.java:37)
    at org.testng.Assert.assertTrue(Assert.java:47)
    at org.jclouds.cloudstack.features.GlobalCapacityClientLiveTest.testListCapacity(GlobalCapacityClientLiveTest.java:48)
