### PR TITLE
Prefer checkNotNull when appropriate

### DIFF
--- a/compute/src/main/java/org/jclouds/compute/strategy/impl/AdaptingComputeServiceStrategies.java
+++ b/compute/src/main/java/org/jclouds/compute/strategy/impl/AdaptingComputeServiceStrategies.java
@@ -162,10 +162,10 @@ public class AdaptingComputeServiceStrategies<N, H, I, L> implements CreateNodeW
     */
    @Override
    public NodeMetadata createNodeWithGroupEncodedIntoName(String group, String name, Template template) {
-      checkState(group != null, "group (that which groups identical nodes together) must be specified");
-      checkState(name != null && name.indexOf(group) != -1, "name should have %s encoded into it", group);
-      checkState(template != null, "template was null");
-      checkState(template.getOptions() != null, "template options was null");
+      checkNotNull(group, "group (that which groups identical nodes together) must be specified");
+      checkNotNull(name, "name should have %s encoded into it", group);
+      checkNotNull(template, "template was null");
+      checkNotNull(template.getOptions(), "template options was null");
 
       NodeAndInitialCredentials<N> from = client.createNodeWithGroupEncodedIntoName(group, name, template);
       LoginCredentials fromNode = from.getCredentials();

--- a/core/src/main/java/org/jclouds/io/Payloads.java
+++ b/core/src/main/java/org/jclouds/io/Payloads.java
@@ -19,7 +19,6 @@
 package org.jclouds.io;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.io.ByteStreams.toByteArray;
 
 import java.io.File;
@@ -141,7 +140,7 @@ public class Payloads {
     * @see #calculateMD5(Payload, MessageDigest)
     */
    public static <T extends PayloadEnclosing> T calculateMD5(T payloadEnclosing, MessageDigest md5) throws IOException {
-      checkState(payloadEnclosing != null, "payloadEnclosing");
+      checkNotNull(payloadEnclosing, "payloadEnclosing");
       Payload newPayload = calculateMD5(payloadEnclosing.getPayload(), md5);
       if (newPayload != payloadEnclosing.getPayload())
          payloadEnclosing.setPayload(newPayload);


### PR DESCRIPTION
Calling checkNotNull on parameters better captures our intent.
