### PR TITLE
Throw return value instead of returning null

### DIFF
--- a/apis/byon/src/main/java/org/jclouds/byon/suppliers/SupplyFromProviderURIOrNodesProperty.java
+++ b/apis/byon/src/main/java/org/jclouds/byon/suppliers/SupplyFromProviderURIOrNodesProperty.java
@@ -81,8 +81,7 @@ public class SupplyFromProviderURIOrNodesProperty implements Supplier<InputStrea
          return input.toURL().openStream();
       } catch (IOException e) {
          logger.error(e, "URI could not be read: %s", url);
-         Throwables.propagate(e);
-         return null;
+         throw Throwables.propagate(e);
       }
    }
 

--- a/core/src/main/java/org/jclouds/collect/InputSupplierMap.java
+++ b/core/src/main/java/org/jclouds/collect/InputSupplierMap.java
@@ -70,8 +70,7 @@ public class InputSupplierMap<K, V> extends AbstractMap<K, V> {
       try {
          return (value != null || toMap.containsKey(key)) ? value.getInput() : null;
       } catch (IOException e) {
-         Throwables.propagate(e);
-         return null;
+         throw Throwables.propagate(e);
       }
    }
 
@@ -80,8 +79,7 @@ public class InputSupplierMap<K, V> extends AbstractMap<K, V> {
       try {
          return toMap.containsKey(key) ? toMap.remove(key).getInput() : null;
       } catch (IOException e) {
-         Throwables.propagate(e);
-         return null;
+         throw Throwables.propagate(e);
       }
    }
 
@@ -124,8 +122,7 @@ public class InputSupplierMap<K, V> extends AbstractMap<K, V> {
                      try {
                         return entry.getValue().getInput();
                      } catch (IOException e) {
-                        Throwables.propagate(e);
-                        return null;
+                        throw Throwables.propagate(e);
                      }
                   }
                };

--- a/core/src/main/java/org/jclouds/crypto/CryptoStreams.java
+++ b/core/src/main/java/org/jclouds/crypto/CryptoStreams.java
@@ -176,8 +176,7 @@ public class CryptoStreams {
       try {
          return digest(supplier, MessageDigest.getInstance("SHA1"));
       } catch (NoSuchAlgorithmException e) {
-         Throwables.propagate(e);
-         return null;
+         throw Throwables.propagate(e);
       }
    }
 
@@ -185,8 +184,7 @@ public class CryptoStreams {
       try {
          return sha1(ByteStreams.newInputStreamSupplier(in));
       } catch (IOException e) {
-         Throwables.propagate(e);
-         return null;
+         throw Throwables.propagate(e);
       }
    }
    
@@ -207,8 +205,7 @@ public class CryptoStreams {
       try {
          return digest(supplier, MessageDigest.getInstance("MD5"));
       } catch (NoSuchAlgorithmException e) {
-         Throwables.propagate(e);
-         return null;
+         throw Throwables.propagate(e);
       }
    }
 
@@ -216,8 +213,7 @@ public class CryptoStreams {
       try {
          return md5(ByteStreams.newInputStreamSupplier(in));
       } catch (IOException e) {
-         Throwables.propagate(e);
-         return null;
+         throw Throwables.propagate(e);
       }
    }
 

--- a/core/src/main/java/org/jclouds/crypto/Pems.java
+++ b/core/src/main/java/org/jclouds/crypto/Pems.java
@@ -169,8 +169,7 @@ public class Pems {
       try {
          return privateKeySpec(InputSuppliers.of(pem));
       } catch (IOException e) {
-         Throwables.propagate(e);
-         return null;
+         throw Throwables.propagate(e);
       }
    }
 

--- a/core/src/main/java/org/jclouds/http/config/SSLModule.java
+++ b/core/src/main/java/org/jclouds/http/config/SSLModule.java
@@ -91,8 +91,7 @@ public class SSLModule extends AbstractModule {
             sc.init(null, new TrustManager[] { trustAllCerts }, new SecureRandom());
             return sc;
          } catch (Exception e) {
-            Throwables.propagate(e);
-            return null;
+            throw Throwables.propagate(e);
          }
 
       }

--- a/core/src/main/java/org/jclouds/io/Payloads.java
+++ b/core/src/main/java/org/jclouds/io/Payloads.java
@@ -131,8 +131,7 @@ public class Payloads {
       try {
          return calculateMD5(payload, MessageDigest.getInstance("MD5"));
       } catch (NoSuchAlgorithmException e) {
-         Throwables.propagate(e);
-         return null;
+         throw Throwables.propagate(e);
       }
    }
 
@@ -160,8 +159,7 @@ public class Payloads {
       try {
          return calculateMD5(payloadEnclosing, MessageDigest.getInstance("MD5"));
       } catch (NoSuchAlgorithmException e) {
-         Throwables.propagate(e);
-         return null;
+         throw Throwables.propagate(e);
       }
    }
 }

