### PR TITLE
Sets endpoint for cloudservers-uk

### DIFF
--- a/providers/cloudservers-uk/src/main/java/org/jclouds/rackspace/cloudservers/CloudServersUKProviderMetadata.java
+++ b/providers/cloudservers-uk/src/main/java/org/jclouds/rackspace/cloudservers/CloudServersUKProviderMetadata.java
@@ -65,6 +65,7 @@ public class CloudServersUKProviderMetadata extends BaseProviderMetadata {
          id("cloudservers-uk")
          .name("Rackspace Cloud Servers UK")
          .apiMetadata(new CloudServersApiMetadata())
+         .endpoint("https://lon.auth.api.rackspacecloud.com")
          .homepage(URI.create("http://www.rackspace.co.uk/cloud-hosting/cloud-products/cloud-servers"))
          .console(URI.create("https://lon.manage.rackspacecloud.com"))
          .linkedServices("cloudloadbalancers-uk", "cloudservers-uk", "cloudfiles-uk")


### PR DESCRIPTION
Previously was inheriting default, which was the US endpoint.
