### PR TITLE
update sshj to 0.8.0, fixing sshj problem

### DIFF
--- a/drivers/sshj/pom.xml
+++ b/drivers/sshj/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>net.schmizz</groupId>
             <artifactId>sshj</artifactId>
-            <version>0.7.0</version>
+            <version>0.8.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>


### PR DESCRIPTION
should apply to 1.4.x and to more recent versions
