### PR TITLE
Issue 994: fix vcloud sax parsing of namespaces

### DIFF
--- a/apis/vcloud/src/main/java/org/jclouds/vcloud/xml/CatalogHandler.java
+++ b/apis/vcloud/src/main/java/org/jclouds/vcloud/xml/CatalogHandler.java
@@ -70,13 +70,13 @@ public class CatalogHandler extends ParseSax.HandlerWithResult<Catalog> {
    @Override
    public void startElement(String uri, String localName, String qName, Attributes attrs) throws SAXException {
       Map<String, String> attributes = SaxUtils.cleanseAttributes(attrs);
-      if (qName.equals("Catalog")) {
+      if (SaxUtils.equalsOrSuffix(qName, "Catalog")) {
          catalog = newReferenceType(attributes, VCloudMediaType.CATALOG_XML);
-      } else if (qName.equals("CatalogItem")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "CatalogItem")) {
          putReferenceType(contents, attributes);
-      } else if (qName.equals("Link") && "up".equals(attributes.get("rel"))) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "Link") && "up".equals(attributes.get("rel"))) {
          org = newReferenceType(attributes);
-      } else if (qName.equals("Link") && "add".equals(attributes.get("rel"))) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "Link") && "add".equals(attributes.get("rel"))) {
          readOnly = false;
       } else {
          taskHandler.startElement(uri, localName, qName, attrs);
@@ -85,11 +85,11 @@ public class CatalogHandler extends ParseSax.HandlerWithResult<Catalog> {
 
    public void endElement(String uri, String name, String qName) {
       taskHandler.endElement(uri, name, qName);
-      if (qName.equals("Task")) {
+      if (SaxUtils.equalsOrSuffix(qName, "Task")) {
          this.tasks.add(taskHandler.getResult());
-      } else if (qName.equals("Description")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "Description")) {
          description = currentOrNull();
-      } else if (qName.equals("IsPublished")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "IsPublished")) {
          published = Boolean.parseBoolean(currentOrNull());
       }
       currentText = new StringBuilder();

--- a/apis/vcloud/src/main/java/org/jclouds/vcloud/xml/CatalogItemHandler.java
+++ b/apis/vcloud/src/main/java/org/jclouds/vcloud/xml/CatalogItemHandler.java
@@ -53,19 +53,19 @@ public class CatalogItemHandler extends ParseSax.HandlerWithResult<CatalogItem> 
    @Override
    public void startElement(String uri, String localName, String qName, Attributes attrs) throws SAXException {
       Map<String, String> attributes = SaxUtils.cleanseAttributes(attrs);
-      if (qName.equals("CatalogItem")) {
+      if (SaxUtils.equalsOrSuffix(qName, "CatalogItem")) {
          catalogItem = newReferenceType(attributes);
-      } else if (qName.equals("Entity")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, ("Entity"))) {
          entity = newReferenceType(attributes);
-      } else if (qName.equals("Property")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, ("Property"))) {
          key = attributes.get("key");
       }
    }
 
    public void endElement(String uri, String name, String qName) {
-      if (qName.equals("Description")) {
+      if (SaxUtils.equalsOrSuffix(qName, ("Description"))) {
          description = currentOrNull();
-      } else if (qName.equals("Property")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, ("Property"))) {
          properties.put(key, currentOrNull());
          key = null;
       }

--- a/apis/vcloud/src/main/java/org/jclouds/vcloud/xml/ErrorHandler.java
+++ b/apis/vcloud/src/main/java/org/jclouds/vcloud/xml/ErrorHandler.java
@@ -40,7 +40,7 @@ public class ErrorHandler extends ParseSax.HandlerWithResult<VCloudError> {
    @Override
    public void startElement(String uri, String localName, String qName, Attributes attrs) throws SAXException {
       Map<String, String> attributes = SaxUtils.cleanseAttributes(attrs);
-      if (qName.equals("Error")) {
+      if (SaxUtils.equalsOrSuffix(qName, "Error")) {
          error = Utils.newError(attributes);
       }
    }

--- a/apis/vcloud/src/main/java/org/jclouds/vcloud/xml/OrgNetworkHandler.java
+++ b/apis/vcloud/src/main/java/org/jclouds/vcloud/xml/OrgNetworkHandler.java
@@ -145,13 +145,13 @@ public class OrgNetworkHandler extends ParseSax.HandlerWithResult<OrgNetwork> {
    @Override
    public void startElement(String uri, String localName, String qName, Attributes attrs) throws SAXException {
       Map<String, String> attributes = SaxUtils.cleanseAttributes(attrs);
-      if (qName.equals("OrgNetwork")) {
+      if (SaxUtils.equalsOrSuffix(qName, "OrgNetwork")) {
          network = newReferenceType(attributes);
-      } else if (qName.equals("FirewallRule")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "FirewallRule")) {
          this.inFirewallRule = true;
-      } else if (qName.equals("ParentNetwork")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "ParentNetwork")) {
          parentNetwork = newReferenceType(attributes);
-      } else if (qName.equals("Link") && "up".equals(attributes.get("rel"))) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "Link") && "up".equals(attributes.get("rel"))) {
          org = newReferenceType(attributes);
       } else {
          taskHandler.startElement(uri, localName, qName, attrs);
@@ -166,38 +166,38 @@ public class OrgNetworkHandler extends ParseSax.HandlerWithResult<OrgNetwork> {
 
    public void endElement(String uri, String name, String qName) {
       taskHandler.endElement(uri, name, qName);
-      if (qName.equals("Task")) {
+      if (SaxUtils.equalsOrSuffix(qName, "Task")) {
          this.tasks.add(taskHandler.getResult());
-      } else if (qName.equals("Description")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "Description")) {
          if (inFirewallRule)
             firewallRuleDescription = currentOrNull();
          else
             orgDescription = currentOrNull();
-      } else if (qName.equals("FenceMode")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "FenceMode")) {
          fenceMode = FenceMode.fromValue(currentOrNull());
-      } else if (qName.equals("StartAddress")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "StartAddress")) {
          startAddress = currentOrNull();
-      } else if (qName.equals("EndAddress")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "EndAddress")) {
          endAddress = currentOrNull();
-      } else if (qName.equals("AllocatedIpAddress")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "AllocatedIpAddress")) {
          allocatedIpAddresses.add(currentOrNull());
-      } else if (qName.equals("IpRange")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "IpRange")) {
          ipRanges.add(new IpRange(startAddress, endAddress));
          this.startAddress = null;
          this.endAddress = null;
-      } else if (qName.equals("IsInherited")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "IsInherited")) {
          inherited = Boolean.parseBoolean(currentOrNull());
-      } else if (qName.equals("Gateway")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "Gateway")) {
          gateway = currentOrNull();
-      } else if (qName.equals("Netmask")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "Netmask")) {
          netmask = currentOrNull();
-      } else if (qName.equals("Dns1")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "Dns1")) {
          dns1 = currentOrNull();
-      } else if (qName.equals("Dns2")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "Dns2")) {
          dns2 = currentOrNull();
-      } else if (qName.equals("DnsSuffix")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "DnsSuffix")) {
          dnsSuffix = currentOrNull();
-      } else if (qName.equals("IpScope")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "IpScope")) {
          ipScope = new IpScope(inherited, gateway, netmask, dns1, dns2, dnsSuffix, ipRanges, allocatedIpAddresses);
          this.inherited = false;
          this.gateway = null;
@@ -207,38 +207,38 @@ public class OrgNetworkHandler extends ParseSax.HandlerWithResult<OrgNetwork> {
          this.dnsSuffix = null;
          this.ipRanges = Sets.newLinkedHashSet();
          this.allocatedIpAddresses = Sets.newLinkedHashSet();
-      } else if (qName.equals("IsEnabled")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "IsEnabled")) {
          if (inFirewallRule)
             firewallRuleEnabled = Boolean.parseBoolean(currentOrNull());
          else
             serviceEnabled = Boolean.parseBoolean(currentOrNull());
-      } else if (qName.equals("DefaultLeaseTime")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "DefaultLeaseTime")) {
          defaultLeaseTime = Integer.parseInt(currentOrNull());
-      } else if (qName.equals("MaxLeaseTime")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "MaxLeaseTime")) {
          maxLeaseTime = Integer.parseInt(currentOrNull());
-      } else if (qName.equals("DhcpService")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "DhcpService")) {
          this.dhcpService = new DhcpService(serviceEnabled, defaultLeaseTime, maxLeaseTime, Iterables
                   .getOnlyElement(ipRanges));
          this.serviceEnabled = false;
          this.defaultLeaseTime = null;
          this.maxLeaseTime = null;
          this.ipRanges = Sets.newLinkedHashSet();
-      } else if (qName.equals("Policy")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "Policy")) {
          if (inFirewallRule)
             firewallPolicy = FirewallPolicy.fromValue(currentOrNull());
          else
             natPolicy = NatPolicy.fromValue(currentOrNull());
-      } else if (qName.equals("Tcp")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "Tcp")) {
          tcp = Boolean.parseBoolean(currentOrNull());
-      } else if (qName.equals("Udp")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "Udp")) {
          udp = Boolean.parseBoolean(currentOrNull());
-      } else if (qName.equals("Protocols")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "Protocols")) {
          this.protocols = new FirewallProtocols(tcp, udp);
          this.tcp = false;
          this.udp = false;
-      } else if (qName.equals("DestinationIp")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "DestinationIp")) {
          this.destinationIp = currentOrNull();
-      } else if (qName.equals("FirewallRule")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "FirewallRule")) {
          this.inFirewallRule = false;
          this.firewallRules.add(new FirewallRule(firewallRuleEnabled, firewallRuleDescription, firewallPolicy,
                   protocols, port, destinationIp));
@@ -248,13 +248,13 @@ public class OrgNetworkHandler extends ParseSax.HandlerWithResult<OrgNetwork> {
          this.protocols = null;
          this.port = -1;
          this.destinationIp = null;
-      } else if (qName.equals("FirewallService")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "FirewallService")) {
          firewallService = new FirewallService(serviceEnabled, firewallRules);
          this.serviceEnabled = false;
          this.firewallRules = Lists.newArrayList();
-      } else if (qName.equals("NatType")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "NatType")) {
          natType = NatType.fromValue(currentOrNull());
-      } else if (qName.equals("MappingMode")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "MappingMode")) {
          mappingMode = MappingMode.fromValue(currentOrNull());
       } else if (qName.equalsIgnoreCase("ExternalIP")) {
          externalIP = currentOrNull();
@@ -264,7 +264,7 @@ public class OrgNetworkHandler extends ParseSax.HandlerWithResult<OrgNetwork> {
          vAppScopedLocalId = currentOrNull();
       } else if (qName.equalsIgnoreCase("vmNicId")) {
          vmNicId = Integer.parseInt(currentOrNull());
-      } else if (qName.equals("OneToOneVmRule")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "OneToOneVmRule")) {
          natRules.add(new OneToOneVmRule(mappingMode, externalIP, vAppScopedVmId, vmNicId));
          this.mappingMode = null;
          this.externalIP = null;
@@ -278,14 +278,14 @@ public class OrgNetworkHandler extends ParseSax.HandlerWithResult<OrgNetwork> {
          internalPort = Integer.parseInt(currentOrNull());
       } else if (equalsOrSuffix(qName, "Protocol")) {
          natProtocol = NatProtocol.valueOf(currentOrNull());
-      } else if (qName.equals("PortForwardingRule")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "PortForwardingRule")) {
          natRules.add(new PortForwardingRule(externalIP, externalPort, internalIP, internalPort, natProtocol));
          this.externalIP = null;
          this.externalPort = -1;
          this.internalIP = null;
          this.internalPort = -1;
          this.natProtocol = null;
-      } else if (qName.equals("VmRule")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "VmRule")) {
          natRules.add(new VmRule(externalIP, externalPort, vAppScopedLocalId, vmNicId, internalPort, natProtocol));
          this.externalIP = null;
          this.externalPort = -1;
@@ -293,24 +293,24 @@ public class OrgNetworkHandler extends ParseSax.HandlerWithResult<OrgNetwork> {
          this.vmNicId = -1;
          this.internalPort = -1;
          this.natProtocol = null;
-      } else if (qName.equals("NatService")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "NatService")) {
          this.natService = new NatService(serviceEnabled, natType, natPolicy, natRules);
          this.serviceEnabled = false;
          this.natType = null;
          this.natPolicy = null;
          this.natRules = Lists.newArrayList();
-      } else if (qName.equals("Features")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "Features")) {
          this.features = new Features(dhcpService, firewallService, natService);
          this.dhcpService = null;
          this.firewallService = null;
          this.natService = null;
-      } else if (qName.equals("Configuration")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "Configuration")) {
          configuration = new OrgNetworkImpl.ConfigurationImpl(ipScope, parentNetwork, fenceMode, features);
          this.ipScope = null;
          this.parentNetwork = null;
          this.fenceMode = null;
          this.features = null;
-      } else if (qName.equals("AllowedExternalIpAddress")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "AllowedExternalIpAddress")) {
          allowedExternalIpAddresses.add(currentOrNull());
       }
       currentText = new StringBuilder();

