### PR TITLE
Don't throw NPE if EC2 image architecture is null

### DIFF
--- a/apis/ec2/src/main/java/org/jclouds/ec2/domain/Image.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/domain/Image.java
@@ -78,7 +78,7 @@ public class Image implements Comparable<Image> {
             @Nullable String ramdiskId, RootDeviceType rootDeviceType, @Nullable String rootDeviceName,
             Map<String, EbsBlockDevice> ebsBlockDevices, VirtualizationType virtualizationType, Hypervisor hypervisor) {
       this.region = checkNotNull(region, "region");
-      this.architecture = checkNotNull(architecture, "architecture");
+      this.architecture = architecture;
       this.imageId = checkNotNull(imageId, "imageId");
       this.name = name;
       this.description = description;


### PR DESCRIPTION
When launching a private image, architecture can be null. This results in many unnecessary and annoying exceptions:

java.lang.NullPointerException: architecture
at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:204) ~[guava-11.0.1.jar:na]
at org.jclouds.ec2.domain.Image.<init>(Image.java:81) ~[ec2-1.3.2.jar:1.3.2]
at org.jclouds.ec2.xml.DescribeImagesResponseHandler.endElement(DescribeImagesResponseHandler.java:169) ~[ec2-1.3.2.jar:1.3.2]
at com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.endElement(AbstractSAXParser.java:601) [na:1.6.0_31]
at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanEndElement(XMLDocumentFragmentScannerImpl.java:1782) [na:1.6.0_31]
at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl$FragmentContentDriver.next(XMLDocumentFragmentScannerImpl.java:2939) [na:1.6.0_31]
at com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl.next(XMLDocumentScannerImpl.java:648) [na:1.6.0_31]
at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanDocument(XMLDocumentFragmentScannerImpl.java:511) [na:1.6.0_31]
at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:808) [na:1.6.0_31]
at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:737) [na:1.6.0_31]
at com.sun.org.apache.xerces.internal.parsers.XMLParser.parse(XMLParser.java:119) [na:1.6.0_31]
at com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.parse(AbstractSAXParser.java:1205) [na:1.6.0_31]
at com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl$JAXPSAXParser.parse(SAXParserImpl.java:522) [na:1.6.0_31]
at org.jclouds.http.functions.ParseSax.doParse(ParseSax.java:141) [jclouds-core-1.3.2.jar:1.3.2]
at org.jclouds.http.functions.ParseSax.parse(ParseSax.java:130) [jclouds-core-1.3.2.jar:1.3.2]
at org.jclouds.http.functions.ParseSax.apply(ParseSax.java:86) [jclouds-core-1.3.2.jar:1.3.2]
at org.jclouds.http.functions.ParseSax.apply(ParseSax.java:54) [jclouds-core-1.3.2.jar:1.3.2]
at com.google.common.util.concurrent.Futures$4.apply(Futures.java:503) [guava-11.0.1.jar:na]
at com.google.common.util.concurrent.Futures$4.apply(Futures.java:501) [guava-11.0.1.jar:na]
at com.google.common.util.concurrent.Futures$3.apply(Futures.java:279) [guava-11.0.1.jar:na]
at com.google.common.util.concurrent.Futures$ChainingListenableFuture.run(Futures.java:729) [guava-11.0.1.jar:na]
at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886) [na:1.6.0_31]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908) [na:1.6.0_31]
at java.lang.Thread.run(Thread.java:680) [na:1.6.0_31]
