### PR TITLE
Use GMT for RFC 822 dates

### DIFF
--- a/core/src/main/java/org/jclouds/date/internal/SimpleDateFormatDateService.java
+++ b/core/src/main/java/org/jclouds/date/internal/SimpleDateFormatDateService.java
@@ -47,7 +47,7 @@ public class SimpleDateFormatDateService implements DateService {
    private static final SimpleDateFormat iso8601SimpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US);
 
    // @GuardedBy("this")
-   private static final SimpleDateFormat rfc822SimpleDateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.US);
+   private static final SimpleDateFormat rfc822SimpleDateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss 'GMT'", Locale.US);
 
    // @GuardedBy("this")
    private static final SimpleDateFormat cSimpleDateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss Z yyyy", Locale.US);

--- a/drivers/joda/src/main/java/org/jclouds/date/joda/JodaDateService.java
+++ b/drivers/joda/src/main/java/org/jclouds/date/joda/JodaDateService.java
@@ -42,7 +42,7 @@ import org.joda.time.format.DateTimeFormatter;
 public class JodaDateService implements DateService {
 
    private static final DateTimeFormatter rfc822DateFormatter = DateTimeFormat.forPattern(
-            "EEE, dd MMM yyyy HH:mm:ss z").withLocale(Locale.US).withZone(DateTimeZone.forID("GMT"));
+            "EEE, dd MMM yyyy HH:mm:ss 'GMT'").withLocale(Locale.US).withZone(DateTimeZone.forID("GMT"));
 
    private static final DateTimeFormatter cDateFormatter = DateTimeFormat
             .forPattern("EEE MMM dd HH:mm:ss Z yyyy").withLocale(Locale.US).withZone(DateTimeZone.forID("GMT"));


### PR DESCRIPTION
This fixes AWS S3 support, which previously complained about a missing
or improper Date header.