--- a/apis/vcloud/src/main/java/org/jclouds/vcloud/xml/SupportedVersionsHandler.java
+++ b/apis/vcloud/src/main/java/org/jclouds/vcloud/xml/SupportedVersionsHandler.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.util.SortedMap;
 
 import org.jclouds.http.functions.ParseSax;
+import org.jclouds.util.SaxUtils;
 
 import com.google.common.collect.Maps;
 
@@ -40,11 +41,11 @@ public class SupportedVersionsHandler extends ParseSax.HandlerWithResult<SortedM
    }
 
    public void endElement(String uri, String name, String qName) {
-      if (qName.equals("Version")) {
+      if (SaxUtils.equalsOrSuffix(qName, "Version")) {
          version = currentOrNull();
-      } else if (qName.equals("LoginUrl")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "LoginUrl")) {
          location = URI.create(currentOrNull());
-      } else if (qName.equals("VersionInfo")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "VersionInfo")) {
          contents.put(version, location);
       }
       currentText = new StringBuilder();

--- a/apis/vcloud/src/main/java/org/jclouds/vcloud/xml/TasksListHandler.java
+++ b/apis/vcloud/src/main/java/org/jclouds/vcloud/xml/TasksListHandler.java
@@ -56,9 +56,9 @@ public class TasksListHandler extends ParseSax.HandlerWithResult<TasksList> {
    @Override
    public void startElement(String uri, String localName, String qName, Attributes attrs) throws SAXException {
       Map<String, String> attributes = SaxUtils.cleanseAttributes(attrs);
-      if (qName.equals("TasksList")) {
+      if (SaxUtils.equalsOrSuffix(qName, "TasksList")) {
          resource = Utils.newReferenceType(attributes);
-      } else if (qName.equals("Link") && "self".equals(attributes.get("rel"))) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "Link") && "self".equals(attributes.get("rel"))) {
          resource = Utils.newReferenceType(attributes);
       } else {
          taskHandler.startElement(uri, localName, qName, attrs);
@@ -68,7 +68,7 @@ public class TasksListHandler extends ParseSax.HandlerWithResult<TasksList> {
    @Override
    public void endElement(String uri, String localName, String qName) throws SAXException {
       taskHandler.endElement(uri, localName, qName);
-      if (qName.equals("Task")) {
+      if (SaxUtils.equalsOrSuffix(qName, "Task")) {
          this.tasks.add(taskHandler.getResult());
       }
    }

--- a/apis/vcloud/src/main/java/org/jclouds/vcloud/xml/VmHandler.java
+++ b/apis/vcloud/src/main/java/org/jclouds/vcloud/xml/VmHandler.java
@@ -113,12 +113,12 @@ public class VmHandler extends ParseSax.HandlerWithResult<Vm> {
          guestCustomizationHandler.startElement(uri, localName, qName, attrs);
       } else if (inTasks) {
          taskHandler.startElement(uri, localName, qName, attrs);
-      } else if (qName.equals("Vm")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "Vm")) {
          vm = newReferenceType(attributes);
          String status = attributes.get("status");
          if (status != null)
             this.status = Status.fromValue(Integer.parseInt(status));
-      } else if (qName.equals("Link") && "up".equals(attributes.get("rel"))) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "Link") && "up".equals(attributes.get("rel"))) {
          vdc = newReferenceType(attributes);
       }
    }
