### PR TITLE
CloudStack pom.xml needs to pass the globalAdminIdentity/Credential prop...

### DIFF
--- a/apis/cloudstack/pom.xml
+++ b/apis/cloudstack/pom.xml
@@ -55,6 +55,8 @@
     <test.cloudstack.credential>FIXME_secretKey</test.cloudstack.credential>
     <test.cloudstack.domainAdminIdentity></test.cloudstack.domainAdminIdentity>
     <test.cloudstack.domainAdminCredential></test.cloudstack.domainAdminCredential>
+    <test.cloudstack.globalAdminIdentity></test.cloudstack.globalAdminIdentity>
+    <test.cloudstack.globalAdminCredential></test.cloudstack.globalAdminCredential>
     <test.cloudstack.image-id></test.cloudstack.image-id>
     <test.cloudstack.image.login-user></test.cloudstack.image.login-user>
     <test.cloudstack.image.authenticate-sudo></test.cloudstack.image.authenticate-sudo>
@@ -126,6 +128,8 @@
                     <test.cloudstack.image.authenticate-sudo>${test.cloudstack.image.authenticate-sudo}</test.cloudstack.image.authenticate-sudo>
                     <test.cloudstack.domainAdminIdentity>${test.cloudstack.domainAdminIdentity}</test.cloudstack.domainAdminIdentity>
                     <test.cloudstack.domainAdminCredential>${test.cloudstack.domainAdminCredential}</test.cloudstack.domainAdminCredential>
+                    <test.cloudstack.globalAdminIdentity>${test.cloudstack.globalAdminIdentity}</test.cloudstack.globalAdminIdentity>
+                    <test.cloudstack.globalAdminCredential>${test.cloudstack.globalAdminCredential}</test.cloudstack.globalAdminCredential>
                   </systemPropertyVariables>
                 </configuration>
               </execution>


### PR DESCRIPTION
...erties to integration(live) tests, otherwise several tests will fail because they don't have global administrator access.
