### PR TITLE
fix Accept header in delete

### DIFF
--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v1_1/extensions/SecurityGroupAsyncClient.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v1_1/extensions/SecurityGroupAsyncClient.java
@@ -104,7 +104,7 @@ public interface SecurityGroupAsyncClient {
    @DELETE
    @Path("/os-security-groups/{id}")
    @ExceptionParser(ReturnNullOnNotFoundOr404.class)
-   @Consumes
+   @Consumes(MediaType.APPLICATION_JSON)
    ListenableFuture<Boolean> deleteSecurityGroup(@PathParam("id") String id);
 
    /**

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v1_1/extensions/SecurityGroupClientExpectTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v1_1/extensions/SecurityGroupClientExpectTest.java
@@ -142,7 +142,7 @@ public class SecurityGroupClientExpectTest extends BaseNovaClientExpectTest {
       HttpRequest deleteSecurityGroup = HttpRequest.builder().method("DELETE").endpoint(
                URI.create("https://compute.north.host/v1.1/3456/os-security-groups/160"))
                .headers(
-                        ImmutableMultimap.<String, String> builder().put("Accept", "*/*")
+                        ImmutableMultimap.<String, String> builder().put("Accept", "application/json")
                                  .put("X-Auth-Token", authToken).build()).build();
 
       HttpResponse deleteSecurityGroupResponse = HttpResponse.builder().statusCode(202).build();


### PR DESCRIPTION
Added MediaType.APPLICATION_JSON to @Consumes for the openstack-nova SecurityGroupAsyncClient.deleteSecurityGroup method.
