### PR TITLE
Issue 830: vCloud Director ApiMetadata

### DIFF
--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/VCloudDirectorApiMetadata.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/VCloudDirectorApiMetadata.java
@@ -17,6 +17,7 @@
  * under the License.
  */
 package org.jclouds.vcloud.director.v1_5;
+
 import static org.jclouds.Constants.PROPERTY_SESSION_INTERVAL;
 import static org.jclouds.vcloud.director.v1_5.VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_TIMEOUT_TASK_COMPLETED;
 import static org.jclouds.vcloud.director.v1_5.VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_VERSION_SCHEMA;
@@ -36,7 +37,7 @@ import org.jclouds.vcloud.director.v1_5.user.VCloudDirectorClient;
 import com.google.common.reflect.TypeToken;
 
 /**
- * Implementation of {@link ApiMetadata} for VCloudDirector 1.0 API
+ * Implementation of {@link ApiMetadata} for VCloudDirector 1.5 API
  * 
  * @author Adrian Cole
  */
@@ -82,14 +83,13 @@ public class VCloudDirectorApiMetadata
 
       protected Builder() {
          super(VCloudDirectorClient.class, VCloudDirectorAsyncClient.class);
-          id("vcloud")
-         .name("VCloud Director 1.5 API")
+          id("vcloud-director")
+         .name("vCloud Director 1.5 API")
          .type(ApiType.COMPUTE)
          .identityName("User at Organization (user@org)")
          .credentialName("Password")
          .documentation(URI.create("http://www.vmware.com/support/pubs/vcd_pubs.html"))
          .version("1.5")
-         .defaultEndpoint("https://vcloudbeta.bluelock.com/api")
          .defaultProperties(VCloudDirectorApiMetadata.defaultProperties())
          .context(TypeToken.of(VCloudDirectorContext.class))
          .contextBuilder(TypeToken.of(VCloudDirectorContextBuilder.class));

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/VCloudDirectorContextBuilder.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/VCloudDirectorContextBuilder.java
@@ -54,6 +54,7 @@ public class VCloudDirectorContextBuilder
    // modules.add(new VCloudDirectorComputeServiceContextModule());
    // }
 
+   @Override
    protected void addClientModule(List<Module> modules) {
       modules.add(new VCloudDirectorRestClientModule());
    }

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/internal/BaseVCloudDirectorExpectTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/internal/BaseVCloudDirectorExpectTest.java
@@ -25,12 +25,10 @@ import java.net.URI;
 import java.util.Properties;
 
 import org.jclouds.Constants;
-import org.jclouds.apis.ApiMetadata;
 import org.jclouds.date.DateService;
 import org.jclouds.http.HttpRequest;
 import org.jclouds.http.HttpResponse;
 import org.jclouds.rest.internal.BaseRestClientExpectTest;
-import org.jclouds.vcloud.director.v1_5.VCloudDirectorApiMetadata;
 import org.jclouds.vcloud.director.v1_5.VCloudDirectorMediaType;
 import org.jclouds.vcloud.director.v1_5.domain.Reference;
 import org.testng.annotations.BeforeGroups;
@@ -41,7 +39,7 @@ import com.google.common.collect.Multimap;
 import com.google.inject.Guice;
 
 /**
- * Base class for writing KeyStone Rest Client Expect tests
+ * Base class for writing vCloud Director REST client expect tests.
  * 
  * @author Adrian Cole
  */
@@ -71,6 +69,7 @@ public abstract class BaseVCloudDirectorExpectTest<T> extends BaseRestClientExpe
    public Properties setupProperties() {
       Properties props = new Properties();
       props.put(Constants.PROPERTY_MAX_RETRIES, 1);
+      props.put(Constants.PROPERTY_ENDPOINT, endpoint);
       return props;
    }
    
@@ -252,10 +251,4 @@ public abstract class BaseVCloudDirectorExpectTest<T> extends BaseRestClientExpe
    public URI toAdminUri(URI uri) {
       return Reference.builder().href(uri).build().toAdminReference(endpoint).getHref();
    }
-   
-   @Override
-   protected ApiMetadata<?, ?, ?, ?> createApiMetadata() {
-      return new VCloudDirectorApiMetadata();
-   }
-   
 }

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/internal/BaseVCloudDirectorRestClientExpectTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/internal/BaseVCloudDirectorRestClientExpectTest.java
@@ -21,10 +21,8 @@ package org.jclouds.vcloud.director.v1_5.internal;
 import org.jclouds.vcloud.director.v1_5.user.VCloudDirectorClient;
 
 /**
- * Base class for writing KeyStone Rest Client Expect tests
- * 
  * @author Adrian Cole
  */
-public abstract class BaseVCloudDirectorRestClientExpectTest extends BaseVCloudDirectorExpectTest<VCloudDirectorClient>  {
+public abstract class BaseVCloudDirectorRestClientExpectTest extends BaseVCloudDirectorExpectTest<VCloudDirectorClient> {
 
 }

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/internal/VCloudDirectorAdminClientExpectTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/internal/VCloudDirectorAdminClientExpectTest.java
@@ -29,7 +29,6 @@ import com.google.common.base.Function;
 import com.google.inject.Module;
 
 /**
- * 
  * @author Adrian Cole
  */
 public abstract class VCloudDirectorAdminClientExpectTest extends


### PR DESCRIPTION
Remove default endpoint from the ApiMetadata implementation, since it pointed at the Bluelock beta site. Instead, added it as an override property in the expect test parent class.
