### PR TITLE
Eliminate Throwables2.propagateOrNull

### DIFF
--- a/apis/atmos/src/main/java/org/jclouds/atmos/functions/ReturnEndpointIfAlreadyExists.java
+++ b/apis/atmos/src/main/java/org/jclouds/atmos/functions/ReturnEndpointIfAlreadyExists.java
@@ -19,7 +19,6 @@
 package org.jclouds.atmos.functions;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.jclouds.util.Throwables2.propagateOrNull;
 
 import java.net.URI;
 
@@ -30,6 +29,7 @@ import org.jclouds.rest.InvocationContext;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 
 /**
  * 
@@ -44,7 +44,7 @@ public class ReturnEndpointIfAlreadyExists implements Function<Exception, URI>,
       if (checkNotNull(from, "exception") instanceof KeyAlreadyExistsException) {
          return endpoint;
       }
-      return URI.class.cast(propagateOrNull(from));
+      throw Throwables.propagate(from);
    }
 
    @Override

--- a/apis/deltacloud/src/main/java/org/jclouds/deltacloud/functions/ReturnVoidOnRedirectedDelete.java
+++ b/apis/deltacloud/src/main/java/org/jclouds/deltacloud/functions/ReturnVoidOnRedirectedDelete.java
@@ -18,8 +18,6 @@
  */
 package org.jclouds.deltacloud.functions;
 
-import static org.jclouds.util.Throwables2.propagateOrNull;
-
 import javax.inject.Singleton;
 import javax.ws.rs.HttpMethod;
 
@@ -27,6 +25,7 @@ import org.jclouds.http.HttpResponseException;
 import org.jclouds.util.Throwables2;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 
 /**
  * When a delete operation is performed, Deltacloud returns 302.
@@ -42,6 +41,6 @@ public class ReturnVoidOnRedirectedDelete implements Function<Exception, Void> {
             && exception.getResponse().getStatusCode() == 302) {
          return null;
       }
-      return Void.class.cast(propagateOrNull(from));
+      throw Throwables.propagate(from);
    }
 }

--- a/apis/ec2/src/main/java/org/jclouds/ec2/functions/ReturnVoidOnVolumeAvailable.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/functions/ReturnVoidOnVolumeAvailable.java
@@ -18,13 +18,12 @@
  */
 package org.jclouds.ec2.functions;
 
-import static org.jclouds.util.Throwables2.propagateOrNull;
-
 import javax.inject.Singleton;
 
 import org.jclouds.aws.AWSResponseException;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 
 @Singleton
 public class ReturnVoidOnVolumeAvailable implements Function<Exception, Void> {
@@ -36,7 +35,7 @@ public class ReturnVoidOnVolumeAvailable implements Function<Exception, Void> {
                   && e.getError().getCode().contains("available"))
             return null;
       }
-      return Void.class.cast(propagateOrNull(from));
+      throw Throwables.propagate(from);
    }
 
 }

--- a/apis/s3/src/main/java/org/jclouds/s3/functions/ReturnFalseIfBucketAlreadyOwnedByYouOrIllegalState.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/functions/ReturnFalseIfBucketAlreadyOwnedByYouOrIllegalState.java
@@ -18,14 +18,13 @@
  */
 package org.jclouds.s3.functions;
 
