### PR TITLE
Issue 886 - update regexps of EC2 AMIs to match newest Windows AMIs

### DIFF
--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/strategy/AWSEC2ReviseParsedImage.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/strategy/AWSEC2ReviseParsedImage.java
@@ -52,6 +52,10 @@ public class AWSEC2ReviseParsedImage implements ReviseParsedImage {
    // amazon/EC2 CentOS 5.4 HVM AMI
    public static final Pattern AMAZON_PATTERN = Pattern.compile("amazon/EC2 ([^ ]+) ([^ ]+).*");
 
+   // amazon/Windows_Server-2008-R2_SP1-English-64Bit-Base-2012.03.13
+   //        1111111        22222222222                    3333333333
+   public static final Pattern AMAZON_WINDOWS_PATTERN = Pattern.compile(".*/(Windows)_Server-([^-]*-[^-]*)-.*-([^-]*)(\\.manifest.xml)?");
+
    public static final Pattern CANONICAL_PATTERN = Pattern.compile(".*/([^-]*)-([^-]*)-.*-(.*)(\\.manifest.xml)?");
 
    // ex rightscale-us-east/CentOS_5.4_x64_v4.4.10.manifest.xml
@@ -106,8 +110,8 @@ public class AWSEC2ReviseParsedImage implements ReviseParsedImage {
     *            if no configured matcher matches the manifest.
     */
    private Matcher getMatcherAndFind(String manifest) {
-      for (Pattern pattern : new Pattern[] { AMZN_PATTERN, AMAZON_PATTERN, CANONICAL_PATTERN, RIGHTIMAGE_PATTERN,
-               RIGHTSCALE_PATTERN }) {
+      for (Pattern pattern : new Pattern[] { AMZN_PATTERN, AMAZON_PATTERN, AMAZON_WINDOWS_PATTERN, CANONICAL_PATTERN,
+              RIGHTIMAGE_PATTERN, RIGHTSCALE_PATTERN }) {
          Matcher matcher = pattern.matcher(manifest);
          if (matcher.find())
             return matcher;

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/strategy/AWSEC2ReviseParsedImageTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/strategy/AWSEC2ReviseParsedImageTest.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.aws.ec2.compute.strategy;
+
+import com.google.inject.Guice;
+import org.jclouds.compute.config.BaseComputeServiceContextModule;
+import org.jclouds.compute.domain.ImageBuilder;
+import org.jclouds.compute.domain.OperatingSystem;
+import org.jclouds.compute.domain.OsFamily;
+import org.jclouds.compute.reference.ComputeServiceConstants;
+import org.jclouds.ec2.compute.strategy.ReviseParsedImage;
+import org.jclouds.ec2.domain.Hypervisor;
+import org.jclouds.ec2.domain.Image;
+import org.jclouds.ec2.domain.RootDeviceType;
+import org.jclouds.ec2.domain.VirtualizationType;
+import org.jclouds.json.Json;
+import org.jclouds.json.config.GsonModule;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+
+public class AWSEC2ReviseParsedImageTest {
+    private Map<OsFamily, Map<String, String>> osVersionMap;
+
+    @BeforeClass
+    public void testFixtureSetUp() {
+        osVersionMap = new BaseComputeServiceContextModule() {
+        }.provideOsVersionMap(new ComputeServiceConstants.ReferenceData(), Guice.createInjector(new GsonModule())
+                .getInstance(Json.class));
+    }
+
+    @Test
+    public void testNewWindowsName() throws Exception {
+
+        ReviseParsedImage rpi = new AWSEC2ReviseParsedImage(osVersionMap);
+
+        Image from = newImage("amazon", "Windows_Server-2008-R2_SP1-English-64Bit-Base-2012.03.13");
+        OperatingSystem.Builder osBuilder = OperatingSystem.builder().description("test");
+        ImageBuilder builder = new ImageBuilder().id("1").operatingSystem(osBuilder.build()).description("test");
+        OsFamily family = OsFamily.WINDOWS;
+
+        rpi.reviseParsedImage(from, builder, family, osBuilder);
+        OperatingSystem os = osBuilder.build();
+        assertEquals(os.getFamily(), OsFamily.WINDOWS);
+        assertEquals(os.getVersion(), "2008");
+        assertEquals(builder.build().getVersion(), "2012.03.13");
+    }
+
+    @Test
+    public void testOldWindowsName() throws Exception {
+
+        ReviseParsedImage rpi = new AWSEC2ReviseParsedImage(osVersionMap);
+
+        Image from = newImage("amazon", "Windows-2008R2-SP1-English-Base-2012.01.12");
+        OperatingSystem.Builder osBuilder = OperatingSystem.builder().description("test");
+        ImageBuilder builder = new ImageBuilder().id("1").operatingSystem(osBuilder.build()).description("test");
+        OsFamily family = OsFamily.WINDOWS;
+
+        rpi.reviseParsedImage(from, builder, family, osBuilder);
+        OperatingSystem os = osBuilder.build();
+        assertEquals(os.getFamily(), OsFamily.WINDOWS);
+        assertEquals(os.getVersion(), "2008");
+        assertEquals(builder.build().getVersion(), "2012.01.12");
+    }
+
+    private static Image newImage(String imageOwnerId, String imageName) {
+        String region = "us-east-1";
+        Image.Architecture architecture = Image.Architecture.X86_64;
+        String description = "";
+        String imageId = "";
+        Image.ImageState imageState = Image.ImageState.AVAILABLE;
+        Image.ImageType imageType = Image.ImageType.MACHINE;
+        boolean isPublic = true;
+        Iterable<String> productCodes = Collections.emptySet();
+        String kernelId = "";
+        String platform = "";
+        String ramdiskId = "";
+        RootDeviceType rootDeviceType = RootDeviceType.EBS;
+        String rootDeviceName = "";
+        Map<String, Image.EbsBlockDevice> ebsBlockDevices = Collections.emptyMap();
+        VirtualizationType virtualizationType = VirtualizationType.HVM;
+        Hypervisor hypervisor = Hypervisor.XEN;
+        Image from = new Image(region, architecture, imageName, description, imageId, imageOwnerId + "/" + imageName, imageOwnerId, imageState, imageType, isPublic, productCodes, kernelId, platform, ramdiskId, rootDeviceType, rootDeviceName, ebsBlockDevices, virtualizationType, hypervisor);
+        return from;
+    }
+}


### PR DESCRIPTION
Add regexp that matches style of Windows AMI names in EC2 starting March 2012. Add a unit test.
