### PR TITLE
Issue 830: vCloud  1.5 updates

### DIFF
--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/VAppClientLiveTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/VAppClientLiveTest.java
@@ -118,12 +118,6 @@ public class VAppClientLiveTest extends AbstractVAppClientLiveTest {
     */
    @Test(testName = "GET /vApp/{id}")
    public void testGetVApp() {
-      VApp vAppInstantiated = instantiateVApp();
-
-      // Wait for the task to complete
-      Task instantiateTask = Iterables.getOnlyElement(vAppInstantiated.getTasks());
-      assertTrue(retryTaskSuccessLong.apply(instantiateTask), String.format(TASK_COMPLETE_TIMELY, "instantiateTask"));
-
       // The method under test
       vApp = vAppClient.getVApp(vAppURI);
 
@@ -1158,18 +1152,27 @@ public class VAppClientLiveTest extends AbstractVAppClientLiveTest {
    /**
     * @see VAppClient#deleteVApp(URI)
     */
-   @Test(testName = "DELETE /vApp/{id}", dependsOnMethods = { "testPowerOffVApp" })
+   @Test(testName = "DELETE /vApp/{id}")
    public void testDeleteVApp() {
+      // Create a temporary VApp to delete
+      VApp temp = instantiateVApp();
+      DeployVAppParams params = DeployVAppParams.builder()
+            .deploymentLeaseSeconds((int) TimeUnit.SECONDS.convert(1L, TimeUnit.HOURS))
+            .notForceCustomization()
+            .notPowerOn()
+            .build();
+      Task deployVApp = vAppClient.deploy(temp.getHref(), params);
+      assertTrue(retryTaskSuccessLong.apply(deployVApp), String.format(TASK_COMPLETE_TIMELY, "deployVApp"));
+
       // The method under test
-      Task deleteVApp = vAppClient.deleteVApp(vApp.getHref());
+      Task deleteVApp = vAppClient.deleteVApp(temp.getHref());
       assertTrue(retryTaskSuccess.apply(deleteVApp), String.format(TASK_COMPLETE_TIMELY, "deleteVApp"));
 
       try {
-         vApp = vAppClient.getVApp(vApp.getHref());
+         vAppClient.getVApp(temp.getHref());
          fail("The VApp should have been deleted");
       } catch (VCloudDirectorException vcde) {
          assertEquals(vcde.getError().getMajorErrorCode(), Integer.valueOf(403), "The error code should have been 'Forbidden' (403)");
-         vApp = null;
       }
    }
 }


### PR DESCRIPTION
- Moved shared code for VApp and VAppTemplate into parent class. needs more methods copied here.
- Updated ProductSection domain objects and tests. Modify test still does not pass, currently.
- Various COM/OVF domain object updates and fixes to tests, mostly to do with JAXB issues, some of which are still present.

Due to the JAXB issues not yet fully resolved, this should probably not be merged yet.

Current test status: 62 methods, 16 failed, 9 skipped, 37 passed
