### PR TITLE
Pretty print in payload is now configurable

### DIFF
--- a/compute/src/main/java/org/jclouds/compute/internal/UtilsImpl.java
+++ b/compute/src/main/java/org/jclouds/compute/internal/UtilsImpl.java
@@ -34,6 +34,7 @@ import org.jclouds.rest.HttpAsyncClient;
 import org.jclouds.rest.HttpClient;
 import org.jclouds.ssh.SshClient;
 import org.jclouds.ssh.SshClient.Factory;
+import org.jclouds.xml.XMLParser;
 
 import com.google.common.base.Function;
 import com.google.common.eventbus.EventBus;
@@ -51,11 +52,11 @@ public class UtilsImpl extends org.jclouds.rest.internal.UtilsImpl implements Ut
    private final Function<NodeMetadata, SshClient> sshForNode;
 
    @Inject
-   UtilsImpl(Injector injector, Json json, HttpClient simpleClient, HttpAsyncClient simpleAsyncClient,
+   UtilsImpl(Injector injector, Json json, XMLParser xml, HttpClient simpleClient, HttpAsyncClient simpleAsyncClient,
          Crypto encryption, DateService date, @Named(Constants.PROPERTY_USER_THREADS) ExecutorService userThreads,
          @Named(Constants.PROPERTY_IO_WORKER_THREADS) ExecutorService ioThreads, EventBus eventBus,
          LoggerFactory loggerFactory, Function<NodeMetadata, SshClient> sshForNode) {
-      super(injector, json, simpleClient, simpleAsyncClient, encryption, date, userThreads, ioThreads, eventBus,
+      super(injector, json, xml, simpleClient, simpleAsyncClient, encryption, date, userThreads, ioThreads, eventBus,
             loggerFactory);
       this.sshForNode = sshForNode;
    }

--- a/core/src/main/java/org/jclouds/Constants.java
+++ b/core/src/main/java/org/jclouds/Constants.java
@@ -259,5 +259,12 @@ public interface Constants {
     * </code>
     */
    public static final String PROPERTY_TIMEOUTS_PREFIX = "jclouds.timeouts.";
+   
+   /**
+    * Boolean property. Default (true).
+    * <p/>
+    * Configures the response parsers to pretty print the payload when possible. 
+    */
+   public static final String PROPERTY_PRETTY_PRINT_PAYLOADS = "jclouds.payloads.pretty-print";
 
 }

--- a/core/src/main/java/org/jclouds/PropertiesBuilder.java
+++ b/core/src/main/java/org/jclouds/PropertiesBuilder.java
@@ -45,6 +45,7 @@ import static org.jclouds.Constants.PROPERTY_SESSION_INTERVAL;
 import static org.jclouds.Constants.PROPERTY_SO_TIMEOUT;
 import static org.jclouds.Constants.PROPERTY_TRUST_ALL_CERTS;
 import static org.jclouds.Constants.PROPERTY_USER_THREADS;
+import static org.jclouds.Constants.PROPERTY_PRETTY_PRINT_PAYLOADS;
 
 import java.util.Properties;
 
@@ -204,6 +205,14 @@ public class PropertiesBuilder {
       properties.setProperty(PROPERTY_MAX_CONNECTIONS_PER_HOST, Integer.toString(connectionLimit));
       return this;
    }
+   
+   /**
+    * @see org.jclouds.Constants.PROPERTY_PRETTY_PRINT_PAYLOADS
+    */
+   public PropertiesBuilder prettyPrintPayloads(boolean prettyPrintPayloads) {
+      properties.setProperty(PROPERTY_PRETTY_PRINT_PAYLOADS, Boolean.toString(prettyPrintPayloads));
+      return this;
+   }
 
    protected final Properties properties;
 
@@ -226,6 +235,7 @@ public class PropertiesBuilder {
       props.setProperty(PROPERTY_MAX_CONNECTION_REUSE, 75 + "");
       props.setProperty(PROPERTY_MAX_SESSION_FAILURES, 2 + "");
       props.setProperty(PROPERTY_SESSION_INTERVAL, 60 + "");
+      props.setProperty(PROPERTY_PRETTY_PRINT_PAYLOADS, "true");
       return props;
    }
 

--- a/core/src/main/java/org/jclouds/rest/Utils.java
+++ b/core/src/main/java/org/jclouds/rest/Utils.java
@@ -25,6 +25,7 @@ import org.jclouds.date.DateService;
 import org.jclouds.json.Json;
 import org.jclouds.logging.Logger.LoggerFactory;
 import org.jclouds.rest.internal.UtilsImpl;
+import org.jclouds.xml.XMLParser;
 
 import com.google.common.annotations.Beta;
 import com.google.common.eventbus.EventBus;
@@ -110,5 +111,12 @@ public interface Utils {
     */
    @Beta
    Injector injector();
+   
+   XMLParser getXml();
+
+   /**
+    * #see #getXml
+    */
+   XMLParser xml();
 
 }

--- a/core/src/main/java/org/jclouds/rest/internal/UtilsImpl.java
+++ b/core/src/main/java/org/jclouds/rest/internal/UtilsImpl.java
@@ -31,6 +31,7 @@ import org.jclouds.logging.Logger.LoggerFactory;
 import org.jclouds.rest.HttpAsyncClient;
 import org.jclouds.rest.HttpClient;
 import org.jclouds.rest.Utils;
+import org.jclouds.xml.XMLParser;
 
 import com.google.common.annotations.Beta;
 import com.google.common.eventbus.EventBus;
@@ -53,9 +54,10 @@ public class UtilsImpl implements Utils {
    private final EventBus eventBus;
    private final LoggerFactory loggerFactory;
    private Injector injector;
+   private XMLParser xml;
 
    @Inject
-   protected UtilsImpl(Injector injector, Json json, HttpClient simpleClient, HttpAsyncClient simpleAsyncClient,
+   protected UtilsImpl(Injector injector, Json json, XMLParser xml, HttpClient simpleClient, HttpAsyncClient simpleAsyncClient,
          Crypto encryption, DateService date, @Named(Constants.PROPERTY_USER_THREADS) ExecutorService userThreads,
          @Named(Constants.PROPERTY_IO_WORKER_THREADS) ExecutorService ioThreads, EventBus eventBus,
          LoggerFactory loggerFactory) {
@@ -69,6 +71,7 @@ public class UtilsImpl implements Utils {
       this.ioExecutor = ioThreads;
       this.eventBus = eventBus;
       this.loggerFactory = loggerFactory;
+      this.xml = xml;
    }
 
    @Override
@@ -171,6 +174,16 @@ public class UtilsImpl implements Utils {
    @Beta
    public Injector injector() {
       return getInjector();
+   }
+   
+   @Override
+   public XMLParser getXml() {
+      return xml;
+   }
+
+   @Override
+   public XMLParser xml() {
+      return xml;
    }
 
 }

--- a/core/src/main/java/org/jclouds/xml/internal/JAXBParser.java
+++ b/core/src/main/java/org/jclouds/xml/internal/JAXBParser.java
@@ -22,14 +22,18 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 
+import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 
+import org.jclouds.Constants;
 import org.jclouds.http.functions.ParseXMLWithJAXB;
 import org.jclouds.xml.XMLParser;
+
+import com.google.inject.name.Named;
 
 /**
  * Parses XML documents using JAXB.
@@ -39,6 +43,16 @@ import org.jclouds.xml.XMLParser;
  */
 @Singleton
 public class JAXBParser implements XMLParser {
+    
+   /** Boolean indicating if the output must be pretty printed. */
+   private Boolean prettyPrint;
+   
+   @Inject
+   public JAXBParser(@Named(Constants.PROPERTY_PRETTY_PRINT_PAYLOADS) String prettyPrint) {
+       super();
+       this.prettyPrint = Boolean.valueOf(prettyPrint);
+   }
+
    @Override
    public String toXML(final Object src) throws IOException {
       return toXML(src, src.getClass());
@@ -49,7 +63,7 @@ public class JAXBParser implements XMLParser {
       try {
          JAXBContext context = JAXBContext.newInstance(type);
          Marshaller marshaller = context.createMarshaller();
-         marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+         marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, prettyPrint);
          StringWriter writer = new StringWriter();
          marshaller.marshal(src, writer);
          return writer.toString();
@@ -58,6 +72,7 @@ public class JAXBParser implements XMLParser {
       }
    }
 
+   @SuppressWarnings("unchecked")
    @Override
    public <T> T fromXML(final String xml, final Class<T> type) throws IOException {
       try {

--- a/core/src/test/java/org/jclouds/rest/binders/BindToXMLPayloadTest.java
+++ b/core/src/test/java/org/jclouds/rest/binders/BindToXMLPayloadTest.java
@@ -40,7 +40,7 @@ import com.google.common.collect.Multimap;
  */
 @Test(groups = "unit", testName = "BindToXMLPayloadTest")
 public class BindToXMLPayloadTest {
-   XMLParser xml = new JAXBParser();
+   XMLParser xml = new JAXBParser("true");
 
    @Test
    public void testBindJAXBObject() throws SecurityException, NoSuchMethodException {

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/NonClientOperationsLiveTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/NonClientOperationsLiveTest.java
@@ -45,77 +45,93 @@ import com.google.common.collect.Iterables;
  * 
  * @author danikov
  */
-@Test(groups = { "live", "user", "nonClient" }, singleThreaded = true, testName = "NonClientOperationsLiveTest")
-public class NonClientOperationsLiveTest extends BaseVCloudDirectorClientLiveTest {
-   
-   private JAXBParser parser = new JAXBParser();
-   private SessionWithToken sessionWithToken;
+@Test(groups = {"live", "user", "nonClient"}, singleThreaded = true, testName = "NonClientOperationsLiveTest")
+public class NonClientOperationsLiveTest extends BaseVCloudDirectorClientLiveTest
+{
 
-   @Override
-   protected void setupRequiredClients() throws Exception {
-      setupCredentials();
-   }
-   
-   @Test(testName = "POST /login")
-   public void testPostLogin() throws IOException {
-      testLoginWithMethod("POST");
-   }
-   
-   @Test(testName = "GET /login")
-   public void testGetLogin() throws IOException {
-      testLoginWithMethod("GET");
-   }
-   
-   private void testLoginWithMethod(String method) throws IOException {
-      String user = identity.substring(0, identity.lastIndexOf('@'));
-      String org = identity.substring(identity.lastIndexOf('@') + 1);
-      String password = credential;
-      
-      String authHeader = "Basic " + CryptoStreams.base64(String.format("%s@%s:%s", 
-                  checkNotNull(user),
-                  checkNotNull(org),
-                  checkNotNull(password)).getBytes("UTF-8"));
-      
-      HttpResponse response = context.getUtils().getHttpClient().invoke(HttpRequest.builder()
-         .method(method)
-         .endpoint(URI.create(endpoint+"/login"))
-         .headers(ImmutableMultimap.of(
-            "Authorization", authHeader,
-            "Accept", "*/*"))
-         .build());
-      
-      sessionWithToken = SessionWithToken.builder()
-         .session(session)
-         .token(response.getFirstHeaderOrNull("x-vcloud-authorization"))
-      .build();
-      
-      assertEquals(sessionWithToken.getSession().getUser(), user);
-      assertEquals(sessionWithToken.getSession().getOrg(), org);
-      assertTrue(sessionWithToken.getSession().getLinks().size() > 0);
-      assertNotNull(sessionWithToken.getToken());
-      
-      OrgList orgList = parser.fromXML(
-            Strings2.toStringAndClose(response.getPayload().getInput()), OrgList.class);
-      
-      assertTrue(orgList.getOrgs().size() > 0, "must have orgs");
-      
-      context.getApi().getOrgClient().getOrg(Iterables.getLast(orgList.getOrgs()).getHref());
-   }
-   
-   @Test(testName = "GET /schema/{schemaFileName}", 
-         dependsOnMethods = {"testPostLogin", "testGetLogin"} )
-   public void testGetSchema() throws IOException {
-      String schemafileName = "master.xsd";
-      HttpResponse response = context.getUtils().getHttpClient().invoke(HttpRequest.builder()
-         .method("GET")
-         .endpoint(URI.create(endpoint+"/v1.5/schema/"+schemafileName))
-         .headers(ImmutableMultimap.of(
-            "x-vcloud-authorization", sessionWithToken.getToken(),
-            "Accept", "*/*"))
-         .build());
-      
-      String schema = Strings2.toStringAndClose(response.getPayload().getInput());
-      
-      // TODO: asserting something about the schema
-   }
+    private JAXBParser parser = new JAXBParser("true");
+
+    private SessionWithToken sessionWithToken;
+
+    @Override
+    protected void setupRequiredClients() throws Exception
+    {
+        setupCredentials();
+    }
+
+    @Test(testName = "POST /login")
+    public void testPostLogin() throws IOException
+    {
+        testLoginWithMethod("POST");
+    }
+
+    @Test(testName = "GET /login")
+    public void testGetLogin() throws IOException
+    {
+        testLoginWithMethod("GET");
+    }
+
+    private void testLoginWithMethod(final String method) throws IOException
+    {
+        String user = identity.substring(0, identity.lastIndexOf('@'));
+        String org = identity.substring(identity.lastIndexOf('@') + 1);
+        String password = credential;
+
+        String authHeader =
+            "Basic "
+                + CryptoStreams.base64(String.format("%s@%s:%s", checkNotNull(user),
+                    checkNotNull(org), checkNotNull(password)).getBytes("UTF-8"));
+
+        HttpResponse response =
+            context
+                .getUtils()
+                .getHttpClient()
+                .invoke(
+                    HttpRequest
+                        .builder()
+                        .method(method)
+                        .endpoint(URI.create(endpoint + "/login"))
+                        .headers(ImmutableMultimap.of("Authorization", authHeader, "Accept", "*/*"))
+                        .build());
+
+        sessionWithToken =
+            SessionWithToken.builder().session(session)
+                .token(response.getFirstHeaderOrNull("x-vcloud-authorization")).build();
+
+        assertEquals(sessionWithToken.getSession().getUser(), user);
+        assertEquals(sessionWithToken.getSession().getOrg(), org);
+        assertTrue(sessionWithToken.getSession().getLinks().size() > 0);
+        assertNotNull(sessionWithToken.getToken());
+
+        OrgList orgList =
+            parser.fromXML(Strings2.toStringAndClose(response.getPayload().getInput()),
+                OrgList.class);
+
+        assertTrue(orgList.getOrgs().size() > 0, "must have orgs");
+
+        context.getApi().getOrgClient().getOrg(Iterables.getLast(orgList.getOrgs()).getHref());
+    }
+
+    @Test(testName = "GET /schema/{schemaFileName}", dependsOnMethods = {"testPostLogin",
+    "testGetLogin"})
+    public void testGetSchema() throws IOException
+    {
+        String schemafileName = "master.xsd";
+        HttpResponse response =
+            context
+                .getUtils()
+                .getHttpClient()
+                .invoke(
+                    HttpRequest
+                        .builder()
+                        .method("GET")
+                        .endpoint(URI.create(endpoint + "/v1.5/schema/" + schemafileName))
+                        .headers(
+                            ImmutableMultimap.of("x-vcloud-authorization",
+                                sessionWithToken.getToken(), "Accept", "*/*")).build());
+
+        String schema = Strings2.toStringAndClose(response.getPayload().getInput());
+
+        // TODO: asserting something about the schema
+    }
 }


### PR DESCRIPTION
Pretty printing the xml payload is good for logging purposes, but can easily introduce errors in unit tests that check the payload string.
Making the payload pretty formatting configurable can avoid this.