@@ -150,9 +150,9 @@ public class VmHandler extends ParseSax.HandlerWithResult<Vm> {
          networkConnectionSectionHandler.endElement(uri, name, qName);
       } else if (inTasks) {
          taskHandler.endElement(uri, name, qName);
-      } else if (qName.equals("Description")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "Description")) {
          description = currentOrNull();
-      } else if (qName.equals("VAppScopedLocalId")) {
+      } else if (SaxUtils.equalsOrSuffix(qName, "VAppScopedLocalId")) {
          vAppScopedLocalId = currentOrNull();
       }
       currentText = new StringBuilder();

--- a/apis/vcloud/src/test/java/org/jclouds/vcloud/xml/CatalogItemHandlerTest.java
+++ b/apis/vcloud/src/test/java/org/jclouds/vcloud/xml/CatalogItemHandlerTest.java
@@ -59,4 +59,30 @@ public class CatalogItemHandlerTest {
                )));
 
    }
+   
+   public void testApplyInputStreamWithNamespaceUsingVcloud() {
+      InputStream is = getClass().getResourceAsStream("/catalogItem-carrenza-with-vcloud-namespace.xml");
+      Injector injector = Guice.createInjector(new SaxParserModule());
+      Factory factory = injector.getInstance(ParseSax.Factory.class);
+      CatalogItem result = factory.create(injector.getInstance(CatalogItemHandler.class)).parse(is);
+
+      assertEquals(result, new CatalogItemImpl("ubuntu10.10x64", 
+               URI.create("https://myvdc.carrenza.net/api/v1.0/catalogItem/ecd4d3a0-0d12-4195-a6d2-14cdf9f925a3"), 
+               null, new ReferenceTypeImpl("ubuntu10.10x64", "application/vnd.vmware.vcloud.vAppTemplate+xml", 
+                        URI.create("https://myvdc.carrenza.net/api/v1.0/vAppTemplate/vappTemplate-123766ea-2b55-482c-8adf-735ab1952834")),
+               ImmutableSortedMap.<String,String>of()));
+   }
+   
+   public void testApplyInputStreamWithNamespaceUsingDefault() {
+      InputStream is = getClass().getResourceAsStream("/catalogItem-carrenza-with-default-namespace.xml");
+      Injector injector = Guice.createInjector(new SaxParserModule());
+      Factory factory = injector.getInstance(ParseSax.Factory.class);
+      CatalogItem result = factory.create(injector.getInstance(CatalogItemHandler.class)).parse(is);
+
+      assertEquals(result, new CatalogItemImpl("ubuntu10.10x64", 
+               URI.create("https://myvdc.carrenza.net/api/v1.0/catalogItem/ecd4d3a0-0d12-4195-a6d2-14cdf9f925a3"), 
+               null, new ReferenceTypeImpl("ubuntu10.10x64", "application/vnd.vmware.vcloud.vAppTemplate+xml", 
+                        URI.create("https://myvdc.carrenza.net/api/v1.0/vAppTemplate/vappTemplate-123766ea-2b55-482c-8adf-735ab1952834")),
+               ImmutableSortedMap.<String,String>of()));
+   }
 }

