### PR TITLE
Issue 830: vCloud 1.5 - Improving CatalogClientLiveTest

### DIFF
--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/features/AdminCatalogAsyncClient.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/features/AdminCatalogAsyncClient.java
@@ -29,6 +29,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 
 import org.jclouds.rest.annotations.BinderParam;
+import org.jclouds.rest.annotations.Delegate;
 import org.jclouds.rest.annotations.EndpointParam;
 import org.jclouds.rest.annotations.ExceptionParser;
 import org.jclouds.rest.annotations.JAXBResponseParser;
@@ -36,6 +37,7 @@ import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.binders.BindToXMLPayload;
 import org.jclouds.vcloud.director.v1_5.VCloudDirectorMediaType;
 import org.jclouds.vcloud.director.v1_5.domain.AdminCatalog;
+import org.jclouds.vcloud.director.v1_5.domain.Metadata;
 import org.jclouds.vcloud.director.v1_5.domain.Owner;
 import org.jclouds.vcloud.director.v1_5.domain.PublishCatalogParams;
 import org.jclouds.vcloud.director.v1_5.filters.AddVCloudAuthorizationToRequest;
@@ -125,4 +127,12 @@ public interface AdminCatalogAsyncClient extends CatalogAsyncClient {
    @ExceptionParser(ThrowVCloudErrorOn4xx.class)
    ListenableFuture<Void> publishCatalog(@EndpointParam URI catalogRef,
          @BinderParam(BindToXMLPayload.class) PublishCatalogParams params);
+
+   /**
+    * @return synchronous access to {@link Metadata.Writable} features
+    */
+   @Override
+   @Delegate
+   MetadataAsyncClient.Writable getMetadataClient();
+
 }

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/features/AdminCatalogClient.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/features/AdminCatalogClient.java
@@ -23,7 +23,9 @@ import java.util.concurrent.TimeUnit;
 
 import org.jclouds.concurrent.Timeout;
 import org.jclouds.rest.annotations.RequestFilters;
+import org.jclouds.rest.annotations.Delegate;
 import org.jclouds.vcloud.director.v1_5.domain.AdminCatalog;
+import org.jclouds.vcloud.director.v1_5.domain.Metadata;
 import org.jclouds.vcloud.director.v1_5.domain.Owner;
 import org.jclouds.vcloud.director.v1_5.domain.PublishCatalogParams;
 import org.jclouds.vcloud.director.v1_5.filters.AddVCloudAuthorizationToRequest;
@@ -112,4 +114,11 @@ public interface AdminCatalogClient extends CatalogClient {
    
    //TODO: lot of work to pass in a single boolean, would like to polymorphically include something like:
    //void publishCatalog(URI catalogRef)
+
+   /**
+    * @return synchronous access to {@link Metadata.Writable} features
+    */
+   @Override
+   @Delegate
+   MetadataClient.Writeable getMetadataClient();
 }

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/features/CatalogAsyncClient.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/features/CatalogAsyncClient.java
@@ -38,7 +38,7 @@ import org.jclouds.rest.binders.BindToXMLPayload;
 import org.jclouds.vcloud.director.v1_5.VCloudDirectorMediaType;
 import org.jclouds.vcloud.director.v1_5.domain.CatalogItem;
 import org.jclouds.vcloud.director.v1_5.domain.CatalogType;
-import org.jclouds.vcloud.director.v1_5.features.MetadataAsyncClient.Writable;
+import org.jclouds.vcloud.director.v1_5.domain.Metadata;
 import org.jclouds.vcloud.director.v1_5.filters.AddVCloudAuthorizationToRequest;
 import org.jclouds.vcloud.director.v1_5.functions.ThrowVCloudErrorOn4xx;
 
@@ -102,8 +102,14 @@ public interface CatalogAsyncClient {
    ListenableFuture<Void> deleteCatalogItem(@EndpointParam URI catalogItemUri);
 
    /**
-    * @return asynchronous access to {@link Writable} features
+    * @return asynchronous access to {@link Metadata.Readable} features
     */
    @Delegate
-   MetadataAsyncClient.Writable getMetadataClient();
+   MetadataAsyncClient.Readable getMetadataClient();
+
+   /**
+    * @return asynchronous access to {@link Metadata.Writeable} features for CatalogItems
+    */
+   @Delegate
+   MetadataAsyncClient.Writable getCatalogItemMetadataClient();
 }

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/features/CatalogClient.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/features/CatalogClient.java
@@ -99,8 +99,15 @@ public interface CatalogClient {
    void deleteCatalogItem(URI catalogItemRef);
 
    /**
-    * @return synchronous access to {@link Metadata.Writeable} features
+    * @return synchronous access to {@link Metadata.Readable} features
     */
    @Delegate
-   MetadataClient.Writeable getMetadataClient();
+   MetadataClient.Readable getMetadataClient();
+
+   /**
+    * @return synchronous access to {@link Metadata.Writeable} features for CatalogItems
+    */
+   @Delegate
+   MetadataClient.Writeable getCatalogItemMetadataClient();
+
 }

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/CatalogClientExpectTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/CatalogClientExpectTest.java
@@ -295,7 +295,7 @@ public class CatalogClientExpectTest extends BaseVCloudDirectorRestClientExpectT
       
       Task expected = mergeMetadataTask();
       
-      assertEquals(client.getCatalogClient().getMetadataClient().mergeMetadata(catalogItemURI, metadata), expected);
+      assertEquals(client.getCatalogClient().getCatalogItemMetadataClient().mergeMetadata(catalogItemURI, metadata), expected);
    }
 
    @Test
@@ -348,7 +348,7 @@ public class CatalogClientExpectTest extends BaseVCloudDirectorRestClientExpectT
       
       Task expected = setMetadataValueTask();
       
-      assertEquals(client.getCatalogClient().getMetadataClient().setMetadata(catalogItemURI, "KEY", value), expected);
+      assertEquals(client.getCatalogClient().getCatalogItemMetadataClient().setMetadata(catalogItemURI, "KEY", value), expected);
    }
 
    @Test
@@ -373,7 +373,7 @@ public class CatalogClientExpectTest extends BaseVCloudDirectorRestClientExpectT
       
       Task expected = deleteMetadataEntryTask();
       
-      assertEquals(client.getCatalogClient().getMetadataClient().deleteMetadataEntry(catalogItemURI, "KEY"), expected);
+      assertEquals(client.getCatalogClient().getCatalogItemMetadataClient().deleteMetadataEntry(catalogItemURI, "KEY"), expected);
    }
 
    @SuppressWarnings("unchecked")


### PR DESCRIPTION
To clarify usage, I also changed CatalogClient.getMetadataClient() return a read-only client, with an extra getCatalogItemMetadataClient() method to return the read-write metadata client for CatalogItems (only).
