### PR TITLE
Issue #830 vcloud-director: QueryClient live tests and fixes

### DIFF
--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/query/QueryResultRecordType.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/query/QueryResultRecordType.java
@@ -45,6 +45,9 @@ import com.google.common.collect.Sets;
  * @author grkvlt@apache.org
  */
 @XmlSeeAlso({
+      QueryResultVAppTemplateRecord.class,
+      QueryResultVAppRecord.class,
+      QueryResultDatastoreRecord.class,
       QueryResultCatalogRecord.class,
       QueryResultNetworkRecord.class}
 )
@@ -125,7 +128,6 @@ public class QueryResultRecordType {
    @XmlElement(name = "Link")
    private Set<Link> links = Sets.newLinkedHashSet();
    @XmlAttribute
-   @XmlSchemaType(name = "anyURI")
    private URI href;
    @XmlAttribute
    private String id;
@@ -150,7 +152,7 @@ public class QueryResultRecordType {
       this.href = href;
    }
 
-   public QueryResultRecordType() {
+   protected QueryResultRecordType() {
       // For JAXB
    }
 

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/features/QueryAsyncClient.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/features/QueryAsyncClient.java
@@ -127,6 +127,20 @@ public interface QueryAsyncClient {
    ListenableFuture<CatalogReferences> catalogReferencesQuery(@QueryParam("page") Integer page, @QueryParam("pageSize") Integer pageSize,
          @QueryParam("filter") String filter);
 
+   @GET
+   @Path("/vAppTemplates/query")
+   @Consumes
+   @JAXBResponseParser
+   @ExceptionParser(ThrowVCloudErrorOn4xx.class)
+   ListenableFuture<QueryResultRecords> vAppTemplatesQueryAll();
+
+   @GET
+   @Path("/vAppTemplates/query")
+   @Consumes
+   @JAXBResponseParser
+   @ExceptionParser(ThrowVCloudErrorOn4xx.class)
+   ListenableFuture<QueryResultRecords> vAppTemplatesQuery(@QueryParam("filter") String filter);
+
    /**
     * Retrieves a list of {@link VApp}s by using REST API general QueryHandler.
     */
@@ -176,4 +190,18 @@ public interface QueryAsyncClient {
    @ExceptionParser(ThrowVCloudErrorOn4xx.class)
    ListenableFuture<VAppReferences> vAppReferencesQuery(@QueryParam("page") Integer page, @QueryParam("pageSize") Integer pageSize,
          @QueryParam("filter") String filter);
+   
+   @GET
+   @Path("/vms/query")
+   @Consumes
+   @JAXBResponseParser
+   @ExceptionParser(ThrowVCloudErrorOn4xx.class)
+   ListenableFuture<QueryResultRecords> vmsQueryAll();
+
+   @GET
+   @Path("/vms/query")
+   @Consumes
+   @JAXBResponseParser
+   @ExceptionParser(ThrowVCloudErrorOn4xx.class)
+   ListenableFuture<QueryResultRecords> vmsQuery(@QueryParam("filter") String filter);
 }

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/features/QueryClient.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/features/QueryClient.java
@@ -21,6 +21,11 @@ package org.jclouds.vcloud.director.v1_5.features;
 import java.util.concurrent.TimeUnit;
 
 import org.jclouds.concurrent.Timeout;
+import org.jclouds.vcloud.director.v1_5.domain.Catalog;
+import org.jclouds.vcloud.director.v1_5.domain.CatalogReference;
+import org.jclouds.vcloud.director.v1_5.domain.Link;
+import org.jclouds.vcloud.director.v1_5.domain.VApp;
+import org.jclouds.vcloud.director.v1_5.domain.VAppTemplate;
 import org.jclouds.vcloud.director.v1_5.domain.query.CatalogReferences;
 import org.jclouds.vcloud.director.v1_5.domain.query.QueryList;
 import org.jclouds.vcloud.director.v1_5.domain.query.QueryResultRecords;
@@ -103,6 +108,20 @@ public interface QueryClient {
    CatalogReferences catalogReferencesQuery(Integer page, Integer pageSize, String filter);
 
    /**
+    * Retrieves a list of {@link VAppTemplate}s by using REST API general QueryHandler.
+    *
+    * <pre>
+    * GET /vAppTemplates/query
+    * </pre>
+    *
+    * @see #queryAll(String)
+    */
+   QueryResultRecords vAppTemplatesQueryAll();
+
+   /** @see #queryAll() */
+   QueryResultRecords vAppTemplatesQuery(String filter);
+
+   /**
     * Retrieves a list of {@link VApp}s by using REST API general QueryHandler.
     *
     * <pre>
@@ -118,6 +137,20 @@ public interface QueryClient {
 
    /** @see #queryAll() */
    QueryResultRecords vAppsQuery(Integer page, Integer pageSize, String filter);
+
+   /**
+    * Retrieves a list of {@link Vm}s by using REST API general QueryHandler.
+    *
+    * <pre>
+    * GET /vms/query
+    * </pre>
+    *
+    * @see #queryAll(String)
+    */
+   QueryResultRecords vmsQueryAll();
+
+   /** @see #queryAll() */
+   QueryResultRecords vmsQuery(String filter);
 
    /**
     * Retrieves a list of {@link VAppReference}s by using REST API general QueryHandler.

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/QueryClientLiveTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/QueryClientLiveTest.java
@@ -19,9 +19,21 @@
 package org.jclouds.vcloud.director.v1_5.features;
 
 import static org.jclouds.vcloud.director.v1_5.VCloudDirectorLiveTestConstants.NOT_EMPTY_OBJECT_FMT;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.jclouds.vcloud.director.v1_5.VCloudDirectorMediaType;
+import org.jclouds.vcloud.director.v1_5.domain.VAppTemplate;
 import org.jclouds.vcloud.director.v1_5.domain.query.CatalogReferences;
+import org.jclouds.vcloud.director.v1_5.domain.query.QueryResultRecordType;
 import org.jclouds.vcloud.director.v1_5.domain.query.QueryResultRecords;
 import org.jclouds.vcloud.director.v1_5.internal.BaseVCloudDirectorClientLiveTest;
 import org.testng.annotations.BeforeClass;
@@ -39,32 +51,80 @@ public class QueryClientLiveTest extends BaseVCloudDirectorClientLiveTest {
     * Convenience references to API clients.
     */
 
-   private CatalogClient catalogClient;
    private QueryClient queryClient;
+   private VAppTemplateClient vappTemplateClient;
 
    @Override
    @BeforeClass(inheritGroups = true)
    public void setupRequiredClients() {
-      catalogClient = context.getApi().getCatalogClient();
       queryClient = context.getApi().getQueryClient();
+      vappTemplateClient = context.getApi().getVAppTemplateClient();
    }
-
-   /*
-    * Shared state between dependant tests.
-    */
-
-   private QueryResultRecords catalogRecords;
-   private CatalogReferences catalogReferences;
 
    @Test(testName = "GET /catalogs/query")
    public void testQueryAllCatalogs() {
-      catalogRecords = queryClient.catalogsQueryAll();
+      QueryResultRecords catalogRecords = queryClient.catalogsQueryAll();
       assertFalse(catalogRecords.getRecords().isEmpty(), String.format(NOT_EMPTY_OBJECT_FMT, "CatalogRecord", "QueryResultRecords"));
    }
 
    @Test(testName = "GET /catalogs/query?format=references", dependsOnMethods = { "testQueryAllCatalogs" })
    public void testQueryAllCatalogReferences() {
-      catalogReferences = queryClient.catalogReferencesQueryAll();
+      CatalogReferences catalogReferences = queryClient.catalogReferencesQueryAll();
       assertFalse(catalogReferences.getReferences().isEmpty(), String.format(NOT_EMPTY_OBJECT_FMT, "CatalogReference", "CatalogReferences"));
+   }
+   
+   @Test(testName = "GET /vAppTemplates/query")
+   public void testQueryAllVAppTemplates() {
+      QueryResultRecords queryResult = queryClient.vAppTemplatesQueryAll();
+      Set<URI> hrefs = toHrefs(queryResult);
+      
+      assertRecordTypes(queryResult, Arrays.asList(VCloudDirectorMediaType.VAPP_TEMPLATE, null));
+      assertTrue(hrefs.contains(vAppTemplateURI), "VAppTemplates query result should include vAppTemplate "+vAppTemplateURI+"; but only has "+hrefs);
+   }
+   
+   @Test(testName = "GET /vAppTemplates/query?filter)")
+   public void testQueryVAppTemplates() {
+      VAppTemplate vAppTemplate = vappTemplateClient.getVAppTemplate(vAppTemplateURI);
+      QueryResultRecords queryResult = queryClient.vAppTemplatesQuery(String.format("name==%s", vAppTemplate.getName()));
+      Set<URI> hrefs = toHrefs(queryResult);
+      
+      assertRecordTypes(queryResult, Arrays.asList(VCloudDirectorMediaType.VAPP_TEMPLATE, null));
+      assertEquals(hrefs, Collections.singleton(vAppTemplateURI), "VAppTemplates query result should have found vAppTemplate "+vAppTemplateURI);
+   }
+
+   @Test(testName = "GET /vApps/query")
+   public void testQueryAllVApps() {
+      // TODO instantiate a vApp, so can assert it's included
+      
+      QueryResultRecords queryResult = queryClient.vAppsQueryAll();
+      Set<URI> hrefs = toHrefs(queryResult);
+      
+      assertRecordTypes(queryResult, Arrays.asList(VCloudDirectorMediaType.VAPP, null));
+      //assertTrue(hrefs.contains(vappUri), "VApp query result should include vapp "+vappUri+"; but only has "+hrefs);
+   }
+   
+   @Test(testName = "GET /vms/query")
+   public void testQueryAllVms() {
+      // TODO instantiate a vApp + vms, so can assert it's included
+      
+      QueryResultRecords queryResult = queryClient.vmsQueryAll();
+      Set<URI> hrefs = toHrefs(queryResult);
+      
+      assertRecordTypes(queryResult, Arrays.asList(VCloudDirectorMediaType.VM, null));
+      //assertTrue(hrefs.contains(vappUri), "VApp query result should include vapp "+vappUri+"; but only has "+hrefs);
+   }
+   
+   private void assertRecordTypes(QueryResultRecords queryResult, Collection<String> validTypes) {
+      for (QueryResultRecordType record : queryResult.getRecords()) {
+         assertTrue(validTypes.contains(record.getType()), "invalid type for query result record, "+record.getType()+"; valid types are "+validTypes);
+      }
+   }
+   
+   private Set<URI> toHrefs(QueryResultRecords queryResult) {
+      Set<URI> hrefs = new LinkedHashSet<URI>();
+      for (QueryResultRecordType record : queryResult.getRecords()) {
+         hrefs.add(record.getHref());
+      }
+      return hrefs;
    }
 }


### PR DESCRIPTION
Live tests for QueryClient, and required fixes.

---

Adds coverage for the following:
- GET /vAppTemplates/query
- GET /vApps/query
- GET /vms/query

---

Code comments:
- The tests do not yet create a vApp (and thus not a VM), so those queries do not have strong assertions.
- The attempt to assert queryResultRecord.getType was futile: there is no type attribute in the xml so the 'type' field is null.
- For the existing QueryAsyncClient.catalogsQuery, it is overloaded to take page+pageSize+filter.
  I haven't (yet) overloaded vAppTemplatesQuery in the same way.
  Also note there are no tests for the existing catalogsQuery that uses filters.
- `GET /query` is still to be tested.