-import static org.jclouds.util.Throwables2.propagateOrNull;
-
 import javax.inject.Singleton;
 
 import org.jclouds.aws.AWSResponseException;
 import org.jclouds.util.Throwables2;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 
 /**
  * 
@@ -42,6 +41,6 @@ public class ReturnFalseIfBucketAlreadyOwnedByYouOrIllegalState implements Funct
       } else if (Throwables2.getFirstThrowableOfType(from, IllegalStateException.class) != null) {
          return false;
       }
-      return Boolean.class.cast(propagateOrNull(from));
+      throw Throwables.propagate(from);
    }
 }

--- a/apis/s3/src/main/java/org/jclouds/s3/functions/ReturnTrueOn404OrNotFoundFalseOnIllegalState.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/functions/ReturnTrueOn404OrNotFoundFalseOnIllegalState.java
@@ -21,13 +21,13 @@ package org.jclouds.s3.functions;
 import static com.google.common.base.Predicates.equalTo;
 import static org.jclouds.http.HttpUtils.returnValueOnCodeOrNull;
 import static org.jclouds.util.Throwables2.getFirstThrowableOfType;
-import static org.jclouds.util.Throwables2.propagateOrNull;
 
 import javax.inject.Singleton;
 
 import org.jclouds.blobstore.ContainerNotFoundException;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 
 /**
  * 
@@ -46,6 +46,6 @@ public class ReturnTrueOn404OrNotFoundFalseOnIllegalState implements Function<Ex
       if (returnValueOnCodeOrNull(from, true, equalTo(404)) != null)
          return true;
 
-      return Boolean.class.cast(propagateOrNull(from));
+      throw Throwables.propagate(from);
    }
 }

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/functions/ReturnTrueOn404FalseOn409.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/functions/ReturnTrueOn404FalseOn409.java
@@ -21,17 +21,19 @@ package org.jclouds.openstack.swift.functions;
 import static com.google.common.base.Predicates.in;
 import static com.google.common.collect.ImmutableSet.of;
 import static org.jclouds.http.HttpUtils.returnValueOnCodeOrNull;
-import static org.jclouds.util.Throwables2.propagateOrNull;
 
 import javax.inject.Singleton;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 
 @Singleton
 public class ReturnTrueOn404FalseOn409 implements Function<Exception, Boolean> {
 
    public Boolean apply(Exception from) {
       Boolean returnVal = returnValueOnCodeOrNull(from, true, in(of(404, 409)));
-      return returnVal != null ? returnVal : Boolean.class.cast(propagateOrNull(from));
+      if (returnVal != null)
+         return returnVal;
+      throw Throwables.propagate(from);
    }
 }

--- a/apis/vcloud/src/main/java/org/jclouds/vcloud/functions/VAppTemplatesForCatalogItems.java
+++ b/apis/vcloud/src/main/java/org/jclouds/vcloud/functions/VAppTemplatesForCatalogItems.java
@@ -20,7 +20,6 @@ package org.jclouds.vcloud.functions;
 
 import static com.google.common.collect.Iterables.filter;
 import static org.jclouds.concurrent.FutureIterables.transformParallel;
-import static org.jclouds.util.Throwables2.propagateOrNull;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -44,6 +43,7 @@ import org.jclouds.vcloud.domain.VAppTemplate;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
+import com.google.common.base.Throwables;
 
 /**
  * @author Adrian Cole
@@ -64,7 +64,7 @@ public class VAppTemplatesForCatalogItems implements Function<Iterable<CatalogIt
          if (from instanceof AuthorizationException) {
             return null;
          }
-         return propagateOrNull(from);
+         throw Throwables.propagate(from);
       }
    }
 

--- a/blobstore/src/main/java/org/jclouds/blobstore/functions/ReturnFalseOnContainerNotFound.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/functions/ReturnFalseOnContainerNotFound.java
@@ -19,13 +19,13 @@
 package org.jclouds.blobstore.functions;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.jclouds.util.Throwables2.propagateOrNull;
 
 import javax.inject.Singleton;
 
 import org.jclouds.blobstore.ContainerNotFoundException;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 
 /**
  * 
@@ -38,6 +38,6 @@ public class ReturnFalseOnContainerNotFound implements Function<Exception, Boole
       if (checkNotNull(from, "exception") instanceof ContainerNotFoundException) {
          return false;
       }
-      return Boolean.class.cast(propagateOrNull(from));
+      throw Throwables.propagate(from);
    }
 }

--- a/blobstore/src/main/java/org/jclouds/blobstore/functions/ReturnFalseOnKeyNotFound.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/functions/ReturnFalseOnKeyNotFound.java
@@ -18,13 +18,12 @@
  */
 package org.jclouds.blobstore.functions;
 
-import static org.jclouds.util.Throwables2.propagateOrNull;
-
 import javax.inject.Singleton;
 
 import org.jclouds.blobstore.KeyNotFoundException;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 
 /**
  * 
@@ -37,6 +36,6 @@ public class ReturnFalseOnKeyNotFound implements Function<Exception, Boolean> {
       if (from instanceof KeyNotFoundException) {
          return false;
       }
-      return Boolean.class.cast(propagateOrNull(from));
+      throw Throwables.propagate(from);
    }
 }

--- a/blobstore/src/main/java/org/jclouds/blobstore/functions/ReturnNullOnContainerNotFound.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/functions/ReturnNullOnContainerNotFound.java
@@ -18,13 +18,12 @@
  */
 package org.jclouds.blobstore.functions;
 
