### PR TITLE
Issue 830: vCloud director Bugfix

### DIFF
--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/UserClientLiveTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/UserClientLiveTest.java
@@ -217,15 +217,7 @@ public class UserClientLiveTest extends BaseVCloudDirectorClientLiveTest {
          dependsOnMethods = { "testCreateUser" } )
    public void testDeleteUser() {
       // Create a user to be deleted (so we remove dependencies on test ordering)
-      String name = name("a");
-      User newUser = User.builder()
-         .name(name)
-         .role(Reference.builder() // FIXME: auto-fetch a role? or inject
-                  .name("vApp User")
-                  .href(URI.create("https://vcloudbeta.bluelock.com/api/admin/role/ff1e0c91-1288-3664-82b7-a6fa303af4d1"))
-                  .build())
-         .password("password")
-         .build();
+      User newUser = randomTestUser("testDeleteUser");
       User userToBeDeleted = userClient.createUser(orgRef.getHref(), newUser);
 
       // Delete the user

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/internal/BaseVCloudDirectorClientLiveTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/internal/BaseVCloudDirectorClientLiveTest.java
@@ -169,6 +169,7 @@ public abstract class BaseVCloudDirectorClientLiveTest extends BaseVersionedServ
       VCloudDirectorContext rootContext = VCloudDirectorContext.class.cast(
             new RestContextFactory().createContext(provider, identity, credential, ImmutableSet.<Module> of(
             new Log4JLoggingModule(), new SshjSshClientModule()), overrides));
+      adminContext = rootContext.getAdminContext();
       
       rootContext.utils().injector().injectMembers(this);
       Reference orgRef = Iterables.getFirst(rootContext.getApi().getOrgClient().getOrgList().getOrgs(), null)
@@ -215,7 +216,8 @@ public abstract class BaseVCloudDirectorClientLiveTest extends BaseVersionedServ
    
    public Reference getRoleReferenceFor(String name) {
       RoleReferences roles = adminContext.getApi().getQueryClient().roleReferencesQueryAll();
-      return Iterables.find(roles.getReferences(), ReferencePredicates.nameEquals(name));
+      // wrapped in a builder to strip out unwanted xml cruft that the api chokes on
+      return Reference.builder().fromReference(Iterables.find(roles.getReferences(), ReferencePredicates.nameEquals(name))).build();
    }
    
    public User randomTestUser(String prefix) {


### PR DESCRIPTION
fixed the user for deleteUser test and an NPE around the early population of adminContext in order to fetch a role reference (plus some sanitising of that reference)

apparently @grkvlt has made changes to exception handling that is either broken or hasn't merged properly. this seems to be causing the results formatter and a bunch of live tests to break
