### PR TITLE
Issue 910: failure to start machines where image description contains regexp charatcer

### DIFF
--- a/compute/src/main/java/org/jclouds/compute/domain/internal/TemplateBuilderImpl.java
+++ b/compute/src/main/java/org/jclouds/compute/domain/internal/TemplateBuilderImpl.java
@@ -33,6 +33,7 @@ import static org.jclouds.compute.util.ComputeServiceUtils.getSpace;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import javax.annotation.Resource;
 import javax.inject.Inject;
@@ -499,13 +500,13 @@ public class TemplateBuilderImpl implements TemplateBuilder {
       if (image.getName() != null)
          this.imageName = image.getName();
       if (image.getDescription() != null)
-         this.imageDescription = String.format("^%s$", image.getDescription());
+         this.imageDescription = String.format("^%s$", Pattern.quote(image.getDescription()));
       if (image.getOperatingSystem().getName() != null)
          this.osName = image.getOperatingSystem().getName();
       if (image.getOperatingSystem().getDescription() != null)
          this.osDescription = image.getOperatingSystem().getDescription();
       if (image.getVersion() != null)
-         this.imageVersion = String.format("^%s$", image.getVersion());
+         this.imageVersion = String.format("^%s$", Pattern.quote(image.getVersion()));
       if (image.getOperatingSystem().getVersion() != null)
          this.osVersion = image.getOperatingSystem().getVersion();
       this.os64Bit = image.getOperatingSystem().is64Bit();


### PR DESCRIPTION
Regex-quote the image description and version in TemplateBuilder.fromImage() to prevent problems with image descriptions containing + and other regex special characters