--- a/core/src/main/java/org/jclouds/io/internal/BasePayloadSlicer.java
+++ b/core/src/main/java/org/jclouds/io/internal/BasePayloadSlicer.java
@@ -76,8 +76,7 @@ public class BasePayloadSlicer implements PayloadSlicer {
       try {
          return doSlice(new FileInputStream(content), offset, length);
       } catch (FileNotFoundException e) {
-         Throwables.propagate(e);
-         return null;
+         throw Throwables.propagate(e);
       }
    }
 

--- a/core/src/main/java/org/jclouds/io/payloads/FilePayload.java
+++ b/core/src/main/java/org/jclouds/io/payloads/FilePayload.java
@@ -47,8 +47,7 @@ public class FilePayload extends BasePayload<File> {
       try {
          return new FileInputStream(content);
       } catch (FileNotFoundException e) {
-         Throwables.propagate(e);
-         return null;
+         throw Throwables.propagate(e);
       }
    }
 

--- a/core/src/main/java/org/jclouds/io/payloads/InputStreamSupplierPayload.java
+++ b/core/src/main/java/org/jclouds/io/payloads/InputStreamSupplierPayload.java
@@ -48,8 +48,7 @@ public class InputStreamSupplierPayload extends BasePayload<InputSupplier<? exte
          toClose.add(returnVal);
          return returnVal;
       } catch (IOException e) {
-         Throwables.propagate(e);
-         return null;
+         throw Throwables.propagate(e);
       }
    }
 

--- a/core/src/main/java/org/jclouds/rest/internal/RestAnnotationProcessor.java
+++ b/core/src/main/java/org/jclouds/rest/internal/RestAnnotationProcessor.java
@@ -550,8 +550,7 @@ public class RestAnnotationProcessor<T> {
          utils.checkRequestHasRequiredProperties(request);
          return request;
       } catch (ExecutionException e) {
-         Throwables.propagate(e);
-         return null;
+         throw Throwables.propagate(e);
       }
    }
 

--- a/core/src/test/java/org/jclouds/json/BaseParserTest.java
+++ b/core/src/test/java/org/jclouds/json/BaseParserTest.java
@@ -58,8 +58,7 @@ public abstract class BaseParserTest<T, G> {
          return (Function<HttpResponse, T>) RestAnnotationProcessor.getTransformerForMethod(getClass()
                   .getMethod("expected"), i);
       } catch (Exception e) {
-         Throwables.propagate(e);
-         return null;
+         throw Throwables.propagate(e);
       }
    }
 

--- a/drivers/gae/src/test/java/org/jclouds/gae/AsyncGaeHttpCommandExecutorServiceIntegrationTest.java
+++ b/drivers/gae/src/test/java/org/jclouds/gae/AsyncGaeHttpCommandExecutorServiceIntegrationTest.java
@@ -90,8 +90,7 @@ public class AsyncGaeHttpCommandExecutorServiceIntegrationTest extends BaseHttpC
             try {
                return Futures.makeListenable(service.fetchAsync(fetch.toURL()), MoreExecutors.sameThreadExecutor());
             } catch (MalformedURLException e) {
-               Throwables.propagate(e);
-               return null;
+               throw Throwables.propagate(e);
             }
          }
 

--- a/labs/savvis-symphonyvpdc/src/main/java/org/jclouds/savvis/vpdc/binders/BaseBindVMSpecToXmlPayload.java
+++ b/labs/savvis-symphonyvpdc/src/main/java/org/jclouds/savvis/vpdc/binders/BaseBindVMSpecToXmlPayload.java
@@ -74,8 +74,7 @@ public abstract class BaseBindVMSpecToXmlPayload<T> extends BindToStringPayload 
          outputProperties.put(javax.xml.transform.OutputKeys.OMIT_XML_DECLARATION, "yes");
          return rootBuilder.asString(outputProperties);
       } catch (Exception e) {
-         Throwables.propagate(e);
-         return null;
+         throw Throwables.propagate(e);
       }
    }
 

--- a/labs/virtualbox/src/main/java/org/jclouds/virtualbox/functions/admin/FileDownloadFromURI.java
+++ b/labs/virtualbox/src/main/java/org/jclouds/virtualbox/functions/admin/FileDownloadFromURI.java
@@ -84,8 +84,7 @@ public class FileDownloadFromURI implements Function<URI, File> {
             return file;
          }
       } catch (Exception e) {
-         Throwables.propagate(e);
-         return null;
+         throw Throwables.propagate(e);
       }
    }
 }

--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/login/AdminAccess.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/login/AdminAccess.java
@@ -201,8 +201,7 @@ public class AdminAccess implements Statement {
                      grantSudoToAdminUser, authorizeAdminPublicKey, installAdminPrivateKey, resetLoginPassword,
                      cryptFunction);
          } catch (IOException e) {
-            Throwables.propagate(e);
-            return null;
+            throw Throwables.propagate(e);
          }
       }
    }


### PR DESCRIPTION
Throwables.propagate always throws its argument and throwing its
impossible return value better represents our intent than returning
null.
