### PR TITLE
Issue 992: Fix AWS S3 to work with non-DNS, but still valid, named buckets.

### DIFF
--- a/apis/s3/src/main/java/org/jclouds/s3/predicates/validators/BucketNameValidator.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/predicates/validators/BucketNameValidator.java
@@ -40,7 +40,7 @@ import com.google.inject.Singleton;
 public class BucketNameValidator extends DnsNameValidator {
 
    @Inject
-   BucketNameValidator() {
+   public BucketNameValidator() {
       super(3, 63);
    }
 

--- a/providers/aws-s3/src/main/java/org/jclouds/aws/s3/AWSS3AsyncClient.java
+++ b/providers/aws-s3/src/main/java/org/jclouds/aws/s3/AWSS3AsyncClient.java
@@ -21,7 +21,6 @@ package org.jclouds.aws.s3;
 import static org.jclouds.blobstore.attr.BlobScopes.CONTAINER;
 
 import java.util.Map;
-
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -68,7 +67,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 /**
  * Provides access to amazon-specific S3 features
  * 
- * @author Adrian Cole
+ * @author Adrian Cole, Jeremy Whitlock
  */
 @SkipEncoding('/')
 @RequestFilters(RequestAuthorizeSignature.class)

--- a/providers/aws-s3/src/main/java/org/jclouds/aws/s3/config/AWSS3RestClientModule.java
+++ b/providers/aws-s3/src/main/java/org/jclouds/aws/s3/config/AWSS3RestClientModule.java
@@ -23,13 +23,13 @@ import static org.jclouds.location.reference.LocationConstants.ENDPOINT;
 import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGION;
 
 import java.net.URI;
-
 import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.jclouds.aws.s3.AWSS3AsyncClient;
 import org.jclouds.aws.s3.AWSS3Client;
 import org.jclouds.aws.s3.binders.AssignCorrectHostnameAndBindAsHostPrefixIfConfigured;
+import org.jclouds.aws.s3.predicates.validators.AWSS3BucketNameValidator;
 import org.jclouds.location.Region;
 import org.jclouds.rest.ConfiguresRestClient;
 import org.jclouds.rest.RestContext;
@@ -38,6 +38,7 @@ import org.jclouds.s3.S3AsyncClient;
 import org.jclouds.s3.S3Client;
 import org.jclouds.s3.binders.BindAsHostPrefixIfConfigured;
 import org.jclouds.s3.config.S3RestClientModule;
+import org.jclouds.s3.predicates.validators.BucketNameValidator;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
@@ -64,6 +65,7 @@ public class AWSS3RestClientModule extends S3RestClientModule<AWSS3Client, AWSS3
    @Override
    protected void configure() {
       bind(BindAsHostPrefixIfConfigured.class).to(AssignCorrectHostnameAndBindAsHostPrefixIfConfigured.class);
+      bind(BucketNameValidator.class).to(AWSS3BucketNameValidator.class);
       super.configure();
    }
    

--- a/providers/aws-s3/src/main/java/org/jclouds/aws/s3/predicates/validators/AWSS3BucketNameValidator.java
+++ b/providers/aws-s3/src/main/java/org/jclouds/aws/s3/predicates/validators/AWSS3BucketNameValidator.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.aws.s3.predicates.validators;
+
+import javax.inject.Inject;
+
+import org.jclouds.s3.predicates.validators.BucketNameValidator;
+
+import com.google.inject.Singleton;
+
+/**
+ * Validates name for AWS S3 buckets. The complete requirements are listed at:
+ * http://docs.amazonwebservices.com/AmazonS3/latest/index.html?BucketRestrictions.html
+ * 
+ * @see org.jclouds.rest.InputParamValidator
+ * @see org.jclouds.predicates.Validator
+ * 
+ * @author Adrian Cole, Jeremy Whitlock
+ */
+@Singleton
+public class AWSS3BucketNameValidator extends BucketNameValidator {
+
+   @Inject
+   AWSS3BucketNameValidator() {
+      super();
+   }
+
+   public void validate(String containerName) {
+      // AWS S3 allows for upper case characters in bucket names (US Standard region only) and behind the scenes will
+      // use the lower-cased version of the bucket name for its DNS name.  So for AWS S3, we will lowercase the bucket
+      // name prior to validation.  For all other regions than US Standard region, we will let AWS throw handle the
+      // error.
+      //
+      // http://code.google.com/p/jclouds/issues/detail?id=992
+      //
+      // It would be nice to scope this more lax validator to only the us regions, since based on AWS S3 documentation,
+      // this is only necessary for the us regions.
+      super.validate(containerName.toLowerCase());
+   }
+
+}

--- a/providers/aws-s3/src/test/java/org/jclouds/aws/s3/AWSS3AsyncClientTest.java
+++ b/providers/aws-s3/src/test/java/org/jclouds/aws/s3/AWSS3AsyncClientTest.java
@@ -19,10 +19,16 @@
 package org.jclouds.aws.s3;
 
 import java.io.IOException;
+import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.inject.Module;
+import com.google.inject.TypeLiteral;
 import org.jclouds.aws.s3.config.AWSS3RestClientModule;
 import org.jclouds.aws.s3.functions.ETagFromHttpResponseViaRegex;
 import org.jclouds.aws.s3.functions.UploadIdFromHttpResponseViaRegex;
@@ -39,21 +45,17 @@ import org.jclouds.rest.ConfiguresRestClient;
 import org.jclouds.rest.functions.MapHttp4xxCodesToExceptions;
 import org.jclouds.rest.functions.ReturnVoidOnNotFoundOr404;
 import org.jclouds.rest.internal.RestAnnotationProcessor;
+import org.jclouds.s3.S3AsyncClient;
 import org.jclouds.s3.S3AsyncClientTest;
 import org.jclouds.s3.domain.ObjectMetadata;
 import org.jclouds.s3.domain.ObjectMetadataBuilder;
 import org.jclouds.s3.domain.S3Object;
 import org.jclouds.s3.functions.ReturnFalseIfBucketAlreadyOwnedByYouOrIllegalState;
+import org.jclouds.s3.options.CopyObjectOptions;
 import org.jclouds.s3.options.PutBucketOptions;
 import org.jclouds.s3.options.PutObjectOptions;
 import org.jclouds.s3.xml.LocationConstraintHandler;
 import org.testng.annotations.Test;
-
-import com.google.common.base.Supplier;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
-import com.google.inject.Module;
-import com.google.inject.TypeLiteral;
 
 /**
  * @author Adrian Cole
@@ -62,6 +64,16 @@ import com.google.inject.TypeLiteral;
 // surefire
 @Test(groups = "unit", testName = "AWSS3AsyncClientTest")
 public class AWSS3AsyncClientTest extends S3AsyncClientTest<AWSS3AsyncClient> {
+
+   @Override
+   public void testCopyObjectInvalidName() throws ArrayIndexOutOfBoundsException, SecurityException,
+                                                  IllegalArgumentException, NoSuchMethodException, IOException {
+      // For AWS S3, S3AsyncClientTest#testCopyObjectInvalidName() will not throw an exception
+      Method method = S3AsyncClient.class.getMethod("copyObject", String.class, String.class, String.class,
+                                                    String.class,
+                                                    Array.newInstance(CopyObjectOptions.class, 0).getClass());
+      processor.createRequest(method, "sourceBucket", "sourceObject", "destinationBucket", "destinationObject");
+   }
 
    public void testGetBucketLocationEU() throws SecurityException, NoSuchMethodException, IOException {
       Method method = AWSS3AsyncClient.class.getMethod("getBucketLocation", String.class);


### PR DESCRIPTION
Prior to this commit, jclouds wouldn't allow you to interact with any buckets
in S3 that were named with uppercase characters.  Per AWS S3 docs, this
non-standard naming is valid in US regions only.  This update fixes jclouds so
that it can interact with, and even attempt to create, buckets with uppercase
characters for AWS S3 without actually impacting other S3 implementations.  This
fix also will not have any impact in non-US regions other than instead of a
bucket name validation error you'll get an InvalidBucketName error back from
AWS S3 when you attempt to create a bucket with an uppercase character in a
non-US region.  To summarize, nothing changes other than US regions now allow
creation of bucket names with upper case characters and jclouds now can
interact with these non-standard named buckets without failure.