-import static org.jclouds.util.Throwables2.propagateOrNull;
-
 import javax.inject.Singleton;
 
 import org.jclouds.blobstore.ContainerNotFoundException;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 
 /**
  * 
@@ -37,6 +36,6 @@ public class ReturnNullOnContainerNotFound implements Function<Exception, Object
       if (from instanceof ContainerNotFoundException) {
          return null;
       }
-      return propagateOrNull(from);
+      throw Throwables.propagate(from);
    }
 }

--- a/blobstore/src/main/java/org/jclouds/blobstore/functions/ReturnNullOnKeyNotFound.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/functions/ReturnNullOnKeyNotFound.java
@@ -18,13 +18,12 @@
  */
 package org.jclouds.blobstore.functions;
 
-import static org.jclouds.util.Throwables2.propagateOrNull;
-
 import javax.inject.Singleton;
 
 import org.jclouds.blobstore.KeyNotFoundException;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 
 /**
  * 
@@ -37,6 +36,6 @@ public class ReturnNullOnKeyNotFound implements Function<Exception, Object> {
       if (from instanceof KeyNotFoundException) {
          return null;
       }
-      return propagateOrNull(from);
+      throw Throwables.propagate(from);
    }
 }

--- a/blobstore/src/main/java/org/jclouds/blobstore/functions/ThrowContainerNotFoundOn404.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/functions/ThrowContainerNotFoundOn404.java
@@ -18,12 +18,11 @@
  */
 package org.jclouds.blobstore.functions;
 
-import static org.jclouds.util.Throwables2.propagateOrNull;
-
 import org.jclouds.blobstore.ContainerNotFoundException;
 import org.jclouds.http.HttpResponseException;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 
 /**
  * 
@@ -42,7 +41,7 @@ public class ThrowContainerNotFoundOn404 implements Function<Exception, Object> 
             throw new ContainerNotFoundException(from);
          }
       }
-      return propagateOrNull(from);
+      throw Throwables.propagate(from);
    }
 
 }

--- a/blobstore/src/main/java/org/jclouds/blobstore/functions/ThrowKeyNotFoundOn404.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/functions/ThrowKeyNotFoundOn404.java
@@ -18,12 +18,11 @@
  */
 package org.jclouds.blobstore.functions;
 
-import static org.jclouds.util.Throwables2.propagateOrNull;
-
 import org.jclouds.blobstore.KeyNotFoundException;
 import org.jclouds.http.HttpResponseException;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 
 /**
  * 
@@ -42,7 +41,7 @@ public class ThrowKeyNotFoundOn404 implements Function<Exception, Object> {
             throw new KeyNotFoundException(from);
          }
       }
-      return propagateOrNull(from);
+      throw Throwables.propagate(from);
    }
 
 }

--- a/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/functions/ReturnVoidOnDeleteDefaultIp.java
+++ b/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/functions/ReturnVoidOnDeleteDefaultIp.java
@@ -18,8 +18,6 @@
  */
 package org.jclouds.trmk.vcloud_0_8.functions;
 
-import static org.jclouds.util.Throwables2.propagateOrNull;
-
 import java.util.regex.Pattern;
 
 import javax.inject.Singleton;
