### PR TITLE
Improve use of Throwables.propagate

### DIFF
--- a/apis/filesystem/src/main/java/org/jclouds/filesystem/FilesystemAsyncBlobStore.java
+++ b/apis/filesystem/src/main/java/org/jclouds/filesystem/FilesystemAsyncBlobStore.java
@@ -262,9 +262,7 @@ public class FilesystemAsyncBlobStore extends BaseAsyncBlobStore {
                .build()));
          return metadata;
       } catch (Exception e) {
-         propagate(e);
-         assert false : "exception should have propagated: " + e;
-         return null;
+         throw propagate(e);
       }
    }
 

--- a/apis/vcloud/src/main/java/org/jclouds/vcloud/binders/BindCloneParamsToXmlPayload.java
+++ b/apis/vcloud/src/main/java/org/jclouds/vcloud/binders/BindCloneParamsToXmlPayload.java
@@ -122,9 +122,7 @@ public abstract class BindCloneParamsToXmlPayload<O extends CloneOptions> implem
       try {
          return getOptionClass().newInstance();
       } catch (Exception e) {
-         Throwables.propagate(e);
-         assert false : "unreachable code";
-         return null;
+         throw Throwables.propagate(e);
       }
    }
 

--- a/blobstore/src/main/java/org/jclouds/blobstore/TransientAsyncBlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/TransientAsyncBlobStore.java
@@ -251,9 +251,7 @@ public class TransientAsyncBlobStore extends BaseAsyncBlobStore {
          HttpUtils.copy(in.getContentMetadata(), out.getContentMetadata());
          return out;
       } catch (Exception e) {
-         propagate(e);
-         assert false : "exception should have propagated: " + e;
-         return null;
+         throw propagate(e);
       }
    }
 

--- a/core/src/main/java/org/jclouds/concurrent/RetryOnTimeOutExceptionSupplier.java
+++ b/core/src/main/java/org/jclouds/concurrent/RetryOnTimeOutExceptionSupplier.java
@@ -48,9 +48,7 @@ public class RetryOnTimeOutExceptionSupplier<T> implements Supplier<T> {
          } catch (Exception e) {
             if ((ex = Throwables2.getFirstThrowableOfType(e, TimeoutException.class)) != null)
                continue;
-            propagate(e);
-            assert false;
-            return null;
+            throw propagate(e);
          }
       }
       if (ex != null)

--- a/core/src/main/java/org/jclouds/http/internal/JavaUrlHttpCommandExecutorService.java
+++ b/core/src/main/java/org/jclouds/http/internal/JavaUrlHttpCommandExecutorService.java
@@ -115,8 +115,7 @@ public class JavaUrlHttpCommandExecutorService extends BaseHttpCommandExecutorSe
          in = bufferAndCloseStream(connection.getErrorStream());
       } catch (RuntimeException e) {
          closeQuietly(in);
-         propagate(e);
-         assert false : "should have propagated exception";
+         throw propagate(e);
       }
 
       int responseCode = connection.getResponseCode();

--- a/core/src/main/java/org/jclouds/rest/suppliers/SetAndThrowAuthorizationExceptionSupplier.java
+++ b/core/src/main/java/org/jclouds/rest/suppliers/SetAndThrowAuthorizationExceptionSupplier.java
@@ -56,9 +56,7 @@ public class SetAndThrowAuthorizationExceptionSupplier<T> implements Supplier<T>
             authException.set(aex);
             throw aex;
          }
-         propagate(e);
-         assert false : e;
-         return null;
+         throw propagate(e);
       }
    }
 

--- a/labs/virtualbox/src/main/java/org/jclouds/virtualbox/functions/RetrieveActiveBridgedInterfaces.java
+++ b/labs/virtualbox/src/main/java/org/jclouds/virtualbox/functions/RetrieveActiveBridgedInterfaces.java
@@ -84,8 +84,7 @@ public class RetrieveActiveBridgedInterfaces implements Function<NodeMetadata, L
          }
       } catch (SocketException e) {
          logger.error(e, "Problem in listing network interfaces.");
-         Throwables.propagate(e);
-         assert false;
+         throw Throwables.propagate(e);
       }
       return activeNetworkInterfaces;
    }
@@ -117,10 +116,8 @@ public class RetrieveActiveBridgedInterfaces implements Function<NodeMetadata, L
             		!networkInterface.isLoopback());
          } catch (SocketException e) {
             logger.error(e, "Problem in listing network interfaces.");
-            Throwables.propagate(e);
-            assert false;
+            throw Throwables.propagate(e);
          }
-         return false;
       }
    }
 }

--- a/sandbox-apis/libvirt/src/main/java/org/jclouds/libvirt/compute/LibvirtComputeService.java
+++ b/sandbox-apis/libvirt/src/main/java/org/jclouds/libvirt/compute/LibvirtComputeService.java
@@ -115,14 +115,7 @@ public class LibvirtComputeService extends BaseComputeService {
          storageVol.delete(0);
          client.domainLookupByUUIDString(id).undefine();
       } catch (Exception e) {
-         propogate(e);
+         Throwables.propagate(e);
       }
    }
-
-   protected <T> T propogate(Exception e) {
-      Throwables.propagate(e);
-      assert false;
-      return null;
-   }
-
 }