--- a/apis/vcloud/src/test/resources/catalogItem-carrenza-with-default-namespace.xml
+++ b/apis/vcloud/src/test/resources/catalogItem-carrenza-with-default-namespace.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CatalogItem xmlns="http://www.vmware.com/vcloud/v1" name="ubuntu10.10x64" type="application/vnd.vmware.vcloud.catalogItem+xml" href="https://myvdc.carrenza.net/api/v1.0/catalogItem/ecd4d3a0-0d12-4195-a6d2-14cdf9f925a3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1 http://myvdc.carrenza.net/api/v1.0/schema/master.xsd">
+    <Link rel="up" type="application/vnd.vmware.vcloud.catalog+xml" href="https://myvdc.carrenza.net/api/v1.0/catalog/5d2c147a-d26d-487a-9a05-577ee175186b"/>
+    <Link rel="edit" type="application/vnd.vmware.vcloud.catalogItem+xml" href="https://myvdc.carrenza.net/api/v1.0/catalogItem/ecd4d3a0-0d12-4195-a6d2-14cdf9f925a3"/>
+    <Link rel="remove" href="https://myvdc.carrenza.net/api/v1.0/catalogItem/ecd4d3a0-0d12-4195-a6d2-14cdf9f925a3"/>
+    <Description> </Description>
+    <Entity type="application/vnd.vmware.vcloud.vAppTemplate+xml" name="ubuntu10.10x64" href="https://myvdc.carrenza.net/api/v1.0/vAppTemplate/vappTemplate-123766ea-2b55-482c-8adf-735ab1952834"/>
+</CatalogItem>

