### PR TITLE
Issue 830: Minor updates

### DIFF
--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/EntityType.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/EntityType.java
@@ -114,7 +114,8 @@ public class EntityType extends ResourceType {
       
       public B fromEntityType(EntityType in) {
          return fromResourceType(in)
-               .description(in.getDescription()).tasks(in.getTasks())
+               .description(in.getDescription())
+               .tasks(in.getTasks())
                .id(in.getId()).name(in.getName());
       }
    }

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/AbstractVAppClientLiveTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/AbstractVAppClientLiveTest.java
@@ -33,7 +33,6 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.util.List;
 
-import org.jclouds.vcloud.director.v1_5.VCloudDirectorMediaType;
 import org.jclouds.vcloud.director.v1_5.domain.GuestCustomizationSection;
 import org.jclouds.vcloud.director.v1_5.domain.NetworkConnectionSection;
 import org.jclouds.vcloud.director.v1_5.domain.RasdItemsList;
@@ -55,7 +54,6 @@ import org.jclouds.vcloud.director.v1_5.features.QueryClient;
 import org.jclouds.vcloud.director.v1_5.features.VAppClient;
 import org.jclouds.vcloud.director.v1_5.features.VAppTemplateClient;
 import org.jclouds.vcloud.director.v1_5.features.VdcClient;
-import org.jclouds.vcloud.director.v1_5.features.MetadataClient.Writeable;
 import org.jclouds.vcloud.director.v1_5.internal.BaseVCloudDirectorClientLiveTest;
 import org.jclouds.vcloud.director.v1_5.predicates.ReferencePredicates;
 import org.jclouds.xml.internal.JAXBParser;
@@ -335,7 +333,6 @@ public abstract class AbstractVAppClientLiveTest extends BaseVCloudDirectorClien
       JAXBParser parser = new JAXBParser();
       try {
          String xml = parser.toXML(object);
-
          logger.debug(Strings.padStart(Strings.padEnd(" " + object.getClass().toString() + " ", 70, '-'), 80, '-'));
          logger.debug(xml);
          logger.debug(Strings.repeat("-", 80));

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/admin/AdminNetworkClientLiveTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/admin/AdminNetworkClientLiveTest.java
@@ -28,6 +28,8 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import java.util.Collections;
+
 import org.jclouds.vcloud.director.v1_5.domain.Checks;
 import org.jclouds.vcloud.director.v1_5.domain.ExternalNetwork;
 import org.jclouds.vcloud.director.v1_5.domain.IpScope;
@@ -94,9 +96,10 @@ public class AdminNetworkClientLiveTest extends BaseVCloudDirectorClientLiveTest
       //TODO: ensure network instanceof OrgNetwork, may require queries
       assertTrue(network instanceof OrgNetwork, String.format(REF_REQ_LIVE, "OrgNetwork"));
       
-      OrgNetwork oldNetwork = Network.<OrgNetwork>toSubType(network).toBuilder()
-         .tasks(null)
-         .build();
+      OrgNetwork oldNetwork = Network.<OrgNetwork>toSubType(network)
+            .toBuilder()
+            .tasks(Collections.<Task>emptySet())
+            .build();
       
       OrgNetwork updateNetwork = getMutatedOrgNetwork(oldNetwork);
       
@@ -159,8 +162,8 @@ public class AdminNetworkClientLiveTest extends BaseVCloudDirectorClientLiveTest
    
    private static OrgNetwork getMutatedOrgNetwork(OrgNetwork network) {
        OrgNetwork.Builder<?> networkBuilder = OrgNetwork.builder().fromNetwork(network)
-          .tasks(null)
-//          .name("new "+network.getName())
+             .tasks(Collections.<Task>emptySet())
+//           .name("new "+network.getName())
           .description("new "+network.getDescription())
           .configuration(getMutatedNetworkConfiguration(network.getConfiguration()));
        

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/admin/GroupClientExpectTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/admin/GroupClientExpectTest.java
@@ -26,7 +26,6 @@ import org.jclouds.vcloud.director.v1_5.VCloudDirectorMediaType;
 import org.jclouds.vcloud.director.v1_5.admin.VCloudDirectorAdminClient;
 import org.jclouds.vcloud.director.v1_5.domain.Group;
 import org.jclouds.vcloud.director.v1_5.domain.Reference;
-import org.jclouds.vcloud.director.v1_5.features.admin.GroupClient;
 import org.jclouds.vcloud.director.v1_5.internal.VCloudDirectorAdminClientExpectTest;
 import org.testng.annotations.Test;
 

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/admin/UserClientExpectTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/admin/UserClientExpectTest.java
@@ -29,7 +29,6 @@ import org.jclouds.vcloud.director.v1_5.admin.VCloudDirectorAdminClient;
 import org.jclouds.vcloud.director.v1_5.domain.Link;
 import org.jclouds.vcloud.director.v1_5.domain.Reference;
 import org.jclouds.vcloud.director.v1_5.domain.User;
-import org.jclouds.vcloud.director.v1_5.features.admin.UserClient;
 import org.jclouds.vcloud.director.v1_5.internal.VCloudDirectorAdminClientExpectTest;
 import org.testng.annotations.Test;
 


### PR DESCRIPTION
Changed `.tasks(null)` to `.tasks(Collections.<Task>emptySet())` to prevent precondition error in tests
