### PR TITLE
Use ContextBuilder.identity, if it's been set

### DIFF
--- a/core/src/main/java/org/jclouds/ContextBuilder.java
+++ b/core/src/main/java/org/jclouds/ContextBuilder.java
@@ -255,7 +255,12 @@ public class ContextBuilder {
 
       Credentials creds = new Credentials(getAndRemove(expanded, PROPERTY_IDENTITY), getAndRemove(expanded,
                PROPERTY_CREDENTIAL));
-
+      
+      // But if identity has been overridden in the builder, then use that identity+credential 
+      if (identity.isPresent()) {
+         creds = new Credentials(identity.get(), credential);
+      }
+      
       ProviderMetadata providerMetadata = new UpdateProviderMetadataFromProperties(apiMetadata, this.providerMetadata).apply(expanded);
 
       return buildInjector(providerMetadata, creds, modules);


### PR DESCRIPTION
Fixes failing test AWSEC2ComputeServiceLiveTest.testCorrectAuthException,
where it ignored the identity+credential passed into the builder.

I'm not familiar with the ContextBuilder code, so not at all convinced this is the best way to fix it...