@@ -28,6 +26,7 @@ import org.jclouds.http.HttpResponseException;
 import org.jclouds.rest.AuthorizationException;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 
 /**
  * There's no current way to determine if an IP is the default outbound one. In this case, we may
@@ -49,6 +48,6 @@ public class ReturnVoidOnDeleteDefaultIp implements Function<Exception, Void> {
       } else if (from instanceof AuthorizationException) {
          return null;
       }
-      return Void.class.cast(propagateOrNull(from));
+      throw Throwables.propagate(from);
    }
 }

--- a/core/src/main/java/org/jclouds/functions/ExceptionToValueOrPropagate.java
+++ b/core/src/main/java/org/jclouds/functions/ExceptionToValueOrPropagate.java
@@ -23,7 +23,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 
 import org.jclouds.javax.annotation.Nullable;
-import org.jclouds.util.Throwables2;
 
 import com.google.common.base.Function;
 import com.google.common.base.Throwables;
@@ -50,7 +49,7 @@ public class ExceptionToValueOrPropagate<E extends Exception, T> implements Func
       Iterable<E> matchingThrowables = Iterables.filter(throwables, matchingClass);
       if (Iterables.size(matchingThrowables) >= 1)
          return value;
-      return (T) Throwables2.propagateOrNull(from);
+      throw Throwables.propagate(from);
    }
 
 }

--- a/core/src/main/java/org/jclouds/http/functions/ReturnFalseOn404.java
+++ b/core/src/main/java/org/jclouds/http/functions/ReturnFalseOn404.java
@@ -20,11 +20,11 @@ package org.jclouds.http.functions;
 
 import static com.google.common.base.Predicates.equalTo;
 import static org.jclouds.http.HttpUtils.returnValueOnCodeOrNull;
-import static org.jclouds.util.Throwables2.propagateOrNull;
 
 import javax.inject.Singleton;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 
 /**
  * 
@@ -35,7 +35,9 @@ public class ReturnFalseOn404 implements Function<Exception, Boolean> {
 
    public Boolean apply(Exception from) {
       Boolean returnVal = returnValueOnCodeOrNull(from, false, equalTo(404));
-      return returnVal != null ? returnVal : Boolean.class.cast(propagateOrNull(from));
+      if (returnVal != null)
+         return returnVal;
+      throw Throwables.propagate(from);
    }
 
 }

--- a/core/src/main/java/org/jclouds/http/functions/ReturnTrueOn404.java
+++ b/core/src/main/java/org/jclouds/http/functions/ReturnTrueOn404.java
@@ -20,18 +20,20 @@ package org.jclouds.http.functions;
 
 import static com.google.common.base.Predicates.equalTo;
 import static org.jclouds.http.HttpUtils.returnValueOnCodeOrNull;
-import static org.jclouds.util.Throwables2.propagateOrNull;
 
 import javax.inject.Singleton;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 
 @Singleton
 public class ReturnTrueOn404 implements Function<Exception, Boolean> {
 
    public Boolean apply(Exception from) {
       Boolean returnVal = returnValueOnCodeOrNull(from, true, equalTo(404));
-      return returnVal != null ? returnVal : Boolean.class.cast(propagateOrNull(from));
+      if (returnVal != null)
+         return returnVal;
+      throw Throwables.propagate(from);
    }
 
 }

--- a/core/src/main/java/org/jclouds/rest/functions/MapHttp4xxCodesToExceptions.java
+++ b/core/src/main/java/org/jclouds/rest/functions/MapHttp4xxCodesToExceptions.java
@@ -18,8 +18,6 @@
  */
 package org.jclouds.rest.functions;
 
-import static org.jclouds.util.Throwables2.propagateOrNull;
-
 import javax.inject.Singleton;
 
 import org.jclouds.http.HttpResponseException;
