### PR TITLE
Issue 910: failure to start machines where image description contains regexp charatcer

### DIFF
--- a/compute/src/main/java/org/jclouds/compute/domain/internal/TemplateBuilderImpl.java
+++ b/compute/src/main/java/org/jclouds/compute/domain/internal/TemplateBuilderImpl.java
@@ -499,13 +499,13 @@ public class TemplateBuilderImpl implements TemplateBuilder {
       if (image.getName() != null)
          this.imageName = image.getName();
       if (image.getDescription() != null)
-         this.imageDescription = String.format("^%s$", image.getDescription());
+         this.imageDescription = String.format("%s", image.getDescription());
       if (image.getOperatingSystem().getName() != null)
          this.osName = image.getOperatingSystem().getName();
       if (image.getOperatingSystem().getDescription() != null)
          this.osDescription = image.getOperatingSystem().getDescription();
       if (image.getVersion() != null)
-         this.imageVersion = String.format("^%s$", image.getVersion());
+         this.imageVersion = String.format("%s", image.getVersion());
       if (image.getOperatingSystem().getVersion() != null)
          this.osVersion = image.getOperatingSystem().getVersion();
       this.os64Bit = image.getOperatingSystem().is64Bit();


### PR DESCRIPTION
TemplateBuilder.fromImage() surrounds the image description and image version fields with ^ $, forcing them to tested as regular expressions - which will cause problems if the image description or version contains characters that have special meaning in regular expressions. Remove ^ $, so that they will match with the equals test instead.
