### PR TITLE
Issue #830: VdcClient live tests

### DIFF
--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/CaptureVAppParams.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/CaptureVAppParams.java
@@ -22,11 +22,13 @@ package org.jclouds.vcloud.director.v1_5.domain;
 import static com.google.common.base.Objects.equal;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.net.URI;
 import java.util.Collections;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementRef;
+import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 import org.jclouds.vcloud.director.v1_5.domain.ovf.DeploymentOptionSection;
@@ -69,6 +71,7 @@ import com.google.common.collect.Sets;
       "source",
       "sections"
 })
+@XmlRootElement(name = "CaptureVAppParams")
 public class CaptureVAppParams extends ParamsType {
    public static Builder<?> builder() {
       return new ConcreteBuilder();
@@ -94,6 +97,16 @@ public class CaptureVAppParams extends ParamsType {
          return self();
       }
 
+      /**
+       * Sets source to a new Reference that uses this URI as the href.
+       * 
+       * @see CaptureVAppParams#getSource()
+       */
+      public B source(URI source) {
+         this.source = Reference.builder().href(source).build();
+         return self();
+      }
+      
       /**
        * @see CaptureVAppParams#getSections()
        */

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/CloneVAppParams.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/CloneVAppParams.java
@@ -18,6 +18,7 @@
  */
 package org.jclouds.vcloud.director.v1_5.domain;
 
+import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 /**
@@ -30,6 +31,7 @@ import javax.xml.bind.annotation.XmlType;
  * @author grkvlt@apache.org
  */
 @XmlType(name = "CloneVAppParams")
+@XmlRootElement(name = "CloneVAppParams")
 public class CloneVAppParams extends InstantiateVAppParamsType {
 
    public static Builder<?> builder() {

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/CloneVAppTemplateParams.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/CloneVAppTemplateParams.java
@@ -21,6 +21,8 @@ package org.jclouds.vcloud.director.v1_5.domain;
 
 import static com.google.common.base.Objects.equal;
 
+import java.net.URI;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
@@ -82,6 +84,16 @@ public class CloneVAppTemplateParams extends ParamsType {
       }
 
       /**
+       * Sets source to a new Reference that uses this URI as the href.
+       * 
+       * @see CloneVAppTemplateParams#getSource()
+       */
+      public B source(URI source) {
+         this.source = Reference.builder().href(source).build();
+         return self();
+      }
+
+      /**
        * @see CloneVAppTemplateParams#isSourceDelete()
        */
       public B isSourceDelete(Boolean isSourceDelete) {
@@ -106,7 +118,7 @@ public class CloneVAppTemplateParams extends ParamsType {
       isSourceDelete = builder.isSourceDelete;
    }
 
-   private CloneVAppTemplateParams() {
+   protected CloneVAppTemplateParams() {
       // for JAXB
    }
 

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/InstantiateVAppParamsType.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/InstantiateVAppParamsType.java
@@ -20,6 +20,8 @@ package org.jclouds.vcloud.director.v1_5.domain;
 
 import static com.google.common.base.Objects.equal;
 
+import java.net.URI;
+
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
@@ -61,6 +63,16 @@ public class InstantiateVAppParamsType extends VAppCreationParamsType {
        */
       public B source(Reference source) {
          this.source = source;
+         return self();
+      }
+
+      /**
+       * Sets source to a new Reference that uses this URI as the href.
+       * 
+       * @see InstantiateVAppParamsType#getSource()
+       */
+      public B source(URI source) {
+         this.source = Reference.builder().href(source).build();
          return self();
       }
 

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/ResourceEntityType.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/ResourceEntityType.java
@@ -52,6 +52,7 @@ public abstract class ResourceEntityType extends EntityType {
    public static enum Status {
       
       FAILED_CREATION(-1, "The object could not be created.", true, true, true),
+      NOT_READY(0, "Not ready", true, false, false), // TODO duplicate code, but mentioned in `POST /vdc/{id}/action/uploadVAppTemplate`
       UNRESOLVED(0, "The object is unresolved.", true, true, true),
       RESOLVED(1, "The object is resolved.", true, true, true),
       DEPLOYED(2, "The object is deployed.", false, false, false),

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/SourcedCompositionItemParam.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/SourcedCompositionItemParam.java
@@ -79,7 +79,7 @@ public class SourcedCompositionItemParam {
       private Reference source;
       private String vAppScopedLocalId;
       private InstantiationParams instantiationParams;
-      private Set<NetworkAssignment> networkAssignments = Sets.newLinkedHashSet();
+      private Set<NetworkAssignment> networkAssignment = Sets.newLinkedHashSet();
       private Boolean sourceDelete;
 
       /**
@@ -107,10 +107,10 @@ public class SourcedCompositionItemParam {
       }
 
       /**
-       * @see SourcedCompositionItemParam#getNetworkAssignments()
+       * @see SourcedCompositionItemParam#getNetworkAssignment()
        */
-      public Builder networkAssignments(Set<NetworkAssignment> networkAssignments) {
-         this.networkAssignments = ImmutableSet.copyOf(checkNotNull(networkAssignments, "networkAssignments"));
+      public Builder networkAssignment(Set<NetworkAssignment> networkAssignment) {
+         this.networkAssignment = ImmutableSet.copyOf(checkNotNull(networkAssignment, "networkAssignments"));
          return this;
       }
 
@@ -123,24 +123,24 @@ public class SourcedCompositionItemParam {
       }
 
       public SourcedCompositionItemParam build() {
-         return new SourcedCompositionItemParam(source, vAppScopedLocalId, instantiationParams, networkAssignments, sourceDelete);
+         return new SourcedCompositionItemParam(source, vAppScopedLocalId, instantiationParams, networkAssignment, sourceDelete);
       }
 
       public Builder fromSourcedCompositionItemParam(SourcedCompositionItemParam in) {
          return source(in.getSource())
                .vAppScopedLocalId(in.getVAppScopedLocalId())
                .instantiationParams(in.getInstantiationParams())
-               .networkAssignments(in.getNetworkAssignments())
+               .networkAssignment(in.getNetworkAssignment())
                .sourceDelete(in.isSourceDelete());
       }
    }
 
    public SourcedCompositionItemParam(Reference source, String vAppScopedLocalId, InstantiationParams instantiationParams,
-                                      Set<NetworkAssignment> networkAssignments, Boolean sourceDelete) {
+                                      Set<NetworkAssignment> networkAssignment, Boolean sourceDelete) {
       this.source = source;
       this.vAppScopedLocalId = vAppScopedLocalId;
       this.instantiationParams = instantiationParams;
-      this.networkAssignments = ImmutableSet.copyOf(networkAssignments);
+      this.networkAssignment = ImmutableSet.copyOf(networkAssignment);
       this.sourceDelete = sourceDelete;
    }
 
@@ -155,7 +155,7 @@ public class SourcedCompositionItemParam {
    @XmlElement(name = "InstantiationParams")
    protected InstantiationParams instantiationParams;
    @XmlElement(name = "NetworkAssignment")
-   protected Set<NetworkAssignment> networkAssignments = Sets.newLinkedHashSet();
+   protected Set<NetworkAssignment> networkAssignment = Sets.newLinkedHashSet();
    @XmlAttribute
    protected Boolean sourceDelete;
 
@@ -193,8 +193,8 @@ public class SourcedCompositionItemParam {
    /**
     * Gets the value of the networkAssignment property.
     */
-   public Set<NetworkAssignment> getNetworkAssignments() {
-      return Collections.unmodifiableSet(this.networkAssignments);
+   public Set<NetworkAssignment> getNetworkAssignment() {
+      return Collections.unmodifiableSet(this.networkAssignment);
    }
 
    /**
@@ -217,7 +217,7 @@ public class SourcedCompositionItemParam {
       return equal(source, that.source) &&
             equal(vAppScopedLocalId, that.vAppScopedLocalId) &&
             equal(instantiationParams, that.instantiationParams) &&
-            equal(networkAssignments, that.networkAssignments) &&
+            equal(networkAssignment, that.networkAssignment) &&
             equal(sourceDelete, that.sourceDelete);
    }
 
@@ -226,7 +226,7 @@ public class SourcedCompositionItemParam {
       return Objects.hashCode(source,
             vAppScopedLocalId,
             instantiationParams,
-            networkAssignments,
+            networkAssignment,
             sourceDelete);
    }
 
@@ -236,7 +236,7 @@ public class SourcedCompositionItemParam {
             .add("source", source)
             .add("vAppScopedLocalId", vAppScopedLocalId)
             .add("instantiationParams", instantiationParams)
-            .add("networkAssignments", networkAssignments)
+            .add("networkAssignment", networkAssignment)
             .add("sourceDelete", sourceDelete).toString();
    }
 

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/UploadVAppTemplateParams.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/UploadVAppTemplateParams.java
@@ -22,6 +22,7 @@ package org.jclouds.vcloud.director.v1_5.domain;
 import static com.google.common.base.Objects.equal;
 
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 import com.google.common.base.Objects;
@@ -48,6 +49,7 @@ import com.google.common.base.Objects;
  * </pre>
  */
 @XmlType(name = "UploadVAppTemplateParams")
+@XmlRootElement(name = "UploadVAppTemplateParams")
 public class UploadVAppTemplateParams extends ParamsType {
    public static Builder<?> builder() {
       return new ConcreteBuilder();

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/domain/Checks.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/domain/Checks.java
@@ -72,11 +72,15 @@ import com.google.common.net.InetAddresses;
 public class Checks {
 
    public static void checkResourceEntityType(ResourceEntityType resourceEntity) {
+      checkResourceEntityType(resourceEntity, true);
+   }
+
+   public static void checkResourceEntityType(ResourceEntityType resourceEntity, boolean ready) {
       // Check optional fields
       // NOTE status cannot be checked (TODO: doesn't status have a range of valid values?)
       Set<File> files = resourceEntity.getFiles();
       if (files != null && !files.isEmpty()) {
-         for (File file : files) checkFile(file);
+         for (File file : files) checkFile(file, ready);
       }
       
       // Check parent type
@@ -197,13 +201,17 @@ public class Checks {
       // Check parent type
       checkEntityType(task);
    }
-   
+
    public static void checkFile(File file) {
+      checkFile(file, true);
+   }
+   
+   public static void checkFile(File file, boolean checkSize) {
       // Check optional fields
       // NOTE checksum be checked
       Long size = file.getSize();
-      if(size != null) {
-         assertTrue(file.size >= 0, "File size must be greater than or equal to 0");
+      if(size != null && checkSize) {
+         assertTrue(size >= 0, "File size must be greater than or equal to 0, but was "+size);
       }
       Long bytesTransferred = file.getBytesTransferred();
       if(bytesTransferred != null) {
@@ -612,8 +620,16 @@ public class Checks {
       // Check parent type
       checkResourceEntityType(abstractVAppType);
    }
-
+   
    public static void checkVAppTemplate(VAppTemplate template) {
+      checkVAppTemplate(template, true);
+   }
+   
+   public static void checkVAppTemplateWhenNotReady(VAppTemplate template) {
+      checkVAppTemplate(template, false);
+   }
+   
+   public static void checkVAppTemplate(VAppTemplate template, boolean ready) {
       // Check required fields
       assertNotNull(template.getName(), String.format(NOT_NULL_OBJECT_FMT, "Name", "VAppTemplate"));
       
@@ -633,7 +649,7 @@ public class Checks {
       }
       if (template.getFiles() != null) {
          for (File file : template.getFiles()) {
-            checkFile(file);
+            checkFile(file, ready);
          }
       }
       
@@ -642,7 +658,7 @@ public class Checks {
       // NOTE goldMaster cannot be checked
       
       // Check parent type
-      checkResourceEntityType(template);
+      checkResourceEntityType(template, ready);
    }
 
    public static void checkVm(Vm vm) {

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/internal/BaseVCloudDirectorClientLiveTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/internal/BaseVCloudDirectorClientLiveTest.java
@@ -18,8 +18,11 @@
  */
 package org.jclouds.vcloud.director.v1_5.internal;
 
+import static org.testng.Assert.assertTrue;
+
 import java.net.URI;
 import java.util.Properties;
+import java.util.Random;
 
 import javax.inject.Inject;
 
@@ -111,6 +114,8 @@ public abstract class BaseVCloudDirectorClientLiveTest extends BaseVersionedServ
    protected URI vdcURI;
    protected URI userURI;
 
+   protected Random random = new Random();
+
    // TODO change properties to URI, not id
    @SuppressWarnings("unchecked")
    protected void initTestParametersFromPropertiesOrLazyDiscover() {
@@ -169,5 +174,13 @@ public abstract class BaseVCloudDirectorClientLiveTest extends BaseVersionedServ
    
    public URI toAdminUri(URI uri) {
       return Reference.builder().href(uri).build().toAdminReference(endpoint).getHref();
+   }
+   
+   protected void assertTaskSucceeds(Task task) {
+      assertTrue(retryTaskSuccess.apply(task));
+   }
+   
+   protected void assertTaskSucceedsLong(Task task) {
+      assertTrue(retryTaskSuccessLong.apply(task));
    }
 }


### PR DESCRIPTION
Code notes:
- an uploaded vAppTemplate starts life in a NOT_READY state. If you ask it for its files, it returns a file with size -1 (i.e. doesn't exist because stage 2-4 of upload haven't been done). I've therefore had to do a bit of unpleasant overloading of the Checks to say whether to assert the file size is >= 0.

---

Progress report:

Tests: 10
Pass: 6
Fail: 3
Skip: 1

Errors:
- clone vApp template gives 500 error (e-mailed Adrian about that yesterday; no response yet)
- clone vApp gives 500 error (possibly same as above?)
- getMetadata wants at least one entry for testing, but none exist yet
- getMetadataValue skipped because no metadata entries exist

Other notes:
- `POST /vdc/{id}/media` is not covered by any live tests yet