@@ -27,6 +25,7 @@ import org.jclouds.rest.AuthorizationException;
 import org.jclouds.rest.ResourceNotFoundException;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 
 /**
  * 
@@ -50,7 +49,7 @@ public class MapHttp4xxCodesToExceptions implements Function<Exception, Object> 
                   throw new IllegalStateException(from);
             }
       }
-      return propagateOrNull(from);
+      throw Throwables.propagate(from);
    }
 
 }

--- a/core/src/main/java/org/jclouds/rest/functions/ReturnEmptyListOnNotFoundOr404.java
+++ b/core/src/main/java/org/jclouds/rest/functions/ReturnEmptyListOnNotFoundOr404.java
@@ -19,7 +19,6 @@
 package org.jclouds.rest.functions;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.jclouds.util.Throwables2.propagateOrNull;
 
 import java.util.List;
 
@@ -55,7 +54,7 @@ public class ReturnEmptyListOnNotFoundOr404 implements Function<Exception, Objec
       } else if (rto404.apply(from)) {
          return ImmutableList.of();
       }
-      return List.class.cast(propagateOrNull(from));
+      throw Throwables.propagate(from);
    }
 
 }

--- a/core/src/main/java/org/jclouds/rest/functions/ReturnEmptyMapOnNotFoundOr404.java
+++ b/core/src/main/java/org/jclouds/rest/functions/ReturnEmptyMapOnNotFoundOr404.java
@@ -19,7 +19,6 @@
 package org.jclouds.rest.functions;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.jclouds.util.Throwables2.propagateOrNull;
 
 import java.util.Map;
 
@@ -55,7 +54,7 @@ public class ReturnEmptyMapOnNotFoundOr404 implements Function<Exception, Object
       } else if (rto404.apply(from)) {
          return ImmutableMap.of();
       }
-      return Map.class.cast(propagateOrNull(from));
+      throw Throwables.propagate(from);
    }
 
 }

--- a/core/src/main/java/org/jclouds/rest/functions/ReturnEmptyMultimapOnNotFoundOr404.java
+++ b/core/src/main/java/org/jclouds/rest/functions/ReturnEmptyMultimapOnNotFoundOr404.java
@@ -19,7 +19,6 @@
 package org.jclouds.rest.functions;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.jclouds.util.Throwables2.propagateOrNull;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -54,7 +53,7 @@ public class ReturnEmptyMultimapOnNotFoundOr404 implements Function<Exception, O
       } else if (rto404.apply(from)) {
          return ImmutableMultimap.of();
       }
-      return Multimap.class.cast(propagateOrNull(from));
+      throw Throwables.propagate(from);
    }
 
 }

--- a/core/src/main/java/org/jclouds/rest/functions/ReturnEmptySetOnNotFoundOr404.java
+++ b/core/src/main/java/org/jclouds/rest/functions/ReturnEmptySetOnNotFoundOr404.java
@@ -19,7 +19,6 @@
 package org.jclouds.rest.functions;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.jclouds.util.Throwables2.propagateOrNull;
 
 import java.util.Set;
 
@@ -55,7 +54,7 @@ public class ReturnEmptySetOnNotFoundOr404 implements Function<Exception, Object
       } else if (rto404.apply(from)) {
          return ImmutableSet.of();
       }
-      return Set.class.cast(propagateOrNull(from));
+      throw Throwables.propagate(from);
    }
 
 }

--- a/core/src/main/java/org/jclouds/rest/functions/ReturnNullOnNotFoundOr404.java
+++ b/core/src/main/java/org/jclouds/rest/functions/ReturnNullOnNotFoundOr404.java
@@ -19,7 +19,6 @@
 package org.jclouds.rest.functions;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.jclouds.util.Throwables2.propagateOrNull;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -52,7 +51,7 @@ public class ReturnNullOnNotFoundOr404 implements Function<Exception, Object> {
       } else if (rto404.apply(from)) {
          return null;
       }
-      return Object.class.cast(propagateOrNull(from));
+      throw Throwables.propagate(from);
    }
 
 }

--- a/core/src/main/java/org/jclouds/rest/functions/ReturnVoidOnNotFoundOr404.java
+++ b/core/src/main/java/org/jclouds/rest/functions/ReturnVoidOnNotFoundOr404.java
@@ -19,7 +19,6 @@
 package org.jclouds.rest.functions;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.jclouds.util.Throwables2.propagateOrNull;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -55,6 +54,6 @@ public class ReturnVoidOnNotFoundOr404 implements Function<Exception, Void> {
          if (value != null && value)
             return null;
       }
-      return Void.class.cast(propagateOrNull(from));
+      throw Throwables.propagate(from);
    }
 }

--- a/core/src/main/java/org/jclouds/util/Throwables2.java
+++ b/core/src/main/java/org/jclouds/util/Throwables2.java
@@ -114,12 +114,6 @@ public class Throwables2 {
       return null;
    }
 
-   public static <T> T propagateOrNull(Exception from) {
-      propagate(from);
-      assert false : "exception should have propogated";
-      return null;
-   }
-
    // Note this needs to be kept up-to-date with all top-level exceptions jclouds works against
    @SuppressWarnings( { "unchecked", "rawtypes" })
    public static Exception returnFirstExceptionIfInListOrThrowStandardExceptionOrCause(Class[] exceptionTypes,

--- a/core/src/test/java/org/jclouds/concurrent/FutureExceptionParserTest.java
+++ b/core/src/test/java/org/jclouds/concurrent/FutureExceptionParserTest.java
@@ -18,7 +18,6 @@
  */
 package org.jclouds.concurrent;
 
-import static org.jclouds.util.Throwables2.propagateOrNull;
 import static org.testng.Assert.assertEquals;
 
 import java.util.concurrent.Callable;
@@ -87,7 +86,7 @@ public class FutureExceptionParserTest {
          public String apply(Exception from) {
             if (Iterables.size(Iterables.filter(Throwables.getCausalChain(from), RuntimeException.class)) >= 1)
                return from.getMessage();
-            return String.class.cast(propagateOrNull(from));
+            throw Throwables.propagate(from);
          }
 
       });

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/functions/VAppTemplatesForCatalogItems.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/functions/VAppTemplatesForCatalogItems.java
@@ -20,7 +20,6 @@ package org.jclouds.vcloud.director.v1_5.functions;
 
 import static com.google.common.collect.Iterables.filter;
 import static org.jclouds.concurrent.FutureIterables.transformParallel;
