### PR TITLE
Fix to support creating new compute nodes using Essex OpenStack through the compute service

### DIFF
--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v1_1/compute/NovaComputeServiceAdapter.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v1_1/compute/NovaComputeServiceAdapter.java
@@ -119,7 +119,12 @@ public class NovaComputeServiceAdapter implements
       String flavorId = template.getHardware().getProviderId();
 
       logger.debug(">> creating new server zone(%s) name(%s) image(%s) flavor(%s) options(%s)", zoneId, name, imageId, flavorId, options);
-      Server server = novaClient.getServerClientForZone(zoneId).createServer(name, imageId, flavorId, options);
+      Server lightweightServer = novaClient.getServerClientForZone(zoneId).createServer(name, imageId, flavorId, options);
+      Server heavyweightServer = novaClient.getServerClientForZone(zoneId).getServer(lightweightServer.getId());
+      Server server = Server.builder().fromServer(heavyweightServer)
+                                      .adminPass(lightweightServer.getAdminPass())
+                                      .build();
+
       logger.trace("<< server(%s)", server.getId());
 
       ServerInZone serverInZone = new ServerInZone(server, zoneId);

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v1_1/compute/NovaComputeServiceAdapterExpectTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v1_1/compute/NovaComputeServiceAdapterExpectTest.java
@@ -66,17 +66,27 @@ public class NovaComputeServiceAdapterExpectTest extends BaseNovaComputeServiceC
                   "{\"server\":{\"name\":\"test-e92\",\"imageRef\":\"1241\",\"flavorRef\":\"100\",\"security_groups\":[{\"name\":\"group2\"},{\"name\":\"group1\"}]}}","application/json"))
          .build();
 
-  
       HttpResponse createServerResponse = HttpResponse.builder().statusCode(202).message("HTTP/1.1 202 Accepted")
          .payload(payloadFromResourceWithContentType("/new_server.json","application/json; charset=UTF-8")).build();
 
-         
+      HttpRequest serverDetail = HttpRequest
+            .builder()
+            .method("GET")
+            .endpoint(URI.create("https://compute.north.host/v1.1/3456/servers/71752"))
+            .headers(
+                  ImmutableMultimap.<String, String> builder().put("Accept", "application/json")
+                        .put("X-Auth-Token", authToken).build()).build();
+
+      HttpResponse serverDetailResponse = HttpResponse.builder().statusCode(200)
+            .payload(payloadFromResource("/server_details.json")).build();
+
       Map<HttpRequest, HttpResponse> requestResponseMap = ImmutableMap.<HttpRequest, HttpResponse> builder()
                .put(keystoneAuthWithUsernameAndPassword, responseWithKeystoneAccess)
                .put(extensionsOfNovaRequest, extensionsOfNovaResponse)
                .put(listImagesDetail, listImagesDetailResponse)
                .put(listFlavorsDetail, listFlavorsDetailResponse)
-               .put(createServer, createServerResponse).build();
+               .put(createServer, createServerResponse)
+               .put(serverDetail, serverDetailResponse).build();
 
       Injector forSecurityGroups = requestsSendResponses(requestResponseMap);
 
@@ -113,13 +123,24 @@ public class NovaComputeServiceAdapterExpectTest extends BaseNovaComputeServiceC
       HttpResponse createServerResponse = HttpResponse.builder().statusCode(202).message("HTTP/1.1 202 Accepted")
          .payload(payloadFromResourceWithContentType("/new_server.json","application/json; charset=UTF-8")).build();
 
-         
+      HttpRequest serverDetail = HttpRequest
+            .builder()
+            .method("GET")
+            .endpoint(URI.create("https://compute.north.host/v1.1/3456/servers/71752"))
+            .headers(
+                  ImmutableMultimap.<String, String> builder().put("Accept", "application/json")
+                        .put("X-Auth-Token", authToken).build()).build();
+
+      HttpResponse serverDetailResponse = HttpResponse.builder().statusCode(200)
+            .payload(payloadFromResource("/server_details.json")).build();
+
       Map<HttpRequest, HttpResponse> requestResponseMap = ImmutableMap.<HttpRequest, HttpResponse> builder()
                .put(keystoneAuthWithUsernameAndPassword, responseWithKeystoneAccess)
                .put(extensionsOfNovaRequest, extensionsOfNovaResponse)
                .put(listImagesDetail, listImagesDetailResponse)
                .put(listFlavorsDetail, listFlavorsDetailResponse)
-               .put(createServer, createServerResponse).build();
+               .put(createServer, createServerResponse)
+               .put(serverDetail, serverDetailResponse).build();
 
       Injector forSecurityGroups = requestsSendResponses(requestResponseMap);
 

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v1_1/compute/NovaComputeServiceExpectTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v1_1/compute/NovaComputeServiceExpectTest.java
@@ -204,6 +204,17 @@ public class NovaComputeServiceExpectTest extends BaseNovaComputeServiceExpectTe
    HttpResponse keyPairWithPrivateKey = HttpResponse.builder().statusCode(200)
          .payload(payloadFromResource("/keypair_created_computeservice.json")).build();
 
+   HttpRequest serverDetail = HttpRequest
+         .builder()
+         .method("GET")
+         .endpoint(URI.create("https://nova-api.trystack.org:9774/v1.1/3456/servers/71752"))
+         .headers(
+               ImmutableMultimap.<String, String> builder().put("Accept", "application/json")
+                     .put("X-Auth-Token", authToken).build()).build();
+
+   HttpResponse serverDetailResponse = HttpResponse.builder().statusCode(200)
+         .payload(payloadFromResource("/server_details.json")).build();
+
    @Test
    public void testCreateNodeWithGeneratedKeyPair() throws Exception {
       Builder<HttpRequest, HttpResponse> requestResponseMap = ImmutableMap.<HttpRequest, HttpResponse> builder()
@@ -217,6 +228,8 @@ public class NovaComputeServiceExpectTest extends BaseNovaComputeServiceExpectTe
       requestResponseMap.put(getSecurityGroup, securityGroupWithPort22);
 
       requestResponseMap.put(createKeyPair, keyPairWithPrivateKey);
+
+      requestResponseMap.put(serverDetail, serverDetailResponse);
 
       HttpRequest createServerWithGeneratedKeyPair = HttpRequest
             .builder()
@@ -270,6 +283,8 @@ public class NovaComputeServiceExpectTest extends BaseNovaComputeServiceExpectTe
       requestResponseMap.put(createSecurityGroupRuleForDefaultPort22, securityGroupRuleCreated);
 
       requestResponseMap.put(getSecurityGroup, securityGroupWithPort22);
+
+      requestResponseMap.put(serverDetail, serverDetailResponse);
 
       HttpRequest createServerWithSuppliedKeyPair = HttpRequest
             .builder()


### PR DESCRIPTION
...the NovaComputeServiceAdapter in Openstack-nova
