### PR TITLE
Issue #830 vcloud-director: fixes/tidy for live tests

### DIFF
--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/QueryClientLiveTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/QueryClientLiveTest.java
@@ -111,6 +111,16 @@ public class QueryClientLiveTest extends BaseVCloudDirectorClientLiveTest {
       vappClient = context.getApi().getVAppClient();
    }
 
+   @Test(testName = "GET /query")
+   public void testQuery() {
+      VAppTemplate vAppTemplate = vappTemplateClient.getVAppTemplate(vAppTemplateURI);
+      QueryResultRecords queryResult = queryClient.query("vAppTemplate", String.format("name==%s", vAppTemplate.getName()));
+      Set<URI> hrefs = toHrefs(queryResult);
+      
+      assertRecordTypes(queryResult, Arrays.asList(VCloudDirectorMediaType.VAPP_TEMPLATE, null), QueryResultVAppTemplateRecord.class);
+      assertTrue(hrefs.contains(vAppTemplateURI), "VAppTemplates query result should include vAppTemplate "+vAppTemplateURI+"; but only has "+hrefs);
+   }
+
    @Test(testName = "GET /catalogs/query")
    public void testQueryAllCatalogs() {
       QueryResultRecords catalogRecords = queryClient.catalogsQueryAll();

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/VAppTemplateClientLiveTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/VAppTemplateClientLiveTest.java
@@ -122,6 +122,20 @@ public class VAppTemplateClientLiveTest extends AbstractVAppClientLiveTest {
       checkProductSectionList(productSectionList);
    }
    
+   @Test
+   public void testEditProductSections() {
+      // TODO make a real modification
+      
+      ProductSectionList origSections = vAppTemplateClient.getProductSectionsForVAppTemplate(vApp.getHref());
+      ProductSectionList newSections = origSections.toBuilder().build();
+      
+      Task task = vAppTemplateClient.editProductSectionsForVAppTemplate(vApp.getHref(), newSections);
+      assertTaskSucceeds(task);
+
+      ProductSectionList modified = vAppTemplateClient.getProductSectionsForVAppTemplate(vApp.getHref());
+      checkProductSectionList(modified);
+   }
+   
    @Test(testName = "GET /vAppTemplate/{id}/guestCustomizationSection")
    public void testGetGuestCustomizationSection() {
       getGuestCustomizationSection(new Function<URI, GuestCustomizationSection>() {
@@ -130,13 +144,6 @@ public class VAppTemplateClientLiveTest extends AbstractVAppClientLiveTest {
             return vAppTemplateClient.getVAppTemplateGuestCustomizationSection(uri);
          }
       });
-   }
-   
-   @Test
-   public void testGetProductSectionsForVAppTemplate() {
-      ProductSectionList productSectionList = vAppTemplateClient.getProductSectionsForVAppTemplate(vAppTemplateURI);
-      
-      checkProductSectionList(productSectionList);
    }
    
    @Test
@@ -305,17 +312,17 @@ public class VAppTemplateClientLiveTest extends AbstractVAppClientLiveTest {
       assertEquals(newCustomizationSection.isCustomizeOnInstantiate(), newVal);
    }
 
+   // FIXME deploymentLeaseInSeconds returned is null
    @Test
    public void testEditLeaseSettingsSection() throws Exception {
-      // FIXME deploymentLeaseInSeconds returned is null
-      //int deploymentLeaseInSeconds = random.nextInt(10000)+1;
+      int deploymentLeaseInSeconds = random.nextInt(10000)+1;
       
       // Note: use smallish number for storageLeaseInSeconds; it seems to be capped at 5184000?
       int storageLeaseInSeconds = random.nextInt(10000)+1;
       LeaseSettingsSection leaseSettingSection = LeaseSettingsSection.builder()
                .info("my info")
                .storageLeaseInSeconds(storageLeaseInSeconds)
-               //.deploymentLeaseInSeconds(deploymentLeaseInSeconds)
+               .deploymentLeaseInSeconds(deploymentLeaseInSeconds)
                .build();
       
       final Task task = vAppTemplateClient.editVappTemplateLeaseSettingsSection(vAppTemplateURI, leaseSettingSection);
@@ -323,7 +330,7 @@ public class VAppTemplateClientLiveTest extends AbstractVAppClientLiveTest {
       
       LeaseSettingsSection newLeaseSettingsSection = vAppTemplateClient.getVappTemplateLeaseSettingsSection(vAppTemplateURI);
       assertEquals(newLeaseSettingsSection.getStorageLeaseInSeconds(), (Integer)storageLeaseInSeconds);
-      //assertEquals(newLeaseSettingsSection.getDeploymentLeaseInSeconds(), (Integer)deploymentLeaseInSeconds);
+      assertEquals(newLeaseSettingsSection.getDeploymentLeaseInSeconds(), (Integer)deploymentLeaseInSeconds);
    }
 
    @Test


### PR DESCRIPTION
Various fixes:
- Cleaned up AdminOrgClientLiveTest so testGetSettings can run even if other tests fail
- Test `GET /query`
- Test `PUT /vAppTemplate/{id}/productSections`
