### PR TITLE
covariant compatible version of futureIterables

### DIFF
--- a/apis/cloudloadbalancers/src/main/java/org/jclouds/cloudloadbalancers/loadbalancer/strategy/CloudLoadBalancersListLoadBalancersStrategy.java
+++ b/apis/cloudloadbalancers/src/main/java/org/jclouds/cloudloadbalancers/loadbalancer/strategy/CloudLoadBalancersListLoadBalancersStrategy.java
@@ -72,7 +72,7 @@ public class CloudLoadBalancersListLoadBalancersStrategy implements ListLoadBala
 
    @Override
    public Iterable<? extends LoadBalancerMetadata> listLoadBalancers() {
-      return transform(concat(transformParallel(regions.get(), new Function<String, Future<Set<LoadBalancer>>>() {
+      return transform(concat(transformParallel(regions.get(), new Function<String, Future<? extends Set<LoadBalancer>>>() {
 
          @Override
          public ListenableFuture<Set<LoadBalancer>> apply(String from) {

--- a/apis/cloudsigma/src/main/java/org/jclouds/cloudsigma/compute/CloudSigmaComputeServiceAdapter.java
+++ b/apis/cloudsigma/src/main/java/org/jclouds/cloudsigma/compute/CloudSigmaComputeServiceAdapter.java
@@ -56,6 +56,7 @@ import org.jclouds.compute.reference.ComputeServiceConstants;
 import org.jclouds.domain.Location;
 import org.jclouds.domain.LoginCredentials;
 import org.jclouds.logging.Logger;
+import org.jclouds.util.Iterables2;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
@@ -170,8 +171,8 @@ public class CloudSigmaComputeServiceAdapter implements
     */
    @Override
    public Iterable<DriveInfo> listImages() {
-      Iterable<DriveInfo> drives = transformParallel(client.listStandardDrives(),
-            new Function<String, Future<DriveInfo>>() {
+      Iterable<? extends DriveInfo> drives = transformParallel(client.listStandardDrives(),
+            new Function<String, Future<? extends DriveInfo>>() {
 
                @Override
                public Future<DriveInfo> apply(String input) {
@@ -190,7 +191,7 @@ public class CloudSigmaComputeServiceAdapter implements
                   return "seedDriveCache()";
                }
             }, executor, null, logger, "drives");
-      return filter(drives, PREINSTALLED_DISK);
+      return Iterables2.concreteCopy(filter(drives, PREINSTALLED_DISK));
    }
 
    @SuppressWarnings("unchecked")

--- a/apis/ec2/src/main/java/org/jclouds/ec2/compute/strategy/DescribeImagesParallel.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/compute/strategy/DescribeImagesParallel.java
@@ -65,7 +65,7 @@ public class DescribeImagesParallel implements
             Iterable<Entry<String, DescribeImagesOptions>> queries) {
       return concat(transformParallel(
                queries,
-               new Function<Entry<String, DescribeImagesOptions>, Future<Set<? extends org.jclouds.ec2.domain.Image>>>() {
+               new Function<Entry<String, DescribeImagesOptions>, Future<? extends Set<? extends org.jclouds.ec2.domain.Image>>>() {
 
                   @Override
                   public Future<Set<? extends org.jclouds.ec2.domain.Image>> apply(

--- a/apis/ec2/src/main/java/org/jclouds/ec2/compute/strategy/EC2ListNodesStrategy.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/compute/strategy/EC2ListNodesStrategy.java
@@ -92,7 +92,7 @@ public class EC2ListNodesStrategy implements ListNodesStrategy {
 
    protected Iterable<? extends RunningInstance> pollRunningInstances() {
       Iterable<? extends Set<? extends Reservation<? extends RunningInstance>>> reservations = transformParallel(
-               regions.get(), new Function<String, Future<Set<? extends Reservation<? extends RunningInstance>>>>() {
+               regions.get(), new Function<String, Future<? extends Set<? extends Reservation<? extends RunningInstance>>>>() {
 
                   @Override
                   public Future<Set<? extends Reservation<? extends RunningInstance>>> apply(String from) {

--- a/apis/elasticstack/src/main/java/org/jclouds/elasticstack/compute/ElasticStackComputeServiceAdapter.java
+++ b/apis/elasticstack/src/main/java/org/jclouds/elasticstack/compute/ElasticStackComputeServiceAdapter.java
@@ -58,6 +58,7 @@ import org.jclouds.elasticstack.domain.ServerStatus;
 import org.jclouds.elasticstack.domain.WellKnownImage;
 import org.jclouds.elasticstack.reference.ElasticStackConstants;
 import org.jclouds.logging.Logger;
+import org.jclouds.util.Iterables2;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
@@ -162,11 +163,11 @@ public class ElasticStackComputeServiceAdapter implements
     */
    @Override
    public Iterable<DriveInfo> listImages() {
-      Iterable<DriveInfo> drives = transformParallel(preinstalledImages.keySet(),
-            new Function<String, Future<DriveInfo>>() {
+      Iterable<? extends DriveInfo> drives = transformParallel(preinstalledImages.keySet(),
+            new Function<String, Future<? extends DriveInfo>>() {
 
                @Override
-               public Future<DriveInfo> apply(String input) {
+               public Future<? extends DriveInfo> apply(String input) {
                   try {
                      return Futures.immediateFuture(cache.getUnchecked(input));
                   } catch (CacheLoader.InvalidCacheLoadException e) {
@@ -183,7 +184,7 @@ public class ElasticStackComputeServiceAdapter implements
                }
 
             }, executor, null, logger, "drives");
-      return filter(drives, notNull());
+      return Iterables2.concreteCopy(filter(drives, notNull()));
    }
 
    @SuppressWarnings("unchecked")

--- a/apis/vcloud/src/main/java/org/jclouds/vcloud/functions/AllCatalogItemsInCatalog.java
+++ b/apis/vcloud/src/main/java/org/jclouds/vcloud/functions/AllCatalogItemsInCatalog.java
@@ -31,6 +31,7 @@ import javax.inject.Singleton;
 
 import org.jclouds.Constants;
 import org.jclouds.logging.Logger;
+import org.jclouds.util.Iterables2;
 import org.jclouds.vcloud.VCloudAsyncClient;
 import org.jclouds.vcloud.VCloudMediaType;
 import org.jclouds.vcloud.domain.Catalog;
@@ -60,14 +61,14 @@ public class AllCatalogItemsInCatalog implements Function<Catalog, Iterable<Cata
    @Override
    public Iterable<CatalogItem> apply(Catalog from) {
 
-      Iterable<CatalogItem> catalogItems = transformParallel(filter(from.values(), new Predicate<ReferenceType>() {
+      Iterable<? extends CatalogItem> catalogItems = transformParallel(filter(from.values(), new Predicate<ReferenceType>() {
 
          @Override
          public boolean apply(ReferenceType input) {
             return input.getType().equals(VCloudMediaType.CATALOGITEM_XML);
          }
 
-      }), new Function<ReferenceType, Future<CatalogItem>>() {
+      }), new Function<ReferenceType, Future<? extends CatalogItem>>() {
 
          @Override
          public Future<CatalogItem> apply(ReferenceType from) {
@@ -75,7 +76,7 @@ public class AllCatalogItemsInCatalog implements Function<Catalog, Iterable<Cata
          }
 
       }, executor, null, logger, "catalogItems in " + from.getHref());
-      return catalogItems;
+      return Iterables2.concreteCopy(catalogItems);
    }
 
 }

--- a/apis/vcloud/src/main/java/org/jclouds/vcloud/functions/AllCatalogItemsInOrg.java
+++ b/apis/vcloud/src/main/java/org/jclouds/vcloud/functions/AllCatalogItemsInOrg.java
@@ -48,9 +48,9 @@ public class AllCatalogItemsInOrg implements Function<Org, Iterable<CatalogItem>
    @Override
    public Iterable<CatalogItem> apply(Org from) {
       return Iterables.concat(Iterables.transform(allCatalogsInOrg.apply(from),
-               new Function<Catalog, Iterable<CatalogItem>>() {
+               new Function<Catalog, Iterable<? extends CatalogItem>>() {
                   @Override
-                  public Iterable<CatalogItem> apply(Catalog from) {
+                  public Iterable<? extends CatalogItem> apply(Catalog from) {
                      return allCatalogItemsInCatalog.apply(from);
                   }
 

--- a/apis/vcloud/src/main/java/org/jclouds/vcloud/functions/AllCatalogsInOrg.java
+++ b/apis/vcloud/src/main/java/org/jclouds/vcloud/functions/AllCatalogsInOrg.java
@@ -30,6 +30,7 @@ import javax.inject.Singleton;
 
 import org.jclouds.Constants;
 import org.jclouds.logging.Logger;
+import org.jclouds.util.Iterables2;
 import org.jclouds.vcloud.VCloudAsyncClient;
 import org.jclouds.vcloud.domain.Catalog;
 import org.jclouds.vcloud.domain.Org;
@@ -56,14 +57,14 @@ public class AllCatalogsInOrg implements Function<Org, Iterable<Catalog>> {
 
    @Override
    public Iterable<Catalog> apply(final Org org) {
-      Iterable<Catalog> catalogs = transformParallel(org.getCatalogs().values(),
-            new Function<ReferenceType, Future<Catalog>>() {
+      Iterable<? extends Catalog> catalogs = transformParallel(org.getCatalogs().values(),
+            new Function<ReferenceType, Future<? extends Catalog>>() {
                @Override
                public Future<Catalog> apply(ReferenceType from) {
-                  return (Future<Catalog>) aclient.getCatalogClient().getCatalog(from.getHref());
+                  return aclient.getCatalogClient().getCatalog(from.getHref());
                }
 
             }, executor, null, logger, "catalogs in " + org.getName());
-      return catalogs;
+      return Iterables2.concreteCopy(catalogs);
    }
 }

--- a/apis/vcloud/src/main/java/org/jclouds/vcloud/functions/AllVDCsInOrg.java
+++ b/apis/vcloud/src/main/java/org/jclouds/vcloud/functions/AllVDCsInOrg.java
@@ -30,6 +30,7 @@ import javax.inject.Singleton;
 
 import org.jclouds.Constants;
 import org.jclouds.logging.Logger;
+import org.jclouds.util.Iterables2;
 import org.jclouds.vcloud.VCloudAsyncClient;
 import org.jclouds.vcloud.domain.Org;
 import org.jclouds.vcloud.domain.ReferenceType;
@@ -41,7 +42,7 @@ import com.google.common.base.Function;
  * @author Adrian Cole
  */
 @Singleton
-public class AllVDCsInOrg implements Function<Org, Iterable<org.jclouds.vcloud.domain.VDC>> {
+public class AllVDCsInOrg implements Function<Org, Iterable<VDC>> {
    @Resource
    public Logger logger = Logger.NULL;
 
@@ -58,14 +59,14 @@ public class AllVDCsInOrg implements Function<Org, Iterable<org.jclouds.vcloud.d
    public Iterable<VDC> apply(final Org org) {
 
       Iterable<VDC> catalogItems = transformParallel(org.getVDCs().values(),
-            new Function<ReferenceType, Future<org.jclouds.vcloud.domain.VDC>>() {
+            new Function<ReferenceType, Future<? extends VDC>>() {
                @Override
-               public Future<VDC> apply(ReferenceType from) {
+               public Future<? extends VDC> apply(ReferenceType from) {
                   return  aclient.getVDCClient().getVDC(from.getHref());
                }
 
             }, executor, null, logger, "vdcs in org " + org.getName());
-      return catalogItems;
+      return Iterables2.concreteCopy(catalogItems);
    }
 
 }

--- a/apis/vcloud/src/main/java/org/jclouds/vcloud/functions/OrgsForLocations.java
+++ b/apis/vcloud/src/main/java/org/jclouds/vcloud/functions/OrgsForLocations.java
@@ -35,6 +35,7 @@ import org.jclouds.Constants;
 import org.jclouds.domain.Location;
 import org.jclouds.domain.LocationScope;
 import org.jclouds.logging.Logger;
+import org.jclouds.util.Iterables2;
 import org.jclouds.vcloud.VCloudAsyncClient;
 import org.jclouds.vcloud.domain.Org;
 
@@ -46,7 +47,7 @@ import com.google.common.collect.Sets;
  * @author Adrian Cole
  */
 @Singleton
-public class OrgsForLocations implements Function<Iterable<Location>, Iterable< Org>> {
+public class OrgsForLocations implements Function<Iterable<Location>, Iterable<Org>> {
    @Resource
    public Logger logger = Logger.NULL;
    private final VCloudAsyncClient aclient;
@@ -65,7 +66,7 @@ public class OrgsForLocations implements Function<Iterable<Location>, Iterable< 
    @Override
    public Iterable<Org> apply(Iterable<Location> from) {
 
-      return transformParallel(Sets.newLinkedHashSet(transform(filter(from, new Predicate<Location>() {
+      return Iterables2.concreteCopy(transformParallel(Sets.newLinkedHashSet(transform(filter(from, new Predicate<Location>() {
 
          @Override
          public boolean apply(Location input) {
@@ -79,14 +80,14 @@ public class OrgsForLocations implements Function<Iterable<Location>, Iterable< 
             return URI.create(from.getParent().getId());
          }
 
-      })), new Function<URI, Future<Org>>() {
+      })), new Function<URI, Future<? extends Org>>() {
 
          @Override
          public Future<Org> apply(URI from) {
             return aclient.getOrgClient().getOrg(from);
          }
 
-      }, executor, null, logger, "organizations for uris");
+      }, executor, null, logger, "organizations for uris"));
    }
 
 }

--- a/apis/vcloud/src/main/java/org/jclouds/vcloud/functions/OrgsForNames.java
+++ b/apis/vcloud/src/main/java/org/jclouds/vcloud/functions/OrgsForNames.java
@@ -30,6 +30,7 @@ import javax.inject.Singleton;
 
 import org.jclouds.Constants;
 import org.jclouds.logging.Logger;
+import org.jclouds.util.Iterables2;
 import org.jclouds.vcloud.VCloudAsyncClient;
 import org.jclouds.vcloud.domain.Org;
 
@@ -53,14 +54,14 @@ public class OrgsForNames implements Function<Iterable<String>, Iterable<Org>> {
 
    @Override
    public Iterable<Org> apply(Iterable<String> from) {
-      return transformParallel(from, new Function<String, Future<Org>>() {
+      return Iterables2.concreteCopy(transformParallel(from, new Function<String, Future<? extends Org>>() {
 
          @Override
          public Future<Org> apply(String from) {
             return aclient.getOrgClient().findOrgNamed(from);
          }
 
-      }, executor, null, logger, "organizations for names");
+      }, executor, null, logger, "organizations for names"));
    }
 
 }

--- a/apis/vcloud/src/main/java/org/jclouds/vcloud/functions/VAppTemplatesForCatalogItems.java
+++ b/apis/vcloud/src/main/java/org/jclouds/vcloud/functions/VAppTemplatesForCatalogItems.java
@@ -36,6 +36,7 @@ import org.jclouds.concurrent.ExceptionParsingListenableFuture;
 import org.jclouds.concurrent.Futures;
 import org.jclouds.logging.Logger;
 import org.jclouds.rest.AuthorizationException;
+import org.jclouds.util.Iterables2;
 import org.jclouds.vcloud.VCloudAsyncClient;
 import org.jclouds.vcloud.VCloudMediaType;
 import org.jclouds.vcloud.domain.CatalogItem;
@@ -78,14 +79,14 @@ public class VAppTemplatesForCatalogItems implements Function<Iterable<CatalogIt
 
    @Override
    public Iterable<VAppTemplate> apply(Iterable<CatalogItem> from) {
-      return transformParallel(filter(from, new Predicate<CatalogItem>() {
+      return Iterables2.concreteCopy(transformParallel(filter(from, new Predicate<CatalogItem>() {
 
          @Override
          public boolean apply(CatalogItem input) {
             return input.getEntity().getType().equals(VCloudMediaType.VAPPTEMPLATE_XML);
          }
 
-      }), new Function<CatalogItem, Future<VAppTemplate>>() {
+      }), new Function<CatalogItem, Future<? extends VAppTemplate>>() {
 
          @Override
          public Future<VAppTemplate> apply(CatalogItem from) {
@@ -94,7 +95,7 @@ public class VAppTemplatesForCatalogItems implements Function<Iterable<CatalogIt
                      returnNullOnAuthorizationException);
          }
 
-      }, executor, null, logger, "vappTemplates in");
+      }, executor, null, logger, "vappTemplates in"));
    }
 
 }

--- a/apis/vcloud/src/main/java/org/jclouds/vcloud/functions/VAppTemplatesInOrg.java
+++ b/apis/vcloud/src/main/java/org/jclouds/vcloud/functions/VAppTemplatesInOrg.java
@@ -25,6 +25,7 @@ import static com.google.common.collect.Iterables.filter;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.jclouds.util.Iterables2;
 import org.jclouds.vcloud.domain.CatalogItem;
 import org.jclouds.vcloud.domain.Org;
 import org.jclouds.vcloud.domain.Status;
@@ -53,7 +54,7 @@ public class VAppTemplatesInOrg implements Function<Org, Iterable<VAppTemplate>>
    @Override
    public Iterable<VAppTemplate> apply(Org from) {
       Iterable<CatalogItem> catalogs = allCatalogItemsInOrg.apply(from);
-      Iterable<VAppTemplate> vAppTemplates = vAppTemplatesForCatalogItems.apply(catalogs);
+      Iterable<VAppTemplate> vAppTemplates = Iterables2.concreteCopy(vAppTemplatesForCatalogItems.apply(catalogs));
       return filter(vAppTemplates, and(notNull(), new Predicate<VAppTemplate>(){
 
          //TODO: test this

--- a/apis/vcloud/src/main/java/org/jclouds/vcloud/suppliers/VAppTemplatesSupplier.java
+++ b/apis/vcloud/src/main/java/org/jclouds/vcloud/suppliers/VAppTemplatesSupplier.java
@@ -69,8 +69,8 @@ public class VAppTemplatesSupplier implements Supplier<Set<VAppTemplate>> {
    @Override
    public Set<VAppTemplate> get() {
       Iterable<Org> orgs = checkNotNull(orgMap.get().values(), "orgs");
-      Iterable<Iterable<VAppTemplate>> images = transformParallel(orgs,
-               new Function<Org, Future<Iterable<VAppTemplate>>>() {
+      Iterable<? extends Iterable<VAppTemplate>> images = transformParallel(orgs,
+               new Function<Org, Future<? extends Iterable<VAppTemplate>>>() {
 
                   @Override
                   public Future<Iterable<VAppTemplate>> apply(final Org from) {

--- a/apis/vcloud/src/test/java/org/jclouds/vcloud/internal/BaseVCloudAsyncClientTest.java
+++ b/apis/vcloud/src/test/java/org/jclouds/vcloud/internal/BaseVCloudAsyncClientTest.java
@@ -43,6 +43,7 @@ import org.jclouds.vcloud.VCloudMediaType;
 import org.jclouds.vcloud.VCloudVersionsClient;
 import org.jclouds.vcloud.config.VCloudRestClientModule;
 import org.jclouds.vcloud.domain.AllocationModel;
+import org.jclouds.vcloud.domain.CatalogItem;
 import org.jclouds.vcloud.domain.Org;
 import org.jclouds.vcloud.domain.ReferenceType;
 import org.jclouds.vcloud.domain.Task;
@@ -257,11 +258,11 @@ public abstract class BaseVCloudAsyncClientTest<T> extends BaseAsyncClientTest<T
          }
 
          @Override
-         public Map<String, Map<String, Map<String, org.jclouds.vcloud.domain.CatalogItem>>> get() {
-            return ImmutableMap.<String, Map<String, Map<String, org.jclouds.vcloud.domain.CatalogItem>>> of(
+         public Map<String, Map<String, Map<String, CatalogItem>>> get() {
+            return ImmutableMap.<String, Map<String, Map<String, CatalogItem>>> of(
                   ORG_REF.getName(), ImmutableMap
-                        .<String, Map<String, org.jclouds.vcloud.domain.CatalogItem>> of(CATALOG_REF
-                              .getName(), ImmutableMap.<String, org.jclouds.vcloud.domain.CatalogItem> of(
+                        .<String, Map<String, CatalogItem>> of(CATALOG_REF
+                              .getName(), ImmutableMap.<String, CatalogItem> of(
                               "template",
                               new CatalogItemImpl("template", URI
                                     .create("https://vcenterprise.bluelock.com/api/v1.0/catalogItem/2"), "description",

--- a/blobstore/src/main/java/org/jclouds/blobstore/strategy/internal/FetchBlobMetadata.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/strategy/internal/FetchBlobMetadata.java
@@ -42,6 +42,7 @@ import org.jclouds.logging.Logger;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 
 /**
@@ -83,21 +84,21 @@ public class FetchBlobMetadata implements Function<PageSet<? extends StorageMeta
    public PageSet<? extends StorageMetadata> apply(PageSet<? extends StorageMetadata> in) {
       checkState(container != null, "container name should be initialized");
 
-      Iterable<BlobMetadata> returnv = transformParallel(Iterables.filter(in, new Predicate<StorageMetadata>() {
+      Iterable<BlobMetadata> returnv = Lists.newArrayList(transformParallel(Iterables.filter(in, new Predicate<StorageMetadata>() {
 
          @Override
          public boolean apply(StorageMetadata input) {
             return input.getType() == StorageType.BLOB;
          }
 
-      }), new Function<StorageMetadata, Future<BlobMetadata>>() {
+      }), new Function<StorageMetadata, Future<? extends BlobMetadata>>() {
 
          @Override
          public Future<BlobMetadata> apply(StorageMetadata from) {
             return ablobstore.blobMetadata(container, from.getName());
          }
 
-      }, userExecutor, maxTime, logger, String.format("getting metadata from containerName: %s", container));
+      }, userExecutor, maxTime, logger, String.format("getting metadata from containerName: %s", container)));
 
       return new PageSetImpl<BlobMetadata>(returnv, in.getNextMarker());
    }

--- a/blobstore/src/main/java/org/jclouds/blobstore/strategy/internal/GetAllBlobsInListAndRetryOnFailure.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/strategy/internal/GetAllBlobsInListAndRetryOnFailure.java
@@ -75,7 +75,7 @@ public class GetAllBlobsInListAndRetryOnFailure implements GetBlobsInListStrateg
 
    public Iterable<Blob> execute(final String container, ListContainerOptions options) {
       Iterable<? extends BlobMetadata> list = getAllBlobMetadata.execute(container, options);
-      return transformParallel(list, new Function<BlobMetadata, Future<Blob>>() {
+      return transformParallel(list, new Function<BlobMetadata, Future<? extends Blob>>() {
 
          @Override
          public Future<Blob> apply(BlobMetadata from) {

--- a/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/compute/suppliers/VCloudHardwareSupplier.java
+++ b/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/compute/suppliers/VCloudHardwareSupplier.java
@@ -69,8 +69,8 @@ public class VCloudHardwareSupplier implements Supplier<Set<? extends Hardware>>
    @Override
    public Set<? extends Hardware> get() {
       Iterable<? extends Org> orgs = checkNotNull(orgMap.get().values(), "orgs");
-      Iterable<Iterable<? extends Hardware>> sizes = transformParallel(orgs,
-               new Function<Org, Future<Iterable<? extends Hardware>>>() {
+      Iterable<? extends Iterable<? extends Hardware>> sizes = transformParallel(orgs,
+               new Function<Org, Future<? extends Iterable<? extends Hardware>>>() {
 
                   @Override
                   public Future<Iterable<? extends Hardware>> apply(final Org from) {

--- a/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/compute/suppliers/VCloudImageSupplier.java
+++ b/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/compute/suppliers/VCloudImageSupplier.java
@@ -69,8 +69,8 @@ public class VCloudImageSupplier implements Supplier<Set<? extends Image>> {
    @Override
    public Set<? extends Image> get() {
       Iterable<? extends Org> orgs = checkNotNull(orgMap.get().values(), "orgs");
-      Iterable<Iterable<? extends Image>> images = transformParallel(orgs,
-               new Function<Org, Future<Iterable<? extends Image>>>() {
+      Iterable<? extends Iterable<? extends Image>> images = transformParallel(orgs,
+               new Function<Org, Future<? extends Iterable<? extends Image>>>() {
 
                   @Override
                   public Future<Iterable<? extends Image>> apply(final Org from) {

--- a/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/functions/AllCatalogItemsInCatalog.java
+++ b/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/functions/AllCatalogItemsInCatalog.java
@@ -61,14 +61,14 @@ public class AllCatalogItemsInCatalog implements Function<Catalog, Iterable<? ex
    @Override
    public Iterable<? extends CatalogItem> apply(Catalog from) {
 
-      Iterable<CatalogItem> catalogItems = transformParallel(filter(from.values(), new Predicate<ReferenceType>() {
+      Iterable<? extends CatalogItem> catalogItems = transformParallel(filter(from.values(), new Predicate<ReferenceType>() {
 
          @Override
          public boolean apply(ReferenceType input) {
             return input.getType().equals(TerremarkVCloudMediaType.CATALOGITEM_XML);
          }
 
-      }), new Function<ReferenceType, Future<CatalogItem>>() {
+      }), new Function<ReferenceType, Future<? extends CatalogItem>>() {
 
          @SuppressWarnings("unchecked")
          @Override

--- a/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/functions/AllCatalogsInOrg.java
+++ b/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/functions/AllCatalogsInOrg.java
@@ -56,8 +56,8 @@ public class AllCatalogsInOrg implements Function<Org, Iterable<? extends Catalo
 
    @Override
    public Iterable<? extends Catalog> apply(final Org org) {
-      Iterable<Catalog> catalogs = transformParallel(org.getCatalogs().values(),
-            new Function<ReferenceType, Future<Catalog>>() {
+      Iterable<? extends Catalog> catalogs = transformParallel(org.getCatalogs().values(),
+            new Function<ReferenceType, Future<? extends Catalog>>() {
                @SuppressWarnings("unchecked")
                @Override
                public Future<Catalog> apply(ReferenceType from) {

--- a/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/functions/AllVDCsInOrg.java
+++ b/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/functions/AllVDCsInOrg.java
@@ -56,12 +56,11 @@ public class AllVDCsInOrg implements Function<Org, Iterable<? extends org.jcloud
    @Override
    public Iterable<? extends org.jclouds.trmk.vcloud_0_8.domain.VDC> apply(final Org org) {
 
-      Iterable<org.jclouds.trmk.vcloud_0_8.domain.VDC> catalogItems = transformParallel(org.getVDCs().values(),
-            new Function<ReferenceType, Future<org.jclouds.trmk.vcloud_0_8.domain.VDC>>() {
-               @SuppressWarnings("unchecked")
+      Iterable<? extends org.jclouds.trmk.vcloud_0_8.domain.VDC> catalogItems = transformParallel(org.getVDCs().values(),
+            new Function<ReferenceType, Future<? extends org.jclouds.trmk.vcloud_0_8.domain.VDC>>() {
                @Override
-               public Future<org.jclouds.trmk.vcloud_0_8.domain.VDC> apply(ReferenceType from) {
-                  return (Future<org.jclouds.trmk.vcloud_0_8.domain.VDC>) aclient.getVDC(from.getHref());
+               public Future<? extends org.jclouds.trmk.vcloud_0_8.domain.VDC> apply(ReferenceType from) {
+                  return aclient.getVDC(from.getHref());
                }
 
             }, executor, null, logger, "vdcs in org " + org.getName());

--- a/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/functions/OrgsForLocations.java
+++ b/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/functions/OrgsForLocations.java
@@ -79,12 +79,10 @@ public class OrgsForLocations implements Function<Iterable<? extends Location>, 
             return URI.create(from.getParent().getId());
          }
 
-      })), new Function<URI, Future<Org>>() {
-
-         @SuppressWarnings("unchecked")
+      })), new Function<URI, Future<? extends Org>>() {
          @Override
-         public Future<Org> apply(URI from) {
-            return (Future<Org>) aclient.getOrg(from);
+         public Future<? extends Org> apply(URI from) {
+            return aclient.getOrg(from);
          }
 
       }, executor, null, logger, "organizations for uris");

--- a/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/functions/OrgsForNames.java
+++ b/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/functions/OrgsForNames.java
@@ -53,12 +53,10 @@ public class OrgsForNames implements Function<Iterable<String>, Iterable<? exten
 
    @Override
    public Iterable<? extends Org> apply(Iterable<String> from) {
-      return transformParallel(from, new Function<String, Future<Org>>() {
-
-         @SuppressWarnings("unchecked")
+      return transformParallel(from, new Function<String, Future<? extends Org>>() {
          @Override
-         public Future<Org> apply(String from) {
-            return (Future<Org>) aclient.findOrgNamed(from);
+         public Future<? extends Org> apply(String from) {
+            return aclient.findOrgNamed(from);
          }
 
       }, executor, null, logger, "organizations for names");

--- a/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/functions/VAppTemplatesForCatalogItems.java
+++ b/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/functions/VAppTemplatesForCatalogItems.java
@@ -68,12 +68,10 @@ public class VAppTemplatesForCatalogItems implements
             return input.getEntity().getType().equals(TerremarkVCloudMediaType.VAPPTEMPLATE_XML);
          }
 
-      }), new Function<CatalogItem, Future<VAppTemplate>>() {
-
-         @SuppressWarnings("unchecked")
+      }), new Function<CatalogItem, Future<? extends VAppTemplate>>() {
          @Override
-         public Future<VAppTemplate> apply(CatalogItem from) {
-            return (Future<VAppTemplate>) aclient.getVAppTemplate(from.getEntity().getHref());
+         public Future<? extends VAppTemplate> apply(CatalogItem from) {
+            return aclient.getVAppTemplate(from.getEntity().getHref());
          }
 
       }, executor, null, logger, "vappTemplates in");

--- a/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/functions/VAppTemplatesForResourceEntities.java
+++ b/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/functions/VAppTemplatesForResourceEntities.java
@@ -69,12 +69,10 @@ public class VAppTemplatesForResourceEntities implements
             return input.getType().equals(TerremarkVCloudMediaType.VAPPTEMPLATE_XML);
          }
 
-      }), new Function<ReferenceType, Future<VAppTemplate>>() {
-
-         @SuppressWarnings("unchecked")
+      }), new Function<ReferenceType, Future<? extends VAppTemplate>>() {
          @Override
-         public Future<VAppTemplate> apply(ReferenceType from) {
-            return (Future<VAppTemplate>) aclient.getVAppTemplate(from.getHref());
+         public Future<? extends VAppTemplate> apply(ReferenceType from) {
+            return aclient.getVAppTemplate(from.getHref());
          }
 
       }, executor, null, logger, "vappTemplates in");

--- a/compute/src/main/java/org/jclouds/compute/internal/BaseComputeService.java
+++ b/compute/src/main/java/org/jclouds/compute/internal/BaseComputeService.java
@@ -238,7 +238,7 @@ public class BaseComputeService implements ComputeService {
    public Set<? extends NodeMetadata> destroyNodesMatching(Predicate<NodeMetadata> filter) {
       logger.debug(">> destroying nodes matching(%s)", filter);
       Set<NodeMetadata> set = newLinkedHashSet(filter(transformParallel(nodesMatchingFilterAndNotTerminated(filter),
-            new Function<NodeMetadata, Future<NodeMetadata>>() {
+            new Function<NodeMetadata, Future<? extends NodeMetadata>>() {
 
                // TODO make an async interface instead of re-wrapping
                @Override
@@ -403,7 +403,7 @@ public class BaseComputeService implements ComputeService {
    public void rebootNodesMatching(Predicate<NodeMetadata> filter) {
       logger.debug(">> rebooting nodes matching(%s)", filter);
       transformParallel(nodesMatchingFilterAndNotTerminatedExceptionIfNotFound(filter),
-            new Function<NodeMetadata, Future<Void>>() {
+            new Function<NodeMetadata, Future<? extends Void>>() {
                // TODO use native async
                @Override
                public Future<Void> apply(NodeMetadata from) {
@@ -434,7 +434,7 @@ public class BaseComputeService implements ComputeService {
    public void resumeNodesMatching(Predicate<NodeMetadata> filter) {
       logger.debug(">> resuming nodes matching(%s)", filter);
       transformParallel(nodesMatchingFilterAndNotTerminatedExceptionIfNotFound(filter),
-            new Function<NodeMetadata, Future<Void>>() {
+            new Function<NodeMetadata, Future<? extends Void>>() {
                // TODO use native async
                @Override
                public Future<Void> apply(NodeMetadata from) {
@@ -465,7 +465,7 @@ public class BaseComputeService implements ComputeService {
    public void suspendNodesMatching(Predicate<NodeMetadata> filter) {
       logger.debug(">> suspending nodes matching(%s)", filter);
       transformParallel(nodesMatchingFilterAndNotTerminatedExceptionIfNotFound(filter),
-            new Function<NodeMetadata, Future<Void>>() {
+            new Function<NodeMetadata, Future<? extends Void>>() {
                // TODO use native async
                @Override
                public Future<Void> apply(NodeMetadata from) {
@@ -649,7 +649,7 @@ public class BaseComputeService implements ComputeService {
    }
 
    private final class TransformNodesIntoInitializedScriptRunners implements
-         Function<NodeMetadata, Future<RunScriptOnNode>> {
+         Function<NodeMetadata, Future<? extends RunScriptOnNode>> {
       private final Map<NodeMetadata, Exception> badNodes;
       private final Statement script;
       private final RunScriptOptions options;

--- a/core/src/main/java/org/jclouds/util/Iterables2.java
+++ b/core/src/main/java/org/jclouds/util/Iterables2.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.util;
+
+import com.google.common.collect.ImmutableSortedSet;
+
+/**
+ * General utilities used in jclouds code for {@link Iterable Iterables}.
+ * 
+ * @author danikov
+ */
+public class Iterables2 {
+
+   /**
+    * Copies the contents of a wildcarded {@link Iterable} into a concrete {@link Iterable} of the left bound
+    * 
+    * @param unboundedValues wildcarded source {@link Iterable}
+    * @return concrete-typed copy of the source
+    */
+   public static <T> Iterable<T> concreteCopy(Iterable<? extends T> unboundedValues) {
+      return ImmutableSortedSet.copyOf(unboundedValues);
+   }
+   
+}

--- a/core/src/main/java/org/jclouds/util/Maps2.java
+++ b/core/src/main/java/org/jclouds/util/Maps2.java
@@ -154,5 +154,15 @@ public class Maps2 {
        }
        return result;
    }
+   
+   /**
+    * Covariant compatible version
+    * 
+    * @see {@link Maps#uniqueIndex(Iterable, Function)}
+    */
+   public static <K, V> ImmutableMap<K, V> uniqueIndex(
+         Iterable<? extends V> values, Function<? super V, ? extends K> keyFunction) {
+      return uniqueIndex(values, keyFunction);
+   }
 
 }

--- a/core/src/test/java/org/jclouds/concurrent/FutureIterablesTest.java
+++ b/core/src/test/java/org/jclouds/concurrent/FutureIterablesTest.java
@@ -43,7 +43,7 @@ public class FutureIterablesTest {
       final AtomicInteger counter = new AtomicInteger();
 
       try {
-         transformParallel(ImmutableSet.of("hello", "goodbye"), new Function<String, Future<String>>() {
+         transformParallel(ImmutableSet.of("hello", "goodbye"), new Function<String, Future<? extends String>>() {
 
             @Override
             public Future<String> apply(String input) {
@@ -63,7 +63,7 @@ public class FutureIterablesTest {
       final AtomicInteger counter = new AtomicInteger();
 
       try {
-         transformParallel(ImmutableSet.of("hello", "goodbye"), new Function<String, Future<String>>() {
+         transformParallel(ImmutableSet.of("hello", "goodbye"), new Function<String, Future<? extends String>>() {
 
             @Override
             public Future<String> apply(String input) {

--- a/labs/elb/src/main/java/org/jclouds/elb/loadbalancer/strategy/ELBListLoadBalancersStrategy.java
+++ b/labs/elb/src/main/java/org/jclouds/elb/loadbalancer/strategy/ELBListLoadBalancersStrategy.java
@@ -74,14 +74,14 @@ public class ELBListLoadBalancersStrategy implements ListLoadBalancersStrategy {
    }
 
    @Override
-   public Iterable<? extends LoadBalancerMetadata> listLoadBalancers() {
+   public Iterable<LoadBalancerMetadata> listLoadBalancers() {
       Iterable<? extends LoadBalancer> loadBalancers;
       Set<String> regions = this.regions.get();
       if (regions.size() > 0)
-         loadBalancers = concat(transformParallel(regions, new Function<String, Future<Set<? extends LoadBalancer>>>() {
+         loadBalancers = concat(transformParallel(regions, new Function<String, Future<? extends Set<? extends LoadBalancer>>>() {
 
             @Override
-            public ListenableFuture<Set<? extends LoadBalancer>> apply(String from) {
+            public ListenableFuture<? extends Set<? extends LoadBalancer>> apply(String from) {
                return aclient.describeLoadBalancersInRegion(from);
             }
 

--- a/labs/glesys/src/main/java/org/jclouds/glesys/compute/GleSYSComputeServiceAdapter.java
+++ b/labs/glesys/src/main/java/org/jclouds/glesys/compute/GleSYSComputeServiceAdapter.java
@@ -62,6 +62,7 @@ import org.jclouds.glesys.options.DestroyServerOptions;
 import org.jclouds.location.predicates.LocationPredicates;
 import org.jclouds.logging.Logger;
 import org.jclouds.predicates.RetryablePredicate;
+import org.jclouds.util.Iterables2;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
@@ -196,13 +197,13 @@ public class GleSYSComputeServiceAdapter implements ComputeServiceAdapter<Server
 
    @Override
    public Iterable<ServerDetails> listNodes() {
-      return transformParallel(client.getServerClient().listServers(), new Function<Server, Future<ServerDetails>>() {
+      return Iterables2.concreteCopy(transformParallel(client.getServerClient().listServers(), new Function<Server, Future<? extends ServerDetails>>() {
          @Override
          public Future<ServerDetails> apply(Server from) {
             return aclient.getServerClient().getServerDetails(from.getId());
          }
 
-      }, userThreads, null, logger, "server details");
+      }, userThreads, null, logger, "server details"));
    }
 
    @Override

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/strategy/AWSEC2ListNodesStrategy.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/strategy/AWSEC2ListNodesStrategy.java
@@ -69,12 +69,10 @@ public class AWSEC2ListNodesStrategy extends EC2ListNodesStrategy {
    @Override
    protected Iterable<? extends RunningInstance> pollRunningInstances() {
       Iterable<? extends AWSRunningInstance> spots = filter(transform(concat(transformParallel(regions.get(),
-               new Function<String, Future<Set<SpotInstanceRequest>>>() {
-
-                  @SuppressWarnings("unchecked")
+               new Function<String, Future<? extends Set<SpotInstanceRequest>>>() {
                   @Override
-                  public Future<Set<SpotInstanceRequest>> apply(String from) {
-                     return (Future<Set<SpotInstanceRequest>>) client.getSpotInstanceServices()
+                  public Future<? extends Set<SpotInstanceRequest>> apply(String from) {
+                     return client.getSpotInstanceServices()
                               .describeSpotInstanceRequestsInRegion(from);
                   }
 


### PR DESCRIPTION
as you may be aware, to allow covariant return types when using generics, you require wildcards. as such, when trying to port the 1.0 functions to vcloud director 1.5, the covariant return types on some of the clients (e.g. CatalogClient.getCatalog() ) threw a spanner in the works.

result of changing FutureIterables to be compatible was this class. problem is, it changes all the call sites and potentially is a wide-sweeping change. sadly, the type-erasure means they can't be included polymorphically along side the existing methods. it's ugly to have an old/new version of the class as well, so I'm not sure if and how to introduce the change.

on the plus side, it eliminates some unchecked exceptions and I believe it's a good improvement to the code
