### PR TITLE
Add the EventBus module when building the injector

### DIFF
--- a/core/src/main/java/org/jclouds/rest/internal/ContextBuilder.java
+++ b/core/src/main/java/org/jclouds/rest/internal/ContextBuilder.java
@@ -298,6 +298,7 @@ public class ContextBuilder<S, A, C extends Closeable, M extends ApiMetadata<S, 
       addHttpModuleIfNeededAndNotPresent(modules);
       ifHttpConfigureRestOtherwiseGuiceClientFactory(modules);
       addExecutorServiceIfNotPresent(modules);
+      addEventBusIfNotPresent(modules);
       addCredentialStoreIfNotPresent(modules);
       modules.add(new LifeCycleModule());
       modules.add(new BindPropertiesToAnnotations());


### PR DESCRIPTION
The addEventBusIfNotPresent call in injector construction seems to have been forgotten in the ContextBuilder refactor. Adding it.
