### PR TITLE
removing stray @Test on base ApiExpectTest class

### DIFF
--- a/core/src/test/java/org/jclouds/rest/internal/BaseRestApiExpectTest.java
+++ b/core/src/test/java/org/jclouds/rest/internal/BaseRestApiExpectTest.java
@@ -118,7 +118,6 @@ import com.google.inject.name.Names;
  * 
  * @author Adrian Cole
  */
-@Test(groups = "unit")
 @Beta
 public abstract class BaseRestApiExpectTest<S> {
 


### PR DESCRIPTION
I've grepped through all subclasses to confirm all (non-base) subclasses have the @Test annotation declared so this change should not lead to tests suddenly not being executed anymore.
