### PR TITLE
Issue 830: Fixes for vCloud live tests

### DIFF
--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/ControlAccessParams.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/ControlAccessParams.java
@@ -129,8 +129,9 @@ public class ControlAccessParams {
 
    public ControlAccessParams(Boolean sharedToEveryone, String everyoneAccessLevel, Iterable<AccessSetting> accessSettings) {
       this.sharedToEveryone = sharedToEveryone;
-      this.everyoneAccessLevel = everyoneAccessLevel;
       if (sharedToEveryone) {
+	      this.everyoneAccessLevel = checkNotNull(everyoneAccessLevel, "everyoneAccessLevel");
+      } else {
          checkNotNull(accessSettings, "accessSettings");
       }
       this.accessSettings = Iterables.isEmpty(accessSettings) ? null : ImmutableList.copyOf(accessSettings);

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/EntityType.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/EntityType.java
@@ -21,7 +21,7 @@ package org.jclouds.vcloud.director.v1_5.domain;
 import static com.google.common.base.Objects.equal;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.Set;
+import java.util.List;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
@@ -30,8 +30,8 @@ import javax.xml.bind.annotation.XmlType;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 /**
  * Basic entity type in the vCloud object model.
@@ -63,7 +63,7 @@ public class EntityType extends ResourceType {
    public static abstract class Builder<B extends Builder<B>> extends ResourceType.Builder<B> {
       
       private String description;
-      private Set<Task> tasks = Sets.newLinkedHashSet();
+      private List<Task> tasks = Lists.newArrayList();
       private String name;
       private String id;
 
@@ -95,7 +95,7 @@ public class EntityType extends ResourceType {
        * @see EntityType#getTasks()
        */
       public B tasks(Iterable<Task> tasks) {
-         this.tasks = Sets.newLinkedHashSet(checkNotNull(tasks, "tasks"));
+         this.tasks = Lists.newArrayList(checkNotNull(tasks, "tasks"));
          return self();
       }
 
@@ -124,7 +124,7 @@ public class EntityType extends ResourceType {
    private String description;
    @XmlElementWrapper(name = "Tasks")
    @XmlElement(name = "Task")
-   private Set<Task> tasks;
+   private List<Task> tasks;
    @XmlAttribute
    private String id;
    @XmlAttribute(required = true)
@@ -133,7 +133,7 @@ public class EntityType extends ResourceType {
    protected EntityType(Builder<?> builder) {
       super(builder);
       this.description = builder.description;
-      this.tasks = builder.tasks == null || builder.tasks.isEmpty() ? null : ImmutableSet.copyOf(builder.tasks);
+      this.tasks = builder.tasks == null || builder.tasks.isEmpty() ? null : ImmutableList.copyOf(builder.tasks);
       this.id = builder.id;
       this.name = builder.name;
    }
@@ -156,8 +156,8 @@ public class EntityType extends ResourceType {
    /**
     * A list of queued, running, or recently completed tasks associated with this entity.
     */
-   public Set<Task> getTasks() {
-      return tasks == null ? ImmutableSet.<Task>of() : ImmutableSet.copyOf(tasks);
+   public List<Task> getTasks() {
+      return tasks == null ? ImmutableList.<Task>of() : ImmutableList.copyOf(tasks);
    }
 
    /**

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/Link.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/Link.java
@@ -69,6 +69,7 @@ public class Link extends Reference {
       @XmlEnumValue("download:default") DOWNLOAD_DEFAULT("download:default"),
       @XmlEnumValue("edit") EDIT("edit"),
       @XmlEnumValue("enable") ENABLE("enable"),
+      @XmlEnumValue("entityResolver") ENTITY_RESOLVER("entityResolver"),
       @XmlEnumValue("firstPage") FIRST_PAGE("firstPage"),
       @XmlEnumValue("installVmwareTools") INSTALL_VMWARE_TOOLS("installVmwareTools"),
       @XmlEnumValue("lastPage") LAST_PAGE("lastPage"),
@@ -115,7 +116,7 @@ public class Link extends Reference {
             ADD, ALTERNATE, CATALOG_ITEM, COLLABORATION_ABORT,
             COLLABORATION_FAIL, COLLABORATION_RESUME, CONSOLIDATE,
             CONTROL_ACCESS, COPY, DEPLOY, DISABLE, DISCARD_STATE, DOWN,
-            DOWNLOAD_ALTERNATE, DOWNLOAD_DEFAULT, EDIT, ENABLE, FIRST_PAGE,
+            DOWNLOAD_ALTERNATE, DOWNLOAD_DEFAULT, EDIT, ENABLE, ENTITY_RESOLVER, FIRST_PAGE,
             INSTALL_VMWARE_TOOLS, LAST_PAGE, EJECT_MEDIA, INSERT_MEDIA, MOVE,
             NEXT_PAGE, OVA, OVF, POWER_OFF, POWER_ON, REBOOT, RESET, SHUTDOWN,
             SUSPEND, PREVIOUS_PAGE, PUBLISH, RECOMPOSE, RECONNECT, REGISTER,
@@ -163,12 +164,20 @@ public class Link extends Reference {
    
    public static class Builder<B extends Builder<B>> extends Reference.Builder<B> {
 
-      private String rel;
+      private Rel rel;
 
       /**
        * @see Link#getRel()
        */
       public B rel(String rel) {
+         this.rel = Rel.fromValue(rel);
+         return self();
+      }
+
+      /**
+       * @see Link#getRel()
+       */
+      public B rel(Rel rel) {
          this.rel = rel;
          return self();
       }
@@ -194,7 +203,7 @@ public class Link extends Reference {
    }
 
    @XmlAttribute(required = true)
-   private String rel;
+   private Rel rel;
 
    protected Link(Builder<?> builder) {
       super(builder);
@@ -213,7 +222,7 @@ public class Link extends Reference {
     *
     * @return relationship of the link to the object that contains it.
     */
-   public String getRel() {
+   public Rel getRel() {
       return rel;
    }
 

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/OrgLdapSettings.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/OrgLdapSettings.java
@@ -110,15 +110,23 @@ public class OrgLdapSettings extends ResourceType {
    
    public static abstract class Builder<B extends Builder<B>> extends ResourceType.Builder<B> {
       
-      private String ldapMode;
+      private LdapMode ldapMode;
       private String customUsersOu;
       private CustomOrgLdapSettings customOrgLdapSettings;
 
       /**
        * @see OrgLdapSettings#getLdapMode()
        */
-      public B ldapMode(String ldapMode) {
+      public B ldapMode(LdapMode ldapMode) {
          this.ldapMode = ldapMode;
+         return self();
+      }
+
+      /**
+       * @see OrgLdapSettings#getLdapMode()
+       */
+      public B ldapMode(String ldapMode) {
+         this.ldapMode = LdapMode.fromValue(ldapMode);
          return self();
       }
 
@@ -162,8 +170,8 @@ public class OrgLdapSettings extends ResourceType {
       this.customOrgLdapSettings = builder.customOrgLdapSettings;
    }
 
-   @XmlElement(name = "OrgLdapMode")
-    private String ldapMode;
+    @XmlElement(name = "OrgLdapMode")
+    private LdapMode ldapMode;
     @XmlElement(name = "CustomUsersOu")
     private String customUsersOu;
     @XmlElement(name = "CustomOrgLdapSettings")
@@ -171,23 +179,13 @@ public class OrgLdapSettings extends ResourceType {
 
     /**
      * Gets the value of the orgLdapMode property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
      */
-    public String getLdapMode() {
+    public LdapMode getLdapMode() {
         return ldapMode;
     }
 
     /**
      * Gets the value of the customUsersOu property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
      */
     public String getCustomUsersOu() {
         return customUsersOu;
@@ -195,11 +193,6 @@ public class OrgLdapSettings extends ResourceType {
 
     /**
      * Gets the value of the customOrgLdapSettings property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link CustomOrgLdapSettings }
-     *     
      */
     public CustomOrgLdapSettings getCustomOrgLdapSettings() {
         return customOrgLdapSettings;

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/ResourceEntityType.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/ResourceEntityType.java
@@ -27,6 +27,8 @@ import java.util.Set;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
 import javax.xml.bind.annotation.XmlType;
 
 import com.google.common.base.Objects;
@@ -49,27 +51,30 @@ import com.google.common.collect.Iterables;
 @XmlType(name = "ResourceEntityType")
 public abstract class ResourceEntityType extends EntityType {
 
+   @XmlType
+   @XmlEnum(Integer.class)
    public static enum Status {
       
-      FAILED_CREATION(-1, "The object could not be created.", true, true, true),
-      NOT_READY(0, "Not ready", true, false, false), // TODO duplicate code, but mentioned in `POST /vdc/{id}/action/uploadVAppTemplate`
-      UNRESOLVED(0, "The object is unresolved.", true, true, true),
-      RESOLVED(1, "The object is resolved.", true, true, true),
-      DEPLOYED(2, "The object is deployed.", false, false, false),
-      SUSPENDED(3, "The object is suspended.", false, true, true),
-      POWERED_ON(4, "The object is powered on.", false, true, true),
-      WAITING_FOR_INPUT(5, "The object is waiting for user input.", false, true, true),
-      UNKNOWN(6, "The object is in an unknown state.", true, true, true),
-      UNRECOGNIZED(7, "The object is in an unrecognized state.", true, true, true),
-      POWERED_OFF(8, "The object is powered off.", true, true, true),
-      INCONSISTENT_STATE(9, "The object is in an inconsistent state.", false, true, true),
-      MIXED(10, "Children do not all have the same status.", true, true, false),
-      UPLOAD_OVF_PENDING(11, "Upload initiated, OVF descriptor pending.", true, false, false),
-      UPLOAD_COPYING(12, "Upload initiated, copying contents.", true, false, false),
-      UPLOAD_DISK_PENDING(13, "Upload initiated , disk contents pending.", true, false, false),
-      UPLOAD_QUARANTINED(14, "Upload has been quarantined.", true, false, false),
-      UPLOAD_QUARANTINE_EXPIRED(15, "Upload quarantine period has expired.", true, false, false),
+      @XmlEnumValue("-1") FAILED_CREATION(-1, "The object could not be created.", true, true, true),
+      @XmlEnumValue("0") UNRESOLVED(0, "The object is unresolved.", true, true, true),
+      @XmlEnumValue("1") RESOLVED(1, "The object is resolved.", true, true, true),
+      @XmlEnumValue("2") DEPLOYED(2, "The object is deployed.", false, false, false),
+      @XmlEnumValue("3") SUSPENDED(3, "The object is suspended.", false, true, true),
+      @XmlEnumValue("4") POWERED_ON(4, "The object is powered on.", false, true, true),
+      @XmlEnumValue("5") WAITING_FOR_INPUT(5, "The object is waiting for user input.", false, true, true),
+      @XmlEnumValue("6") UNKNOWN(6, "The object is in an unknown state.", true, true, true),
+      @XmlEnumValue("7") UNRECOGNIZED(7, "The object is in an unrecognized state.", true, true, true),
+      @XmlEnumValue("8") POWERED_OFF(8, "The object is powered off.", true, true, true),
+      @XmlEnumValue("9") INCONSISTENT_STATE(9, "The object is in an inconsistent state.", false, true, true),
+      @XmlEnumValue("10") MIXED(10, "Children do not all have the same status.", true, true, false),
+      @XmlEnumValue("11") UPLOAD_OVF_PENDING(11, "Upload initiated, OVF descriptor pending.", true, false, false),
+      @XmlEnumValue("12") UPLOAD_COPYING(12, "Upload initiated, copying contents.", true, false, false),
+      @XmlEnumValue("13") UPLOAD_DISK_PENDING(13, "Upload initiated , disk contents pending.", true, false, false),
+      @XmlEnumValue("14") UPLOAD_QUARANTINED(14, "Upload has been quarantined.", true, false, false),
+      @XmlEnumValue("15") UPLOAD_QUARANTINE_EXPIRED(15, "Upload quarantine period has expired.", true, false, false),
       
+      // TODO duplicate code, but mentioned in `POST /vdc/{id}/action/uploadVAppTemplate`
+      NOT_READY(0, "Not ready", true, false, false),
       // Convention is "UNRECOGNIZED", but that is already a valid state name! so using UNRECOGNIZED_VALUE
       UNRECOGNIZED_VALUE(404, "Unrecognized", false, false, false);
       
@@ -137,7 +142,7 @@ public abstract class ResourceEntityType extends EntityType {
    
    public static abstract class Builder<B extends Builder<B>> extends EntityType.Builder<B> {
       private Set<File> files;
-      private Integer status;
+      private Status status;
 
       /**
        * @see ResourceEntityType#getFiles()
@@ -150,8 +155,16 @@ public abstract class ResourceEntityType extends EntityType {
       /**
        * @see ResourceEntityType#getStatus()
        */
-      public B status(Integer status) {
+      public B status(Status status) {
          this.status = status;
+         return self();
+      }
+
+      /**
+       * @see ResourceEntityType#getStatus()
+       */
+      public B status(Integer status) {
+         this.status = Status.fromValue(status);
          return self();
       }
 
@@ -163,9 +176,8 @@ public abstract class ResourceEntityType extends EntityType {
    @XmlElementWrapper(name = "Files")
    @XmlElement(name = "File")
    private Set<File> files;
-   
    @XmlAttribute
-   private Integer status;
+   private Status status;
 
    public ResourceEntityType(Builder<?> builder) {
       super(builder);
@@ -187,7 +199,7 @@ public abstract class ResourceEntityType extends EntityType {
    /**
     * Gets the value of the status property.
     */
-   public Integer getStatus() {
+   public Status getStatus() {
       return status;
    }
 

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/Task.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/Task.java
@@ -60,12 +60,19 @@ public class Task extends EntityType {
    @XmlType
    @XmlEnum(String.class)
    public static enum Status {
+      /** The task has been queued for execution. */
       @XmlEnumValue("queued") QUEUED("queued"),
+      /** The task is awaiting preprocessing or, if it is a blocking task, administrative action. */
       @XmlEnumValue("preRunning") PRE_RUNNING("preRunning"),
+      /** The task is runnning.*/
       @XmlEnumValue("running") RUNNING("running"),
+      /** The task completed with a status of success. */
       @XmlEnumValue("success") SUCCESS("success"),
+      /** The task encountered an error while running. */
       @XmlEnumValue("error") ERROR("error"),
+      /** The task was canceled by the owner or an administrator. */
       @XmlEnumValue("canceled") CANCELED("canceled"),
+      /** The task was aborted by an administrative action. */
       @XmlEnumValue("aborted") ABORTED("aborted"),
       UNRECOGNIZED("unrecognized");
       
@@ -116,7 +123,7 @@ public class Task extends EntityType {
       private Reference user;
       private Object params;
       private Integer progress;
-      private String status;
+      private Status status;
       private String operation;
       private String operationName;
       private Date startTime;
@@ -175,6 +182,14 @@ public class Task extends EntityType {
        * @see Task#getStatus()
        */
       public B status(String status) {
+         this.status = Status.fromValue(status);
+         return self();
+      }
+
+      /**
+       * @see Task#getStatus()
+       */
+      public B status(Status status) {
          this.status = status;
          return self();
       }
@@ -274,7 +289,7 @@ public class Task extends EntityType {
    @XmlElement(name = "Params")
    private Object params;
    @XmlAttribute
-   private String status;
+   private Status status;
    @XmlAttribute
    private String operation;
    @XmlAttribute
@@ -333,19 +348,8 @@ public class Task extends EntityType {
 
    /**
     * The execution status of the task.
-    *
-    * One of:
-    * <ul>
-    * <li>queued - The task has been queued for execution.
-    * <li>preRunning - The task is awaiting preprocessing or, if it is a blocking task, administrative action.
-    * <li>running - The task is runnning.
-    * <li>success - The task completed with a status of success.
-    * <li>error - The task encountered an error while running.
-    * <li>canceled - The task was canceled by the owner or an administrator.
-    * <li>aborted - The task was aborted by an administrative action.
-    * </ul>
     */
-   public String getStatus() {
+   public Status getStatus() {
       return status;
    }
 

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/predicates/LinkPredicates.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/predicates/LinkPredicates.java
@@ -35,22 +35,28 @@ public class LinkPredicates {
    /**
     * matches links of the given relation
     * 
-    * @param rel
-    *           ex. {@code context.getApi().getCurrentSession().getOrg().getLinks()}
+    * @param rel from {@code context.getApi().getCurrentSession().getOrg().getLinks()}
     * @return predicate that will match links of the given rel
     */
    public static Predicate<Link> relEquals(final String rel) {
       checkNotNull(rel, "rel must be defined");
 
+      return relEquals(Link.Rel.fromValue(rel));
+   }
+
+   /** @see #relEquals(String) */
+   public static Predicate<Link> relEquals(final Link.Rel rel) {
+      checkNotNull(rel, "rel must be defined");
+
       return new Predicate<Link>() {
          @Override
          public boolean apply(Link link) {
-            return rel.equals(link.getRel());
+            return rel == link.getRel();
          }
 
          @Override
          public String toString() {
-            return "relEquals(" + rel + ")";
+            return "relEquals(" + rel.value() + ")";
          }
       };
    }

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/predicates/TaskStatusEquals.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/predicates/TaskStatusEquals.java
@@ -31,6 +31,7 @@ import org.jclouds.vcloud.director.v1_5.domain.Task.Status;
 import org.jclouds.vcloud.director.v1_5.features.TaskClient;
 
 import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
 
 /**
  * Test a {@link Task} to see if it has succeeded.
@@ -69,22 +70,17 @@ public class TaskStatusEquals implements Predicate<Task> {
       if (task == null) return false;
       logger.trace("%s: looking for status %s: currently: %s", task, expectedStatuses, task.getStatus());
       
-      for (Status failingStatus : failingStatuses) {
-         if (task.getStatus().equals(failingStatus)) {
-            throw new VCloudDirectorException(task);
-         }
+      if (failingStatuses.contains(task.getStatus())) {
+         throw new VCloudDirectorException(task);
       }
-      
-      for (Status expectedStatus : expectedStatuses) {
-         if (task.getStatus().equals(expectedStatus)) {
-            return true;
-         }
+      if (expectedStatuses.contains(task.getStatus())) {
+         return true;
       }
       return false;
    }
 
    @Override
    public String toString() {
-      return "checkTaskSuccess()";
+      return "taskStatusEquals(" + Iterables.toString(expectedStatuses) + ")";
    }
 }

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/AbstractVAppClientLiveTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/AbstractVAppClientLiveTest.java
@@ -251,7 +251,7 @@ public abstract class AbstractVAppClientLiveTest extends BaseVCloudDirectorClien
    protected VApp powerOn(final URI testVAppURI) {
       VApp testVApp = vAppClient.getVApp(testVAppURI);
       Vm vm = Iterables.getOnlyElement(testVApp.getChildren().getVms());
-      Status status = Status.fromValue(vm.getStatus());
+      Status status = vm.getStatus();
       if (status != Status.POWERED_ON) {
          Task powerOn = vAppClient.powerOn(vm.getHref());
          assertTaskSucceedsLong(powerOn);
@@ -275,7 +275,7 @@ public abstract class AbstractVAppClientLiveTest extends BaseVCloudDirectorClien
    protected VApp powerOff(final URI testVAppURI) {
       VApp testVApp = vAppClient.getVApp(testVAppURI);
       Vm vm = Iterables.getOnlyElement(testVApp.getChildren().getVms());
-      Status status = Status.fromValue(vm.getStatus());
+      Status status = vm.getStatus();
       if (status != Status.POWERED_OFF) {
          Task powerOff = vAppClient.powerOff(vm.getHref());
          assertTaskSucceedsLong(powerOff);
@@ -299,7 +299,7 @@ public abstract class AbstractVAppClientLiveTest extends BaseVCloudDirectorClien
    protected VApp suspend(final URI testVAppURI) {
       VApp testVApp = vAppClient.getVApp(testVAppURI);
       Vm vm = Iterables.getOnlyElement(testVApp.getChildren().getVms());
-      Status status = Status.fromValue(vm.getStatus());
+      Status status = vm.getStatus();
       if (status != Status.SUSPENDED) {
          Task suspend = vAppClient.suspend(vm.getHref());
          assertTaskSucceedsLong(suspend);
@@ -314,7 +314,7 @@ public abstract class AbstractVAppClientLiveTest extends BaseVCloudDirectorClien
    protected void assertVAppStatus(final URI testVAppURI, final Status status) {
       VApp testVApp = vAppClient.getVApp(testVAppURI);
       Vm vm = Iterables.getOnlyElement(testVApp.getChildren().getVms());
-      assertEquals(vm.getStatus(), status.getValue(), String.format(OBJ_FIELD_EQ, VAPP, "status", status.toString(), Status.fromValue(vm.getStatus()).toString()));
+      assertEquals(vm.getStatus(), status, String.format(OBJ_FIELD_EQ, VAPP, "status", status.toString(), vm.getStatus().toString()));
    }
 
    /**

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/domain/Checks.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/domain/Checks.java
@@ -42,6 +42,7 @@ import static org.testng.Assert.fail;
 
 import java.net.URI;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -96,7 +97,7 @@ public class Checks {
 
       // Check optional fields
       // NOTE description cannot be checked
-      Set<Task> tasks = entity.getTasks();
+      List<Task> tasks = entity.getTasks();
       if (tasks != null && tasks != null && !tasks.isEmpty()) {
          for (Task task : tasks) checkTask(task);
       }
@@ -133,12 +134,28 @@ public class Checks {
       // NOTE name cannot be checked
    }
 
+   /**
+    * Assumes the validTypes to be vcloud-specific types.
+    * 
+    * @see #checkResourceType(ResourceType, Collection)
+    */
    public static void checkResourceType(ResourceType resource) {
+      checkResourceType(resource, VCloudDirectorMediaType.ALL);
+   }
+
+   /**
+    * @see #checkResourceType(ResourceType, Collection)
+    */
+   public static void checkResourceType(ResourceType resource, String type) {
+      checkResourceType(resource, ImmutableSet.of(type));
+   }
+
+   public static void checkResourceType(ResourceType resource, Collection<String> validTypes) {
       // Check optional fields
       URI href = resource.getHref();
       if (href != null) checkHref(href);
       String type = resource.getType();
-      if (type != null) checkType(type);
+      if (type != null) checkType(type, validTypes);
       Set<Link> links = resource.getLinks();
       if (links != null && !links.isEmpty()) {
          for (Link link : links) checkLink(link);
@@ -286,6 +303,7 @@ public class Checks {
    public static void checkAdminOrg(AdminOrg org) {
       // required
       assertNotNull(org.getSettings(), String.format(NOT_NULL_OBJ_FIELD_FMT, "settings", "AdminOrg"));
+      checkResourceType(org, VCloudDirectorMediaType.ADMIN_ORG);
       
       // optional
       for (Reference user : org.getUsers()) {
@@ -298,7 +316,7 @@ public class Checks {
          checkReferenceType(catalog, VCloudDirectorMediaType.ADMIN_CATALOG);
       }
       for (Reference vdc : org.getVdcs()) {
-         checkReferenceType(vdc, VCloudDirectorMediaType.ADMIN_VDC);
+         checkReferenceType(vdc, VCloudDirectorMediaType.VDC);
       }
       for (Reference network : org.getNetworks()) {
          checkReferenceType(network, VCloudDirectorMediaType.ADMIN_NETWORK);
@@ -841,7 +859,7 @@ public class Checks {
       // NOTE customUsersOu cannot be checked
       if (settings.getLdapMode() != null) {
          assertTrue(LdapMode.ALL.contains(settings.getLdapMode()),
-               String.format(REQUIRED_VALUE_OBJECT_FMT, "LdapMode", "OrdLdapSettings", settings.getLdapMode(),
+               String.format(REQUIRED_VALUE_OBJECT_FMT, "LdapMode", "OrgLdapSettings", settings.getLdapMode(),
                      Iterables.toString(OrgLdapSettings.LdapMode.ALL)));
       }
       if (settings.getCustomOrgLdapSettings() != null) {

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/MediaClientLiveTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/MediaClientLiveTest.java
@@ -177,8 +177,7 @@ public class MediaClientLiveTest extends BaseVCloudDirectorClientLiveTest {
       Checks.checkMediaFor(MEDIA, media);
    }
    
-   @Test(description = "GET /media/{id}/owner",
-         dependsOnMethods = { "testGetMedia" })
+   @Test(description = "GET /media/{id}/owner", dependsOnMethods = { "testGetMedia" })
    public void testGetMediaOwner() {
       Owner directOwner = mediaClient.getOwner(media.getHref());
       assertEquals(owner.toBuilder()
@@ -196,8 +195,7 @@ public class MediaClientLiveTest extends BaseVCloudDirectorClientLiveTest {
       Checks.checkReferenceType(directOwner.getUser());
    }
    
-   @Test(description = "POST /vdc/{id}/action/cloneMedia",
-         dependsOnMethods = { "testGetMediaOwner" })
+   @Test(description = "POST /vdc/{id}/action/cloneMedia", dependsOnMethods = { "testGetMediaOwner" })
    public void testCloneMedia() {
       oldMedia = media;
       media = vdcClient.cloneMedia(vdcURI, CloneMediaParams.builder()
@@ -246,8 +244,7 @@ public class MediaClientLiveTest extends BaseVCloudDirectorClientLiveTest {
             media.toString(), oldMedia.toString()));
    }
    
-   @Test(description = "PUT /media/{id}",
-         dependsOnMethods = { "testCloneMedia" })
+   @Test(description = "PUT /media/{id}", dependsOnMethods = { "testCloneMedia" })
    public void testSetMedia() {
       String oldName = media.getName();
       String newName = "new "+oldName;
@@ -276,8 +273,7 @@ public class MediaClientLiveTest extends BaseVCloudDirectorClientLiveTest {
       media = mediaClient.getMedia(media.getHref());
    }
    
-   @Test(description = "GET /media/{id}/metadata",
-         dependsOnMethods = { "testSetMetadataValue" })
+   @Test(description = "GET /media/{id}/metadata", dependsOnMethods = { "testSetMetadataValue" })
    public void testGetMetadata() {
       metadata = mediaClient.getMetadataClient().getMetadata(media.getHref());
       // required for testing
@@ -287,8 +283,7 @@ public class MediaClientLiveTest extends BaseVCloudDirectorClientLiveTest {
       Checks.checkMetadataFor(MEDIA, metadata);
    }
    
-   @Test(description = "POST /media/{id}/metadata",
-         dependsOnMethods = { "testGetMedia" })
+   @Test(description = "POST /media/{id}/metadata", dependsOnMethods = { "testGetMedia" })
    public void testMergeMetadata() {
       // test new
       Set<MetadataEntry> inputEntries = ImmutableSet.of(MetadataEntry.builder().entry("testKey", "testValue").build());
@@ -340,15 +335,13 @@ public class MediaClientLiveTest extends BaseVCloudDirectorClientLiveTest {
       }
    }
    
-   @Test(description = "GET /media/{id}/metadata/{key}",
-         dependsOnMethods = { "testSetMetadataValue" })
+   @Test(description = "GET /media/{id}/metadata/{key}", dependsOnMethods = { "testSetMetadataValue" })
    public void testGetMetadataValue() {
       metadataValue = mediaClient.getMetadataClient().getMetadataValue(media.getHref(), "key");
       Checks.checkMetadataValueFor(MEDIA, metadataValue);
    }
    
-   @Test(description = "PUT /media/{id}/metadata/{key}",
-         dependsOnMethods = { "testMergeMetadata" })
+   @Test(description = "PUT /media/{id}/metadata/{key}", dependsOnMethods = { "testMergeMetadata" })
    public void testSetMetadataValue() {
       metadataEntryValue = "value";
       MetadataValue newValue = MetadataValue.builder().value(metadataEntryValue).build();
@@ -361,35 +354,17 @@ public class MediaClientLiveTest extends BaseVCloudDirectorClientLiveTest {
       Checks.checkMetadataValueFor(MEDIA, metadataValue);
    }
    
-   @Test(description = "DELETE /media/{id}/metadata/{key}",
-         dependsOnMethods = { "testGetMetadata", "testGetMetadataValue" } )
+   @Test(description = "DELETE /media/{id}/metadata/{key}", dependsOnMethods = { "testGetMetadata", "testGetMetadataValue" } )
    public void testDeleteMetadata() {
       Task deleteMetadataEntry = mediaClient.getMetadataClient().deleteMetadataEntry(media.getHref(), "testKey");
       Checks.checkTask(deleteMetadataEntry);
       assertTrue(retryTaskSuccess.apply(deleteMetadataEntry),
             String.format(TASK_COMPLETE_TIMELY, "deleteMetadataEntry"));
       
-      Error expected = Error.builder()
-            .message("The access to the resource metadata_item with id testKey is forbidden")
-            .majorErrorCode(403)
-            .minorErrorCode("ACCESS_TO_RESOURCE_IS_FORBIDDEN")
-            .build();
-      
-      try {
-         metadataValue = mediaClient.getMetadataClient().getMetadataValue(media.getHref(), "testKey");
-         fail("Should give HTTP 403 error");
-      } catch (VCloudDirectorException vde) {
-         assertEquals(vde.getError(), expected);
-         metadataValue = null;
-      } catch (Exception e) {
-         fail("Should have thrown a VCloudDirectorException");
-      }
-      
-      if (metadataValue != null) { // guard against NPE on the .toStrings
-         assertNull(metadataValue, String.format(OBJ_FIELD_ATTRB_DEL, MEDIA,
-               "Metadata", metadataValue.toString(),
-               "metadataEntry", metadataValue.toString()));
-      }
+      metadataValue = mediaClient.getMetadataClient().getMetadataValue(media.getHref(), "testKey");
+      assertNull(metadataValue, String.format(OBJ_FIELD_ATTRB_DEL, MEDIA,
+               "Metadata", metadataValue != null ? metadataValue.toString() : "",
+               "MetadataEntry", metadataValue != null ? metadataValue.toString() : ""));
       
       metadataValue = mediaClient.getMetadataClient().getMetadataValue(media.getHref(), "key");
       Checks.checkMetadataValueFor(MEDIA, metadataValue);
@@ -398,40 +373,19 @@ public class MediaClientLiveTest extends BaseVCloudDirectorClientLiveTest {
       Checks.checkMediaFor(MEDIA, media);
    }
    
-   @Test(description = "DELETE /media/{id}",
-         dependsOnMethods = { "testDeleteMetadata" } )
+   @Test(description = "DELETE /media/{id}", dependsOnMethods = { "testDeleteMetadata" } )
    public void testDeleteMedia() {
       Task deleteMedia = mediaClient.deleteMedia(media.getHref());
       Checks.checkTask(deleteMedia);
       assertTrue(retryTaskSuccess.apply(deleteMedia),
             String.format(TASK_COMPLETE_TIMELY, "deleteMedia"));
       
-      Error expected = Error.builder()
-            .message(String.format(
-                  "No access to entity \"(com.vmware.vcloud.entity.media:%s)\".",
-                  media.getId().substring("urn:vcloud:media:".length())))
-            .majorErrorCode(403)
-            .minorErrorCode("ACCESS_TO_RESOURCE_IS_FORBIDDEN")
-            .build();
-      
-      try {
-         media = mediaClient.getMedia(media.getHref());
-         fail("Should give HTTP 403 error");
-      } catch (VCloudDirectorException vde) {
-         assertEquals(vde.getError(), expected);
-         media = null;
-      } catch (Exception e) {
-         fail("Should have thrown a VCloudDirectorException");
-      }
-      
-      if (media != null) { // guard against NPE on the .toStrings
-         assertNull(metadataValue, String.format(OBJ_DEL, MEDIA, media.toString()));
-      }
+      media = mediaClient.getMedia(media.getHref());
+      assertNull(media, String.format(OBJ_DEL, MEDIA, media != null ? media.toString() : ""));
       
       deleteMedia = mediaClient.deleteMedia(oldMedia.getHref());
       Checks.checkTask(deleteMedia);
-      assertTrue(retryTaskSuccess.apply(deleteMedia),
-            String.format(TASK_COMPLETE_TIMELY, "deleteMedia"));
+      assertTrue(retryTaskSuccess.apply(deleteMedia), String.format(TASK_COMPLETE_TIMELY, "deleteMedia"));
       oldMedia = null;
    }
 }

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/VAppClientLiveTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/VAppClientLiveTest.java
@@ -166,7 +166,7 @@ public class VAppClientLiveTest extends AbstractVAppClientLiveTest {
          if (media.getTasks().size() == 1) {
             Task uploadTask = Iterables.getOnlyElement(media.getTasks());
             Checks.checkTask(uploadTask);
-            assertEquals(uploadTask.getStatus(), "running");
+            assertEquals(uploadTask.getStatus(), Task.Status.RUNNING);
             assertTrue(retryTaskSuccess.apply(uploadTask), String.format(TASK_COMPLETE_TIMELY, "uploadTask"));
             media = context.getApi().getMediaClient().getMedia(media.getHref());
          }
@@ -184,6 +184,7 @@ public class VAppClientLiveTest extends AbstractVAppClientLiveTest {
       }
    }
    
+   @Override
    @AfterClass(alwaysRun = true)
    public void cleanUp() {
       if (adminContext != null && mediaURI != null) {

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/VAppTemplateClientLiveTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/VAppTemplateClientLiveTest.java
@@ -35,15 +35,18 @@ import static org.jclouds.vcloud.director.v1_5.domain.Checks.checkVAppTemplate;
 import static org.jclouds.vcloud.director.v1_5.domain.Checks.metadataToMap;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import java.net.URI;
+import java.util.EnumSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.jclouds.dmtf.ovf.NetworkSection;
 import org.jclouds.vcloud.director.v1_5.AbstractVAppClientLiveTest;
-import org.jclouds.vcloud.director.v1_5.VCloudDirectorException;
 import org.jclouds.vcloud.director.v1_5.domain.Checks;
 import org.jclouds.vcloud.director.v1_5.domain.CloneVAppTemplateParams;
 import org.jclouds.vcloud.director.v1_5.domain.CustomizationSection;
@@ -51,6 +54,7 @@ import org.jclouds.vcloud.director.v1_5.domain.Envelope;
 import org.jclouds.vcloud.director.v1_5.domain.GuestCustomizationSection;
 import org.jclouds.vcloud.director.v1_5.domain.LeaseSettingsSection;
 import org.jclouds.vcloud.director.v1_5.domain.Link;
+import org.jclouds.vcloud.director.v1_5.domain.Link.Rel;
 import org.jclouds.vcloud.director.v1_5.domain.Metadata;
 import org.jclouds.vcloud.director.v1_5.domain.MetadataEntry;
 import org.jclouds.vcloud.director.v1_5.domain.MetadataValue;
@@ -69,6 +73,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Function;
+import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 
@@ -404,11 +409,8 @@ public class VAppTemplateClientLiveTest extends AbstractVAppClientLiveTest {
       retryTaskSuccess.apply(task);
 
       // Confirm that can't access post-delete, i.e. template has been deleted
-      try {
-         vAppTemplateClient.getVAppTemplate(clonedVappTemplate.getHref());
-      } catch (VCloudDirectorException e) {
-         // success; should get a 403 because vAppTemplate no longer exists
-      }
+      VAppTemplate deleted = vAppTemplateClient.getVAppTemplate(clonedVappTemplate.getHref());
+      assertNull(deleted);
    }
 
    @Test(description = "POST /vAppTemplate/{id}/action/disableDownload")
@@ -418,11 +420,10 @@ public class VAppTemplateClientLiveTest extends AbstractVAppClientLiveTest {
       // TODO Check that it really is disabled. The only thing I can see for determining this 
       // is the undocumented "download" link in the VAppTemplate. But that is brittle and we
       // don't know what timing guarantees there are for adding/removing the link.
-      //
-      // For example:
-      //    VAppTemplate vAppTemplate = vAppTemplateClient.getVAppTemplate(vAppTemplateURI);
-      //    Set<Link> links = vAppTemplate.getLinks();
-      //    assertFalse(hasLinkMatchingRel(links, "download.*"), "Should not offer download link after disabling download: "+vAppTemplate);
+      VAppTemplate vAppTemplate = vAppTemplateClient.getVAppTemplate(vAppTemplateURI);
+      Set<Link> links = vAppTemplate.getLinks();
+      assertTrue(Iterables.all(Iterables.transform(links, rel), Predicates.not(Predicates.in(EnumSet.of(Link.Rel.DOWNLOAD_DEFAULT, Link.Rel.DOWNLOAD_ALTERNATE)))),
+            "Should not offer download link after disabling download: "+vAppTemplate);
    }
    
    @Test(description = "POST /vAppTemplate/{id}/action/enableDownload")
@@ -435,22 +436,18 @@ public class VAppTemplateClientLiveTest extends AbstractVAppClientLiveTest {
       // TODO Check that it really is enabled. The only thing I can see for determining this 
       // is the undocumented "download" link in the VAppTemplate. But that is brittle and we
       // don't know what timing guarantees there are for adding/removing the link.
-      //
-      // For example:
-      //    VAppTemplate vAppTemplate = vAppTemplateClient.getVAppTemplate(vAppTemplateURI);
-      //    Set<Link> links = vAppTemplate.getLinks();
-      //    assertTrue(hasLinkMatchingRel(links, "download.*"), "Should offer download link after enabling download: "+vAppTemplate);
+      VAppTemplate vAppTemplate = vAppTemplateClient.getVAppTemplate(vAppTemplateURI);
+      Set<Link> links = vAppTemplate.getLinks();
+      assertTrue(Iterables.any(Iterables.transform(links, rel), Predicates.in(EnumSet.of(Link.Rel.DOWNLOAD_DEFAULT, Link.Rel.DOWNLOAD_ALTERNATE))),
+            "Should offer download link after enabling download: "+vAppTemplate);
    }
    
-   @SuppressWarnings("unused")
-   private boolean hasLinkMatchingRel(Set<Link> links, String regex) {
-      for (Link link : links) {
-         if (link.getRel() != null && link.getRel().matches(regex)) {
-            return true;
-         }
+   private Function<Link, Link.Rel> rel = new Function<Link, Link.Rel>() {
+      @Override
+      public Rel apply(Link input) {
+         return input.getRel();
       }
-      return false;
-   }
+   };
    
    @Test(description = "POST /vAppTemplate/{id}/action/consolidate")
    public void testConsolidateVAppTemplate() throws Exception {
@@ -490,11 +487,11 @@ public class VAppTemplateClientLiveTest extends AbstractVAppClientLiveTest {
 
       // Ask the VAppTemplate for its tasks, and the status of the matching task if it exists
       VAppTemplate vAppTemplate = vAppTemplateClient.getVAppTemplate(vAppTemplateURI);
-      Set<Task> tasks = vAppTemplate.getTasks();
+      List<Task> tasks = vAppTemplate.getTasks();
       for (Task contender : tasks) {
          if (task.getId().equals(contender.getId())) {
-            String status = contender.getStatus();
-            if (status.equals(Task.Status.QUEUED) || status.equals(Task.Status.PRE_RUNNING) || status.equals(Task.Status.RUNNING)) {
+            Task.Status status = contender.getStatus();
+            if (EnumSet.of(Task.Status.QUEUED, Task.Status.PRE_RUNNING, Task.Status.RUNNING).contains(status)) {
                fail("Task "+contender+" reported complete, but is included in VAppTemplate in status "+status);
             }
          }

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/VdcClientLiveTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/VdcClientLiveTest.java
@@ -305,8 +305,8 @@ public class VdcClientLiveTest extends BaseVCloudDirectorClientLiveTest {
                String.format(OBJ_FIELD_EQ, "VAppTemplate", "name", name, uploadedVAppTemplate.getName()));
       
       ResourceEntityType.Status expectedStatus = ResourceEntityType.Status.NOT_READY;
-      Integer actualStatus = uploadedVAppTemplate.getStatus();
-      assertEquals(actualStatus, expectedStatus.getValue(),
+      ResourceEntityType.Status actualStatus = uploadedVAppTemplate.getStatus();
+      assertEquals(actualStatus, expectedStatus,
                String.format(OBJ_FIELD_EQ, "VAppTemplate", "status", expectedStatus, actualStatus));
       
    }

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/admin/AdminCatalogClientLiveTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/admin/AdminCatalogClientLiveTest.java
@@ -107,23 +107,20 @@ public class AdminCatalogClientLiveTest extends BaseVCloudDirectorClientLiveTest
       // FIXME: documentation suggests we should wait for a task here
    }
 
-   @Test(description = "GET /admin/catalog/{id}",
-         dependsOnMethods = { "testCreateCatalog" })
+   @Test(description = "GET /admin/catalog/{id}", dependsOnMethods = { "testCreateCatalog" })
    public void testGetCatalog() {
       catalog = catalogClient.getCatalog(catalog.getHref());
       
       Checks.checkAdminCatalog(catalog);
    }
    
-   @Test(description = "GET /admin/catalog/{id}/owner",
-         dependsOnMethods = { "testGetCatalog" })
+   @Test(description = "GET /admin/catalog/{id}/owner", dependsOnMethods = { "testGetCatalog" })
    public void testGetCatalogOwner() {
       owner = catalogClient.getOwner(catalog.getHref());
       Checks.checkOwner(owner);
    }
    
-   @Test(description = "PUT /admin/catalog/{id}/owner",
-         dependsOnMethods = { "testGetCatalog" })
+   @Test(description = "PUT /admin/catalog/{id}/owner", dependsOnMethods = { "testGetCatalog" })
    public void updateCatalogOwner() {
       User newOwnerUser = randomTestUser("testUpdateCatalogOwner");
       newOwnerUser = adminContext.getApi().getUserClient().createUser(orgRef.getHref(), newOwnerUser);
@@ -187,8 +184,8 @@ public class AdminCatalogClientLiveTest extends BaseVCloudDirectorClientLiveTest
       }
    }
    
-   @Test(description = "POST /admin/catalog/{id}/action/publish",
-         dependsOnMethods = { "testUpdateCatalog" } ) // FIXME: fails with a 403
+   // FIXME fails with a 403
+   @Test(description = "POST /admin/catalog/{id}/action/publish", dependsOnMethods = { "testUpdateCatalog" } )
    public void testPublishCatalog() {
       assertNotNull(catalog, String.format(NOT_NULL_OBJ_FMT, "Catalog"));
       assertTrue(!catalog.isPublished(), String.format(OBJ_FIELD_EQ, 
@@ -205,8 +202,7 @@ public class AdminCatalogClientLiveTest extends BaseVCloudDirectorClientLiveTest
             CATALOG, "isPublished", true, catalog.isPublished()));
    }
    
-   @Test(description = "DELETE /admin/catalog/{id}",
-         dependsOnMethods = { "testCreateCatalog" } )
+   @Test(description = "DELETE /admin/catalog/{id}", dependsOnMethods = { "testCreateCatalog" } )
    public void testDeleteCatalog() {
 //      assertEquals(catalog.getCatalogItems().getCatalogItems().size(), 0, 
 //            String.format(OBJ_FIELD_EMPTY_TO_DELETE, "Catalog", "CatalogItems", 
@@ -218,25 +214,7 @@ public class AdminCatalogClientLiveTest extends BaseVCloudDirectorClientLiveTest
       deleteCatalog = catalogClient.createCatalog(orgRef.getHref(), deleteCatalog);
       catalogClient.deleteCatalog(deleteCatalog.getHref());
       
-      Error expected = Error.builder()
-            .message("No access to entity \"(com.vmware.vcloud.entity.catalog:"+
-                  deleteCatalog.getId().substring("urn:vcloud:catalog:".length())+")\".")
-            .majorErrorCode(403)
-            .minorErrorCode("ACCESS_TO_RESOURCE_IS_FORBIDDEN")
-            .build();
-      
-      try {
-         deleteCatalog = catalogClient.getCatalog(deleteCatalog.getHref());
-         fail("Should give HTTP 403 error");
-      } catch (VCloudDirectorException vde) {
-         assertEquals(vde.getError(), expected);
-         deleteCatalog = null;
-      } catch (Exception e) {
-         fail("Should have thrown a VCloudDirectorException");
-      }
-      
-      if (deleteCatalog != null) { // guard against NPE on the .toStrings
-         assertNull(deleteCatalog, String.format(OBJ_DEL, CATALOG, deleteCatalog.toString()));
-      }
+      deleteCatalog = catalogClient.getCatalog(deleteCatalog.getHref());
+      assertNull(deleteCatalog, String.format(OBJ_DEL, CATALOG, deleteCatalog != null ? deleteCatalog.toString() : ""));
    }
 }

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/internal/BaseVCloudDirectorClientLiveTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/internal/BaseVCloudDirectorClientLiveTest.java
@@ -303,7 +303,7 @@ public abstract class BaseVCloudDirectorClientLiveTest extends BaseVersionedServ
       assertTrue(retryTaskSuccessLong.apply(task), String.format(TASK_COMPLETE_TIMELY, task));
    }
 
-   protected void assertTaskStatusEventually(Task task, org.jclouds.vcloud.director.v1_5.domain.Task.Status running, ImmutableSet<org.jclouds.vcloud.director.v1_5.domain.Task.Status> immutableSet) {
+   protected void assertTaskStatusEventually(Task task, Task.Status running, ImmutableSet<Task.Status> immutableSet) {
       TaskClient taskClient = context.getApi().getTaskClient();
       TaskStatusEquals predicate = new TaskStatusEquals(taskClient, running, immutableSet);
       RetryablePredicate<Task> retryablePredicate = new RetryablePredicate<Task>(predicate, TASK_TIMEOUT_SECONDS * 1000L);

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/predicates/LinkPredicatesTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/predicates/LinkPredicatesTest.java
@@ -39,6 +39,11 @@ public class LinkPredicatesTest {
 
    @Test
    public void testRelEqualsWhenEqual() {
+      assert relEquals(Link.Rel.ADD).apply(ref);
+   }
+
+   @Test
+   public void testRelEqualsWhenEqualString() {
       assert relEquals("add").apply(ref);
    }
 


### PR DESCRIPTION
This fixes some regressions due to:
- New XML enumeration annotations
- ReturnNullOnNotFoundOr404 changes for deletion tests
- DMTF object move
- Not running the live tests often enough

There's more to be done here, so perhaps hold off on merge, since the build isn't breaking due to these