-import static org.jclouds.util.Throwables2.propagateOrNull;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -43,6 +42,7 @@ import org.jclouds.vcloud.director.v1_5.user.VCloudDirectorAsyncClient;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
+import com.google.common.base.Throwables;
 
 /**
  * @author danikov
@@ -63,7 +63,7 @@ public class VAppTemplatesForCatalogItems implements Function<Iterable<CatalogIt
          if (from instanceof AuthorizationException) {
             return null;
          }
-         return propagateOrNull(from);
+         throw Throwables.propagate(from);
       }
    }
 

--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/functions/ReturnFalseIfContainerAlreadyExists.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/functions/ReturnFalseIfContainerAlreadyExists.java
@@ -18,11 +18,10 @@
  */
 package org.jclouds.azureblob.functions;
 
-import static org.jclouds.util.Throwables2.propagateOrNull;
-
 import org.jclouds.azure.storage.AzureStorageResponseException;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 
 /**
  * 
@@ -37,7 +36,7 @@ public class ReturnFalseIfContainerAlreadyExists implements Function<Exception, 
             return false;
          }
       }
-      return Boolean.class.cast(propagateOrNull(from));
+      throw Throwables.propagate(from);
    }
 
 }

--- a/providers/rimuhosting/src/main/java/org/jclouds/rimuhosting/miro/functions/ParseRimuHostingException.java
+++ b/providers/rimuhosting/src/main/java/org/jclouds/rimuhosting/miro/functions/ParseRimuHostingException.java
@@ -18,8 +18,6 @@
  */
 package org.jclouds.rimuhosting.miro.functions;
 
-import static org.jclouds.util.Throwables2.propagateOrNull;
-
 import java.lang.reflect.Type;
 import java.util.Map;
 
@@ -32,6 +30,7 @@ import org.jclouds.rest.AuthorizationException;
 import org.jclouds.rimuhosting.miro.domain.internal.RimuHostingResponse;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
 import com.google.gson.reflect.TypeToken;
 
@@ -68,6 +67,6 @@ public class ParseRimuHostingException implements Function<Exception, Object> {
             throw new RuntimeException(firstResponse.getErrorInfo().getErrorMessage(), e);
          }
       }
-      return propagateOrNull(e);
+      throw Throwables.propagate(e);
    }
 }

--- a/sandbox-apis/pcs/src/main/java/org/jclouds/mezeo/pcs/functions/ReturnFalseIfContainerNotFound.java
+++ b/sandbox-apis/pcs/src/main/java/org/jclouds/mezeo/pcs/functions/ReturnFalseIfContainerNotFound.java
@@ -18,13 +18,12 @@
  */
 package org.jclouds.mezeo.pcs.functions;
 
-import static org.jclouds.util.Throwables2.propagateOrNull;
-
 import javax.inject.Singleton;
 
 import org.jclouds.blobstore.ContainerNotFoundException;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 
 /**
  * 
@@ -38,7 +37,7 @@ public class ReturnFalseIfContainerNotFound implements Function<Exception, Boole
       if (from instanceof ContainerNotFoundException) {
          return false;
       }
-      return Boolean.class.cast(propagateOrNull(from));
+      throw Throwables.propagate(from);
    }
 
 }

--- a/sandbox-apis/pcs/src/main/java/org/jclouds/mezeo/pcs/functions/ReturnTrueIfContainerAlreadyExists.java
+++ b/sandbox-apis/pcs/src/main/java/org/jclouds/mezeo/pcs/functions/ReturnTrueIfContainerAlreadyExists.java
@@ -18,13 +18,12 @@
  */
 package org.jclouds.mezeo.pcs.functions;
 
-import static org.jclouds.util.Throwables2.propagateOrNull;
-
 import javax.inject.Singleton;
 
 import org.jclouds.http.HttpResponseException;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 
 /**
  * 
@@ -40,7 +39,7 @@ public class ReturnTrueIfContainerAlreadyExists implements Function<Exception, B
             return true;
          }
       }
-      return Boolean.class.cast(propagateOrNull(from));
+      throw Throwables.propagate(from);
    }
 
 }


### PR DESCRIPTION
Throwables.propagate always propagates the Throwable; there is no need
to return null.
