### PR TITLE
Remove unused transient blobstore methods

### DIFF
--- a/apis/swift/src/test/java/org/jclouds/openstack/swift/internal/StubSwiftAsyncClient.java
+++ b/apis/swift/src/test/java/org/jclouds/openstack/swift/internal/StubSwiftAsyncClient.java
@@ -98,7 +98,7 @@ public class StubSwiftAsyncClient implements CommonSwiftAsyncClient {
    }
 
    public ListenableFuture<Boolean> containerExists(final String container) {
-      return immediateFuture(blobStore.getContainerToBlobs().containsKey(container));
+      return blobStore.containerExists(container);
    }
 
    public ListenableFuture<Boolean> createContainer(String container) {
@@ -106,7 +106,7 @@ public class StubSwiftAsyncClient implements CommonSwiftAsyncClient {
    }
 
    public ListenableFuture<Boolean> deleteContainerIfEmpty(String container) {
-      return blobStore.deleteContainerImpl(container);
+      return blobStore.deleteContainerIfEmpty(container);
    }
 
    public ListenableFuture<Boolean> disableCDN(String container) {


### PR DESCRIPTION
Also make some helpers private.  Generally, make the transient
blobstore more similar to others.
