### PR TITLE
Issue 647: fix handling of malformed 'Expires' header

### DIFF
--- a/core/src/main/java/org/jclouds/io/ContentMetadataCodec.java
+++ b/core/src/main/java/org/jclouds/io/ContentMetadataCodec.java
@@ -17,8 +17,10 @@ import org.jclouds.date.DateCodec;
 import org.jclouds.date.DateCodecFactory;
 import org.jclouds.io.ContentMetadataCodec.DefaultContentMetadataCodec;
 import org.jclouds.logging.Logger;
+import org.jclouds.util.Throwables2;
 
 import com.google.common.base.Predicate;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableMultimap.Builder;
 import com.google.common.collect.Multimap;
@@ -115,9 +117,13 @@ public interface ContentMetadataCodec {
       public Date parseExpires(String expires) {
          try {
             return (expires != null) ? getExpiresDateCodec().toDate(expires) : null;
-         } catch (ParseException e) {
-            logger.warn(e, "Invalid Expires header (%s); should be in RFC-1123 format; treating as already expired", expires);
-            return new Date(0);
+         } catch (Exception e) {
+            if (Throwables2.getFirstThrowableOfType(e, ParseException.class) != null) {
+               logger.debug("Invalid Expires header (%s); should be in RFC-1123 format; treating as already expired: %s", expires, e.getMessage());
+               return new Date(0);
+            } else {
+               throw Throwables.propagate(e);
+            }
          }
       }
    }

--- a/core/src/test/java/org/jclouds/date/internal/SimpleDateCodecFactoryTest.java
+++ b/core/src/test/java/org/jclouds/date/internal/SimpleDateCodecFactoryTest.java
@@ -1,0 +1,44 @@
+package org.jclouds.date.internal;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+import java.text.ParseException;
+import java.util.Date;
+
+import org.jclouds.date.DateCodec;
+import org.jclouds.util.Throwables2;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class SimpleDateCodecFactoryTest {
+
+   private SimpleDateCodecFactory simpleDateCodecFactory;
+   private DateCodec rfc1123Codec;
+
+   @BeforeMethod
+   public void setUp() throws Exception {
+      simpleDateCodecFactory = new SimpleDateCodecFactory(new SimpleDateFormatDateService());
+      rfc1123Codec = simpleDateCodecFactory.rfc1123();
+   }
+   
+   @Test
+   public void testCodecForRfc1123() throws Exception {
+      Date date = new Date(1000);
+      assertEquals(rfc1123Codec.toDate(rfc1123Codec.toString(date)), date);
+      
+      assertEquals(rfc1123Codec.toDate("Thu, 01 Dec 1994 16:00:00 GMT"), new Date(786297600000L));
+   }
+   
+   @Test
+   public void testCodecForRfc1123ThrowsParseExceptionWhenMalformed() throws Exception {
+      try {
+         rfc1123Codec.toDate("wrong");
+         fail();
+      } catch (Exception e) {
+         if (Throwables2.getFirstThrowableOfType(e, ParseException.class) == null) {
+            throw e;
+         }
+      }
+   }
+}


### PR DESCRIPTION
Fixes s3 testCreateBlobWithMalformedExpiry live test.

---

I also tried running the test against HP Cloud Objects. The changes had introduced some noisy (benign) warn log messages, such as:

```
2012-05-17 23:51:41,645 WARN  <Invalid Expires header (-1); should be in RFC-1123 format; treating as already expired>
```

I therefore (hesitantly) dropped the logging to debug. We're doing what the HTTP 1.1 spec says, so I think that's ok but not great...

---

I tried moving the tests into the base BaseContainerLiveTest, and ran them against HP Cloud Objects. The testCreateBlobWithExpiry failed, with the Expires metadata being null when retrieved.

I haven't investigated that further yet (e.g. whether we'd expect it to work at all with that cloud), and haven't pushed the change to move the tests into the base class.