--- a/apis/vcloud/src/test/resources/catalogItem-carrenza-with-vcloud-namespace.xml
+++ b/apis/vcloud/src/test/resources/catalogItem-carrenza-with-vcloud-namespace.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<vcloud:CatalogItem xmlns:vcloud="http://www.vmware.com/vcloud/v1" name="ubuntu10.10x64" type="application/vnd.vmware.vcloud.catalogItem+xml" href="https://myvdc.carrenza.net/api/v1.0/catalogItem/ecd4d3a0-0d12-4195-a6d2-14cdf9f925a3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1 http://myvdc.carrenza.net/api/v1.0/schema/master.xsd">
+    <vcloud:Link rel="up" type="application/vnd.vmware.vcloud.catalog+xml" href="https://myvdc.carrenza.net/api/v1.0/catalog/5d2c147a-d26d-487a-9a05-577ee175186b"/>
+    <vcloud:Link rel="edit" type="application/vnd.vmware.vcloud.catalogItem+xml" href="https://myvdc.carrenza.net/api/v1.0/catalogItem/ecd4d3a0-0d12-4195-a6d2-14cdf9f925a3"/>
+    <vcloud:Link rel="remove" href="https://myvdc.carrenza.net/api/v1.0/catalogItem/ecd4d3a0-0d12-4195-a6d2-14cdf9f925a3"/>
+    <vcloud:Description> </vcloud:Description>
+    <vcloud:Entity type="application/vnd.vmware.vcloud.vAppTemplate+xml" name="ubuntu10.10x64" href="https://myvdc.carrenza.net/api/v1.0/vAppTemplate/vappTemplate-123766ea-2b55-482c-8adf-735ab1952834"/>
+</vcloud:CatalogItem>


### PR DESCRIPTION
Handles when xml tags are qualified with and without xmlns.

---

I changed everywhere in apis/vcloud/src/main/java/org/jclouds/vcloud/xml that said `qName.equals(...)` to `SaxUtils.equalsOrSuffix(qName, ...)`.

I left the places that already said `qName.endsWith(...)`, just in case it relied on any strange suffix matching that wasn't just taking the string after the colon!