--- a/sandbox-apis/libvirt/src/main/java/org/jclouds/libvirt/compute/functions/DomainToHardware.java
+++ b/sandbox-apis/libvirt/src/main/java/org/jclouds/libvirt/compute/functions/DomainToHardware.java
@@ -83,22 +83,16 @@ public class DomainToHardware implements Function<Domain, Hardware> {
 			}
 			builder.volumes((List<Volume>) volumes);
 		} catch (LibvirtException e) {
-			propagate(e);
+			Throwables.propagate(e);
 		} catch (XPathExpressionException e) {
-			propagate(e);
+			Throwables.propagate(e);
 		} catch (ParserConfigurationException e) {
-			propagate(e);
+			Throwables.propagate(e);
 		} catch (SAXException e) {
-			propagate(e);
+			Throwables.propagate(e);
 		} catch (IOException e) {
-			propagate(e);
+			Throwables.propagate(e);
 		}
 		return builder.build();
-	}
-	
-	protected <T> T propagate(Exception e) {
-		Throwables.propagate(e);
-		assert false;
-		return null;
 	}
 }

--- a/sandbox-apis/libvirt/src/main/java/org/jclouds/libvirt/compute/strategy/LibvirtComputeServiceAdapter.java
+++ b/sandbox-apis/libvirt/src/main/java/org/jclouds/libvirt/compute/strategy/LibvirtComputeServiceAdapter.java
@@ -116,9 +116,9 @@ public class LibvirtComputeServiceAdapter implements ComputeServiceAdapter<Domai
          credentialStore.put(domain.getUUIDString() + "", new Credentials("identity", "credential"));
          return newDomain;
       } catch (LibvirtException e) {
-         return propogate(e);
+         throw Throwables.propagate(e);
       } catch (Exception e) {
-         return propogate(e);
+         throw Throwables.propagate(e);
       }
    }
 
@@ -138,7 +138,7 @@ public class LibvirtComputeServiceAdapter implements ComputeServiceAdapter<Domai
          }
          return images;
       } catch (Exception e) {
-         return propogate(e);
+         throw Throwables.propagate(e);
       }
    }
 
@@ -151,7 +151,7 @@ public class LibvirtComputeServiceAdapter implements ComputeServiceAdapter<Domai
          }
          return domains;
       } catch (LibvirtException e) {
-         return propogate(e);
+         throw Throwables.propagate(e);
       }
    }
 
@@ -168,7 +168,7 @@ public class LibvirtComputeServiceAdapter implements ComputeServiceAdapter<Domai
       } catch (LibvirtException e) {
          if (e.getMessage().indexOf("Domain not found: no domain with matching uuid") != -1)
             return null;
-         propogate(e);
+         Throwables.propagate(e);
       }
       return d;
    }
@@ -187,9 +187,9 @@ public class LibvirtComputeServiceAdapter implements ComputeServiceAdapter<Domai
          client.domainLookupByUUIDString(id).undefine();
 
       } catch (LibvirtException e) {
-         propogate(e);
+         Throwables.propagate(e);
       } catch (Exception e) {
-         propogate(e);
+         Throwables.propagate(e);
       }
    }
 
@@ -198,20 +198,8 @@ public class LibvirtComputeServiceAdapter implements ComputeServiceAdapter<Domai
       try {
          client.domainLookupByUUIDString(id).reboot(0);
       } catch (LibvirtException e) {
-         propogate(e);
+         Throwables.propagate(e);
       }
-   }
-
-   protected <T> T propogate(LibvirtException e) {
-      Throwables.propagate(e);
-      assert false;
-      return null;
-   }
-
-   protected <T> T propogate(Exception e) {
-      Throwables.propagate(e);
-      assert false;
-      return null;
    }
 
    private static StorageVol cloneVolume(StoragePool storagePool, StorageVol from) throws LibvirtException,
@@ -224,7 +212,7 @@ public class LibvirtComputeServiceAdapter implements ComputeServiceAdapter<Domai
       try {
          client.domainLookupByUUIDString(id).resume();
       } catch (LibvirtException e) {
-         propogate(e);
+         Throwables.propagate(e);
       }
    }
 
@@ -233,7 +221,7 @@ public class LibvirtComputeServiceAdapter implements ComputeServiceAdapter<Domai
       try {
          client.domainLookupByUUIDString(id).suspend();
       } catch (LibvirtException e) {
-         propogate(e);
+         Throwables.propagate(e);
       }
    }
 

--- a/sandbox-drivers/asynchttpclient/src/main/java/org/jclouds/http/ning/NingHttpCommandExecutorService.java
+++ b/sandbox-drivers/asynchttpclient/src/main/java/org/jclouds/http/ning/NingHttpCommandExecutorService.java
@@ -192,8 +192,7 @@ public class NingHttpCommandExecutorService implements HttpCommandExecutorServic
             in = BaseHttpCommandExecutorService.consumeOnClose(nativeResponse.getResponseBodyAsStream());
          } catch (IOException e) {
             Closeables.closeQuietly(in);
-            propagate(e);
-            assert false : "should have propagated exception";
+            throw propagate(e);
          }
 
          Payload payload = in != null ? Payloads.newInputStreamPayload(in) : null;


### PR DESCRIPTION
Throwing the return value removes some unneeded asserts and return
statements.  Also remove some useless and misspelled propogate
wrappers.
