### PR TITLE
Do not check for equality on overwrites

### DIFF
--- a/apis/filesystem/src/main/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImpl.java
+++ b/apis/filesystem/src/main/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImpl.java
@@ -199,15 +199,11 @@ public class FilesystemStorageStrategyImpl implements FilesystemStorageStrategy 
       filesystemContainerNameValidator.validate(container);
       filesystemBlobKeyValidator.validate(blobKey);
       File outputFile = getFileForBlobKey(container, blobKey);
-      if (payload.getRawContent().equals(outputFile)){
-         // we shouldn't re-copy the same contents
-         return;
-      }
       FileOutputStream output = null;
       try {
          Files.createParentDirs(outputFile);
          if (payload.getRawContent() instanceof File)
-            Files.copy(File.class.cast(payload.getRawContent()), outputFile);
+            Files.copy((File) payload.getRawContent(), outputFile);
          else {
             output = new FileOutputStream(outputFile);
             payload.writeTo(output);


### PR DESCRIPTION
Firstly, this check never triggered because Payload.equals always
returns false for File objects.  Secondly, this would not reduce IO
even if it worked since the common case is not overwriting a file with
the same contents.  Lastly, simplify a cast.
