### PR TITLE
swift keystone 2.0: adjusting default modules for swift-keystone to include RegionModule

### DIFF
--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/SwiftKeystoneApiMetadata.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/SwiftKeystoneApiMetadata.java
@@ -87,6 +87,7 @@ public class SwiftKeystoneApiMetadata extends SwiftApiMetadata {
                .identityName("tenantName:user or user")
                .credentialName("password")
                .context(CONTEXT_TOKEN)
+               .defaultProperties(SwiftKeystoneApiMetadata.defaultProperties())
                .defaultModules(ImmutableSet.<Class<? extends Module>>of(KeystoneStorageEndpointModule.class, KeystoneAuthenticationModule.RegionModule.class,
                      SwiftKeystoneRestClientModule.class, SwiftBlobStoreContextModule.class));
       }


### PR DESCRIPTION
Clears issue encountered by machilucky - tested using hpcloud object storage account
