### PR TITLE
Remove deprecated code

### DIFF
--- a/common/trmk/src/test/java/org/jclouds/trmk/vcloud_0_8/compute/strategy/PopulateDefaultLoginCredentialsForVAppTemplateTest.java
+++ b/common/trmk/src/test/java/org/jclouds/trmk/vcloud_0_8/compute/strategy/PopulateDefaultLoginCredentialsForVAppTemplateTest.java
@@ -51,7 +51,7 @@ public class PopulateDefaultLoginCredentialsForVAppTemplateTest {
       replay(template);
       ParseVAppTemplateDescriptionToGetDefaultLoginCredentials converter = new ParseVAppTemplateDescriptionToGetDefaultLoginCredentials(
                null, ImmutableMap.<String, Credentials> of(), ImmutableMap.<OsFamily, LoginCredentials> of());
-      Credentials creds = converter.execute(template);
+      Credentials creds = converter.apply(template);
       assertEquals(creds.identity, "vcloud");
       assertEquals(creds.credential, "$Ep455l0ud!2");
       verify(template);
@@ -66,7 +66,7 @@ public class PopulateDefaultLoginCredentialsForVAppTemplateTest {
       replay(template);
       ParseVAppTemplateDescriptionToGetDefaultLoginCredentials converter = new ParseVAppTemplateDescriptionToGetDefaultLoginCredentials(
                null, ImmutableMap.<String, Credentials> of(), ImmutableMap.<OsFamily, LoginCredentials> of());
-      Credentials creds = converter.execute(template);
+      Credentials creds = converter.apply(template);
       assertEquals(creds.identity, "ecloud");
       assertEquals(creds.credential, "$Ep455l0ud!2");
       verify(template);
@@ -81,7 +81,7 @@ public class PopulateDefaultLoginCredentialsForVAppTemplateTest {
       replay(template);
       ParseVAppTemplateDescriptionToGetDefaultLoginCredentials converter = new ParseVAppTemplateDescriptionToGetDefaultLoginCredentials(
                null, ImmutableMap.<String, Credentials> of(), ImmutableMap.<OsFamily, LoginCredentials> of());
-      Credentials creds = converter.execute(template);
+      Credentials creds = converter.apply(template);
       assertEquals(creds.identity, "vpncubed");
       assertEquals(creds.credential, "vpncubed");
       verify(template);
@@ -96,7 +96,7 @@ public class PopulateDefaultLoginCredentialsForVAppTemplateTest {
       replay(template);
       ParseVAppTemplateDescriptionToGetDefaultLoginCredentials converter = new ParseVAppTemplateDescriptionToGetDefaultLoginCredentials(
                null, ImmutableMap.<String, Credentials> of(), ImmutableMap.<OsFamily, LoginCredentials> of());
-      Credentials creds = converter.execute(template);
+      Credentials creds = converter.apply(template);
       assertEquals(creds.identity, "ecloud");
       assertEquals(creds.credential, "TmrkCl0ud1s#1!");
       verify(template);
@@ -111,7 +111,7 @@ public class PopulateDefaultLoginCredentialsForVAppTemplateTest {
       replay(template);
       ParseVAppTemplateDescriptionToGetDefaultLoginCredentials converter = new ParseVAppTemplateDescriptionToGetDefaultLoginCredentials(
                null, ImmutableMap.<String, Credentials> of(), ImmutableMap.<OsFamily, LoginCredentials> of());
-      Credentials creds = converter.execute(template);
+      Credentials creds = converter.apply(template);
       assertEquals(creds.identity, "Administrator");
       assertEquals(creds.credential, null);
       verify(template);

--- a/compute/src/main/java/org/jclouds/compute/domain/ExecResponse.java
+++ b/compute/src/main/java/org/jclouds/compute/domain/ExecResponse.java
@@ -46,6 +46,8 @@ public class ExecResponse implements CustomizationResponse {
    }
 
    /**
+    * <h4>will be removed in jclouds 1.6.0</h4> <br/>
+    * 
     * @see #getExitStatus
     */
    @Deprecated

--- a/compute/src/main/java/org/jclouds/compute/strategy/PopulateDefaultLoginCredentialsForImageStrategy.java
+++ b/compute/src/main/java/org/jclouds/compute/strategy/PopulateDefaultLoginCredentialsForImageStrategy.java
@@ -19,7 +19,6 @@
 package org.jclouds.compute.strategy;
 
 import org.jclouds.compute.strategy.impl.ReturnCredentialsBoundToImage;
-import org.jclouds.domain.Credentials;
 import org.jclouds.domain.LoginCredentials;
 
 import com.google.common.base.Function;
@@ -31,21 +30,6 @@ import com.google.inject.ImplementedBy;
 @ImplementedBy(ReturnCredentialsBoundToImage.class)
 public interface PopulateDefaultLoginCredentialsForImageStrategy extends Function<Object, LoginCredentials> {
 
-   /**
-    * <h4>will be removed in jclouds 1.4.0</h4> <br/>
-    * 
-    * Processes the resource to determine credentials.
-    * 
-    * @param resourceToAuthenticate
-    *           this can be any resource, such as an image, running server
-    *           instance or other. It's the responsibility of an implementation
-    *           to apply the cloud-specific logic.
-    * @return credentials object. Note: the key may not be set, but the identity
-    *         must be set
-    */
-   @Deprecated
-   Credentials execute(Object resourceToAuthenticate);
-   
    /**
     * Processes the cloud-specific resources to determine the login credentials.
     * 

--- a/compute/src/main/java/org/jclouds/compute/strategy/impl/ReturnCredentialsBoundToImage.java
+++ b/compute/src/main/java/org/jclouds/compute/strategy/impl/ReturnCredentialsBoundToImage.java
@@ -67,9 +67,4 @@ public class ReturnCredentialsBoundToImage implements PopulateDefaultLoginCreden
          return LoginCredentials.builder().user("root").build();
       }
    }
-
-   @Override
-   public Credentials execute(Object resourceToAuthenticate) {
-      return apply(resourceToAuthenticate);
-   }
 }

--- a/compute/src/test/java/org/jclouds/compute/strategy/impl/ReturnCredentialsBoundToImageTest.java
+++ b/compute/src/test/java/org/jclouds/compute/strategy/impl/ReturnCredentialsBoundToImageTest.java
@@ -46,7 +46,7 @@ public class ReturnCredentialsBoundToImageTest {
 
       LoginCredentials creds = new LoginCredentials("ubuntu", "foo", null, false);
       assertEquals(new ReturnCredentialsBoundToImage(creds, ImmutableMap.<String, Credentials> of(), ImmutableMap
-               .<OsFamily, LoginCredentials> of()).execute(image), creds);
+               .<OsFamily, LoginCredentials> of()).apply(image), creds);
 
       verify(image);
 
@@ -59,7 +59,7 @@ public class ReturnCredentialsBoundToImageTest {
 
       LoginCredentials creds = new LoginCredentials("ubuntu", "foo", null, false);
       assertEquals(new ReturnCredentialsBoundToImage(null, ImmutableMap.<String, Credentials> of("image#1", creds),
-               ImmutableMap.<OsFamily, LoginCredentials> of()).execute(image), creds);
+               ImmutableMap.<OsFamily, LoginCredentials> of()).apply(image), creds);
 
       verify(image);
 
@@ -74,7 +74,7 @@ public class ReturnCredentialsBoundToImageTest {
 
       Credentials creds = new Credentials("Administrator", null);
       assertEquals(new ReturnCredentialsBoundToImage(null, ImmutableMap.<String, Credentials> of(), ImmutableMap.of(
-               OsFamily.WINDOWS, LoginCredentials.builder().user("Administrator").build())).execute(image), creds);
+               OsFamily.WINDOWS, LoginCredentials.builder().user("Administrator").build())).apply(image), creds);
 
       verify(image);
 
@@ -89,7 +89,7 @@ public class ReturnCredentialsBoundToImageTest {
 
       Credentials creds = new Credentials("root", null);
       assertEquals(new ReturnCredentialsBoundToImage(null, ImmutableMap.<String, Credentials> of(), ImmutableMap
-               .<OsFamily, LoginCredentials> of()).execute(image), creds);
+               .<OsFamily, LoginCredentials> of()).apply(image), creds);
 
       verify(image);
 


### PR DESCRIPTION
Removes PopulateDefaultLoginCredentialsForImageStrategy.execute().
The javadoc said it would be removed in jclouds 1.4.

Adds javadoc to ExecResponse.getExitCode, saying to be deleted in 1.6.
It was deprecated in 1.4 release (so 1.6 would be two releases time).
