### PR TITLE
don't overwrite USER_AGENT if already there

### DIFF
--- a/core/src/main/java/org/jclouds/http/internal/JavaUrlHttpCommandExecutorService.java
+++ b/core/src/main/java/org/jclouds/http/internal/JavaUrlHttpCommandExecutorService.java
@@ -215,7 +215,9 @@ public class JavaUrlHttpCommandExecutorService extends BaseHttpCommandExecutorSe
          host += ":" + request.getEndpoint().getPort();
       }
       connection.setRequestProperty(HttpHeaders.HOST, host);
-      connection.setRequestProperty(HttpHeaders.USER_AGENT, USER_AGENT);
+      if (connection.getRequestProperty(HttpHeaders.USER_AGENT) == null) {
+          connection.setRequestProperty(HttpHeaders.USER_AGENT, USER_AGENT);
+      }
 
       if (request.getPayload() != null) {
          MutableContentMetadata md = request.getPayload().getContentMetadata();


### PR DESCRIPTION
one of two changes required in common code for FGCP, and would save me so much hassle if I didn't need to maintain a separate copy of this class for FGCP anymore :)
In FGCP I'm setting the USER_AGENT in an httpRequestFilter btw. (ModifyRequest.replaceHeader(request, HttpHeaders.USER_AGENT, "...");)
