### PR TITLE
Prefer InputSupplier helpers

### DIFF
--- a/apis/atmos/src/main/java/org/jclouds/atmos/handlers/ParseAtmosErrorFromXmlContent.java
+++ b/apis/atmos/src/main/java/org/jclouds/atmos/handlers/ParseAtmosErrorFromXmlContent.java
@@ -71,7 +71,7 @@ public class ParseAtmosErrorFromXmlContent implements HttpErrorHandler {
          AtmosError error = null;
          if (response.getPayload() != null) {
             try {
-               String content = Strings2.toStringAndClose(response.getPayload().getInput());
+               String content = Strings2.toString(response.getPayload());
                if (content != null && content.indexOf('<') >= 0) {
                   error = utils.parseAtmosErrorFromContent(command, response, Strings2.toInputStream(content));
                } else {

--- a/apis/atmos/src/test/java/org/jclouds/atmos/AtmosClientLiveTest.java
+++ b/apis/atmos/src/test/java/org/jclouds/atmos/AtmosClientLiveTest.java
@@ -239,14 +239,14 @@ public class AtmosClientLiveTest extends BaseBlobStoreIntegrationTest {
    private static void verifyHeadObject(AtmosClient connection, String path, String metadataValue)
             throws InterruptedException, ExecutionException, TimeoutException, IOException {
       AtmosObject getBlob = connection.headFile(path);
-      assertEquals(Strings2.toStringAndClose(getBlob.getPayload().getInput()), "");
+      assertEquals(Strings2.toString(getBlob.getPayload()), "");
       verifyMetadata(metadataValue, getBlob);
    }
 
    private static void verifyObject(AtmosClient connection, String path, String compare, String metadataValue)
             throws InterruptedException, ExecutionException, TimeoutException, IOException {
       AtmosObject getBlob = connection.readFile(path);
-      assertEquals(Strings2.toStringAndClose(getBlob.getPayload().getInput()), compare);
+      assertEquals(Strings2.toString(getBlob.getPayload()), compare);
       verifyMetadata(metadataValue, getBlob);
    }
 

--- a/apis/cloudloadbalancers/src/main/java/org/jclouds/cloudloadbalancers/handlers/ParseCloudLoadBalancersErrorFromHttpResponse.java
+++ b/apis/cloudloadbalancers/src/main/java/org/jclouds/cloudloadbalancers/handlers/ParseCloudLoadBalancersErrorFromHttpResponse.java
@@ -85,7 +85,7 @@ public class ParseCloudLoadBalancersErrorFromHttpResponse implements HttpErrorHa
    String parseErrorFromContentOrNull(HttpCommand command, HttpResponse response) {
       if (response.getPayload() != null) {
          try {
-            return Strings2.toStringAndClose(response.getPayload().getInput());
+            return Strings2.toString(response.getPayload());
          } catch (IOException e) {
             logger.warn(e, "exception reading error from response", response);
          }

--- a/apis/cloudservers/src/main/java/org/jclouds/cloudservers/handlers/ParseCloudServersErrorFromHttpResponse.java
+++ b/apis/cloudservers/src/main/java/org/jclouds/cloudservers/handlers/ParseCloudServersErrorFromHttpResponse.java
@@ -85,7 +85,7 @@ public class ParseCloudServersErrorFromHttpResponse implements HttpErrorHandler 
    String parseErrorFromContentOrNull(HttpCommand command, HttpResponse response) {
       if (response.getPayload() != null) {
          try {
-            return Strings2.toStringAndClose(response.getPayload().getInput());
+            return Strings2.toString(response.getPayload());
          } catch (IOException e) {
             logger.warn(e, "exception reading error from response", response);
          }

--- a/apis/cloudservers/src/test/java/org/jclouds/cloudservers/CloudServersClientLiveTest.java
+++ b/apis/cloudservers/src/test/java/org/jclouds/cloudservers/CloudServersClientLiveTest.java
@@ -383,7 +383,7 @@ public class CloudServersClientLiveTest extends BaseComputeServiceContextLiveTes
       try {
          client.connect();
          Payload etcPasswd = client.get("/etc/jclouds.txt");
-         String etcPasswdContents = Strings2.toStringAndClose(etcPasswd.getInput());
+         String etcPasswdContents = Strings2.toString(etcPasswd);
          assertEquals("rackspace", etcPasswdContents.trim());
       } finally {
          if (client != null)

--- a/apis/cloudsigma/src/main/java/org/jclouds/cloudsigma/handlers/CloudSigmaErrorHandler.java
+++ b/apis/cloudsigma/src/main/java/org/jclouds/cloudsigma/handlers/CloudSigmaErrorHandler.java
@@ -94,7 +94,7 @@ public class CloudSigmaErrorHandler implements HttpErrorHandler {
       if (response.getPayload() == null)
          return null;
       try {
-         return Strings2.toStringAndClose(response.getPayload().getInput());
+         return Strings2.toString(response.getPayload());
       } catch (IOException e) {
          throw new RuntimeException(e);
       } finally {

--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/handlers/CloudStackErrorHandler.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/handlers/CloudStackErrorHandler.java
@@ -92,7 +92,7 @@ public class CloudStackErrorHandler implements HttpErrorHandler {
       if (response.getPayload() == null)
          return null;
       try {
-         return Strings2.toStringAndClose(response.getPayload().getInput());
+         return Strings2.toString(response.getPayload());
       } catch (IOException e) {
          throw new RuntimeException(e);
       } finally {

--- a/apis/deltacloud/src/main/java/org/jclouds/deltacloud/handlers/DeltacloudErrorHandler.java
+++ b/apis/deltacloud/src/main/java/org/jclouds/deltacloud/handlers/DeltacloudErrorHandler.java
@@ -87,7 +87,7 @@ public class DeltacloudErrorHandler implements HttpErrorHandler {
       if (response.getPayload() == null)
          return null;
       try {
-         return Strings2.toStringAndClose(response.getPayload().getInput());
+         return Strings2.toString(response.getPayload());
       } catch (IOException e) {
          throw new RuntimeException(e);
       } finally {

--- a/apis/elasticstack/src/main/java/org/jclouds/elasticstack/handlers/ElasticStackErrorHandler.java
+++ b/apis/elasticstack/src/main/java/org/jclouds/elasticstack/handlers/ElasticStackErrorHandler.java
@@ -92,7 +92,7 @@ public class ElasticStackErrorHandler implements HttpErrorHandler {
       if (response.getPayload() == null)
          return null;
       try {
-         return Strings2.toStringAndClose(response.getPayload().getInput());
+         return Strings2.toString(response.getPayload());
       } catch (IOException e) {
          throw new RuntimeException(e);
       } finally {

--- a/apis/elasticstack/src/test/java/org/jclouds/elasticstack/ElasticStackClientLiveTest.java
+++ b/apis/elasticstack/src/test/java/org/jclouds/elasticstack/ElasticStackClientLiveTest.java
@@ -326,7 +326,7 @@ public class ElasticStackClientLiveTest
    public void testWeCanReadAndWriteToDrive() throws IOException {
       drive2 = client.createDrive(new CreateDriveRequest.Builder().name(prefix + "2").size(1 * 1024 * 1024l).build());
       client.writeDrive(drive2.getUuid(), Payloads.newStringPayload("foo"));
-      assertEquals(Strings2.toStringAndClose(client.readDrive(drive2.getUuid(), 0, 3).getInput()), "foo");
+      assertEquals(Strings2.toString(client.readDrive(drive2.getUuid(), 0, 3)), "foo");
    }
 
    @Test(dependsOnMethods = "testWeCanReadAndWriteToDrive")
@@ -341,7 +341,7 @@ public class ElasticStackClientLiveTest
          assert driveNotClaimed.apply(drive2) : client.getDriveInfo(drive2.getUuid());
          System.err.println("after image; drive 2" + client.getDriveInfo(drive2.getUuid()));
          System.err.println("after image; drive 3" + client.getDriveInfo(drive3.getUuid()));
-         assertEquals(Strings2.toStringAndClose(client.readDrive(drive3.getUuid(), 0, 3).getInput()), "foo");
+         assertEquals(Strings2.toString(client.readDrive(drive3.getUuid(), 0, 3)), "foo");
       } finally {
          client.destroyDrive(drive2.getUuid());
          client.destroyDrive(drive3.getUuid());

--- a/apis/nova/src/main/java/org/jclouds/openstack/nova/handlers/ParseNovaErrorFromHttpResponse.java
+++ b/apis/nova/src/main/java/org/jclouds/openstack/nova/handlers/ParseNovaErrorFromHttpResponse.java
@@ -85,7 +85,7 @@ public class ParseNovaErrorFromHttpResponse implements HttpErrorHandler {
    String parseErrorFromContentOrNull(HttpCommand command, HttpResponse response) {
       if (response.getPayload() != null) {
          try {
-            return Strings2.toStringAndClose(response.getPayload().getInput());
+            return Strings2.toString(response.getPayload());
          } catch (IOException e) {
             logger.warn(e, "exception reading error from response", response);
          }

--- a/apis/nova/src/test/java/org/jclouds/openstack/nova/NovaClientLiveTest.java
+++ b/apis/nova/src/test/java/org/jclouds/openstack/nova/NovaClientLiveTest.java
@@ -303,7 +303,7 @@ public class NovaClientLiveTest extends BaseComputeServiceContextLiveTest {
       try {
          client.connect();
          Payload etcPasswd = client.get("/etc/jclouds.txt");
-         String etcPasswdContents = Strings2.toStringAndClose(etcPasswd.getInput());
+         String etcPasswdContents = Strings2.toString(etcPasswd);
          assertEquals("nova", etcPasswdContents.trim());
       } finally {
          if (client != null)

--- a/apis/s3/src/test/java/org/jclouds/s3/S3ClientLiveTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/S3ClientLiveTest.java
@@ -284,7 +284,7 @@ public class S3ClientLiveTest extends BaseBlobStoreIntegrationTest {
       assertConsistencyAwareContainerSize(sourceContainer, 1);
       S3Object newObject = getApi().getObject(sourceContainer, key);
       assert newObject != null;
-      assertEquals(Strings2.toStringAndClose(newObject.getPayload().getInput()), TEST_STRING);
+      assertEquals(Strings2.toString(newObject.getPayload()), TEST_STRING);
       return newObject;
    }
 

--- a/apis/swift/src/test/java/org/jclouds/openstack/swift/CommonSwiftClientLiveTest.java
+++ b/apis/swift/src/test/java/org/jclouds/openstack/swift/CommonSwiftClientLiveTest.java
@@ -222,7 +222,7 @@ public abstract class CommonSwiftClientLiveTest<C extends CommonSwiftClient> ext
          assert getApi().getObject(containerName, "non-existent-object") == null;
          // Test GET of object (including updated metadata)
          SwiftObject getBlob = getApi().getObject(containerName, object.getInfo().getName());
-         assertEquals(Strings2.toStringAndClose(getBlob.getPayload().getInput()), data);
+         assertEquals(Strings2.toString(getBlob.getPayload()), data);
          // TODO assertEquals(getBlob.getName(),
          // object.getMetadata().getName());
          assertEquals(getBlob.getInfo().getBytes(), new Long(data.length()));
@@ -267,7 +267,7 @@ public abstract class CommonSwiftClientLiveTest<C extends CommonSwiftClient> ext
                   GetOptions.Builder.ifETagMatches(newEtag));
          assertEquals(getBlob.getInfo().getHash(), CryptoStreams.hex(newEtag));
          getBlob = getApi().getObject(containerName, object.getInfo().getName(), GetOptions.Builder.startAt(8));
-         assertEquals(Strings2.toStringAndClose(getBlob.getPayload().getInput()), data.substring(8));
+         assertEquals(Strings2.toString(getBlob.getPayload()), data.substring(8));
 
       } finally {
          returnContainer(containerName);

--- a/apis/vcloud/src/main/java/org/jclouds/vcloud/handlers/ParseVCloudErrorFromHttpResponse.java
+++ b/apis/vcloud/src/main/java/org/jclouds/vcloud/handlers/ParseVCloudErrorFromHttpResponse.java
@@ -73,7 +73,7 @@ public class ParseVCloudErrorFromHttpResponse implements HttpErrorHandler {
                   message = error.getMessage();
                   exception = new VCloudResponseException(command, response, error);
                } else {
-                  message = Strings2.toStringAndClose(response.getPayload().getInput());
+                  message = Strings2.toString(response.getPayload());
                   exception = message != null ? new HttpResponseException(command, response, message) : exception;
                }
             } catch (IOException e) {

--- a/blobstore/src/test/java/org/jclouds/blobstore/binders/BindBlobToMultipartFormTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/binders/BindBlobToMultipartFormTest.java
@@ -65,7 +65,7 @@ public class BindBlobToMultipartFormTest {
       HttpRequest request = HttpRequest.builder().method("GET").endpoint("http://localhost:8001").build();
       binder.bindToRequest(request, TEST_BLOB);
 
-      assertEquals(Strings2.toStringAndClose(request.getPayload().getInput()), EXPECTS);
+      assertEquals(Strings2.toString(request.getPayload()), EXPECTS);
       assertEquals(request.getPayload().getContentMetadata().getContentLength(), new Long(113));
 
       assertEquals(request.getPayload().getContentMetadata().getContentType(), "multipart/form-data; boundary="

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobSignerLiveTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobSignerLiveTest.java
@@ -67,7 +67,7 @@ public class BaseBlobSignerLiveTest extends BaseBlobStoreIntegrationTest {
          assertConsistencyAwareContainerSize(container, 1);
          HttpRequest request = view.getSigner().signGetBlob(container, name);
          assertEquals(request.getFilters().size(), 0);
-         assertEquals(Strings2.toStringAndClose(view.utils().http().invoke(request).getPayload().getInput()), text);
+         assertEquals(Strings2.toString(view.utils().http().invoke(request).getPayload()), text);
       } finally {
          returnContainer(container);
       }
@@ -85,7 +85,7 @@ public class BaseBlobSignerLiveTest extends BaseBlobStoreIntegrationTest {
          assertConsistencyAwareContainerSize(container, 1);
          HttpRequest request = view.getSigner().signGetBlob(container, name, range(0, 1));
          assertEquals(request.getFilters().size(), 0);
-         assertEquals(Strings2.toStringAndClose(view.utils().http().invoke(request).getPayload().getInput()), "fo");
+         assertEquals(Strings2.toString(view.utils().http().invoke(request).getPayload()), "fo");
       } finally {
          returnContainer(container);
       }
@@ -101,7 +101,7 @@ public class BaseBlobSignerLiveTest extends BaseBlobStoreIntegrationTest {
       try {
          HttpRequest request = view.getSigner().signPutBlob(container, blob);
          assertEquals(request.getFilters().size(), 0);
-         Strings2.toStringAndClose(view.utils().http().invoke(request).getPayload().getInput());
+         Strings2.toString(view.utils().http().invoke(request).getPayload());
          assertConsistencyAwareContainerSize(container, 1);
       } finally {
          returnContainer(container);

--- a/common/aws/src/main/java/org/jclouds/aws/handlers/ParseAWSErrorFromXmlContent.java
+++ b/common/aws/src/main/java/org/jclouds/aws/handlers/ParseAWSErrorFromXmlContent.java
@@ -81,7 +81,7 @@ public class ParseAWSErrorFromXmlContent implements HttpErrorHandler {
                }
             } else {
                try {
-                  message = Strings2.toStringAndClose(response.getPayload().getInput());
+                  message = Strings2.toString(response.getPayload());
                   exception = new HttpResponseException(command, response, message);
                } catch (IOException e) {
                }

--- a/common/azure/src/main/java/org/jclouds/azure/storage/handlers/ParseAzureStorageErrorFromXmlContent.java
+++ b/common/azure/src/main/java/org/jclouds/azure/storage/handlers/ParseAzureStorageErrorFromXmlContent.java
@@ -76,14 +76,14 @@ public class ParseAzureStorageErrorFromXmlContent implements HttpErrorHandler {
                   }
                } catch (RuntimeException e) {
                   try {
-                     message = Strings2.toStringAndClose(response.getPayload().getInput());
+                     message = Strings2.toString(response.getPayload());
                      exception = new HttpResponseException(command, response, message);
                   } catch (IOException e1) {
                   }
                }
             } else {
                try {
-                  message = Strings2.toStringAndClose(response.getPayload().getInput());
+                  message = Strings2.toString(response.getPayload());
                   exception = new HttpResponseException(command, response, message);
                } catch (IOException e) {
                }

--- a/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/handlers/ParseTerremarkVCloudErrorFromHttpResponse.java
+++ b/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/handlers/ParseTerremarkVCloudErrorFromHttpResponse.java
@@ -101,7 +101,7 @@ public class ParseTerremarkVCloudErrorFromHttpResponse implements HttpErrorHandl
    String parseErrorFromContentOrNull(HttpCommand command, HttpResponse response) {
       if (response.getPayload() != null) {
          try {
-            return Strings2.toStringAndClose(response.getPayload().getInput());
+            return Strings2.toString(response.getPayload());
          } catch (IOException e) {
             logger.warn(e, "exception reading error from response", response);
          }

--- a/compute/src/test/java/org/jclouds/compute/StubComputeServiceIntegrationTest.java
+++ b/compute/src/test/java/org/jclouds/compute/StubComputeServiceIntegrationTest.java
@@ -422,7 +422,7 @@ public class StubComputeServiceIntegrationTest extends BaseComputeServiceLiveTes
             return actual == null;
          }
          try {
-            String real = Strings2.toStringAndClose(((Payload) actual).getInput());
+            String real = Strings2.toString(((Payload) actual));
             assertEquals(real, expected);
             return true;
          } catch (IOException e) {

--- a/core/src/main/java/org/jclouds/http/HttpResponseException.java
+++ b/core/src/main/java/org/jclouds/http/HttpResponseException.java
@@ -88,7 +88,7 @@ public class HttpResponseException extends RuntimeException {
             && request.getPayload().getContentMetadata().getContentLength() < 1024) {
          try {
             return String.format(" [%s] ", request.getPayload() instanceof StringPayload ? request.getPayload()
-                  .getRawContent() : Strings2.toStringAndClose(request.getPayload().getInput()));
+                  .getRawContent() : Strings2.toString(request.getPayload()));
          } catch (IOException e) {
          }
       }

--- a/core/src/main/java/org/jclouds/http/functions/ParseURIFromListOrLocationHeaderIf20x.java
+++ b/core/src/main/java/org/jclouds/http/functions/ParseURIFromListOrLocationHeaderIf20x.java
@@ -61,7 +61,7 @@ public class ParseURIFromListOrLocationHeaderIf20x implements Function<HttpRespo
          try {
             if (from.getPayload().getInput() == null)
                throw new HttpResponseException("no content", null, from);
-            String toParse = Strings2.toStringAndClose(from.getPayload().getInput());
+            String toParse = Strings2.toString(from.getPayload());
             return URI.create(toParse.trim());
          } catch (IOException e) {
             throw new HttpResponseException("couldn't parse uri from content", null, from, e);

--- a/core/src/main/java/org/jclouds/http/handlers/CloseContentAndSetExceptionErrorHandler.java
+++ b/core/src/main/java/org/jclouds/http/handlers/CloseContentAndSetExceptionErrorHandler.java
@@ -40,7 +40,7 @@ public class CloseContentAndSetExceptionErrorHandler implements HttpErrorHandler
    public void handleError(HttpCommand command, HttpResponse from) {
       String content;
       try {
-         content = from.getPayload() != null ? Strings2.toStringAndClose(from.getPayload().getInput()) : null;
+         content = from.getPayload() != null ? Strings2.toString(from.getPayload()) : null;
          command.setException(new HttpResponseException(command, from, content));
       } catch (IOException e) {
          command.setException(new HttpResponseException(command, from));

--- a/core/src/main/java/org/jclouds/util/Strings2.java
+++ b/core/src/main/java/org/jclouds/util/Strings2.java
@@ -46,6 +46,8 @@ import javax.annotation.Resource;
 import org.jclouds.logging.Logger;
 
 import com.google.common.base.Charsets;
+import com.google.common.io.CharStreams;
+import com.google.common.io.InputSupplier;
 
 /**
  * 
@@ -124,6 +126,12 @@ public class Strings2 {
    }
 
    public static final String UTF8_ENCODING = "UTF-8";
+
+   public static String toString(InputSupplier<? extends InputStream> supplier)
+         throws IOException {
+      return CharStreams.toString(CharStreams.newReaderSupplier(supplier,
+         Charsets.UTF_8));
+   }
 
    public static String toStringAndClose(InputStream input) throws IOException {
       checkNotNull(input, "input");

--- a/core/src/test/java/org/jclouds/io/payloads/MultipartFormTest.java
+++ b/core/src/test/java/org/jclouds/io/payloads/MultipartFormTest.java
@@ -54,7 +54,7 @@ public class MultipartFormTest {
 
       MultipartForm multipartForm = new MultipartForm(boundary, newPart("hello"));
 
-      assertEquals(Strings2.toStringAndClose(multipartForm.getInput()), expects);
+      assertEquals(Strings2.toString(multipartForm), expects);
       assertEquals(multipartForm.getContentMetadata().getContentLength(), new Long(199));
    }
 
@@ -119,11 +119,11 @@ public class MultipartFormTest {
 
       MultipartForm multipartForm = new MultipartForm(boundary, newPart("hello"), newPart("goodbye"));
 
-      assertEquals(Strings2.toStringAndClose(multipartForm.getInput()), expects);
+      assertEquals(Strings2.toString(multipartForm), expects);
 
       // test repeatable
       assert multipartForm.isRepeatable();
-      assertEquals(Strings2.toStringAndClose(multipartForm.getInput()), expects);
+      assertEquals(Strings2.toString(multipartForm), expects);
       assertEquals(multipartForm.getContentMetadata().getContentLength(), new Long(352));
    }
 

--- a/core/src/test/java/org/jclouds/rest/internal/BaseRestApiExpectTest.java
+++ b/core/src/test/java/org/jclouds/rest/internal/BaseRestApiExpectTest.java
@@ -386,8 +386,8 @@ public abstract class BaseRestApiExpectTest<S> {
  
          switch (compareHttpRequestAsType(a)) {
             case XML: {
-               Diff diff = XMLUnit.compareXML(Strings2.toStringAndClose(a.getPayload().getInput()), Strings2
-                        .toStringAndClose(b.getPayload().getInput()));
+               Diff diff = XMLUnit.compareXML(Strings2.toString(a.getPayload()), Strings2
+                        .toString(b.getPayload()));
 
                // Ignoring whitespace in elements that have other children, xsi:schemaLocation and
                // differences in namespace prefixes
@@ -419,8 +419,8 @@ public abstract class BaseRestApiExpectTest<S> {
             }
             case JSON: {               
                JsonParser parser = new JsonParser();
-               JsonElement payloadA = parser.parse(Strings2.toStringAndClose(a.getPayload().getInput()));
-               JsonElement payloadB = parser.parse(Strings2.toStringAndClose(b.getPayload().getInput()));
+               JsonElement payloadA = parser.parse(Strings2.toString(a.getPayload()));
+               JsonElement payloadB = parser.parse(Strings2.toString(b.getPayload()));
                return Objects.equal(payloadA, payloadB);
             }
             default: {
@@ -486,7 +486,7 @@ public abstract class BaseRestApiExpectTest<S> {
             builder.append(header.getKey()).append(": ").append(header.getValue()).append('\n');
          }
          try {
-            builder.append('\n').append(Strings2.toStringAndClose(request.getPayload().getInput()));
+            builder.append('\n').append(Strings2.toString(request.getPayload()));
          } catch (IOException e) {
             throw Throwables.propagate(e);
          }

--- a/core/src/test/java/org/jclouds/rest/internal/BaseRestApiTest.java
+++ b/core/src/test/java/org/jclouds/rest/internal/BaseRestApiTest.java
@@ -107,7 +107,7 @@ public abstract class BaseRestApiTest {
       } else {
          String payload = null;
          try {
-            payload = Strings2.toStringAndClose(request.getPayload().getInput());
+            payload = Strings2.toString(request.getPayload());
          } catch (IOException e) {
             propagate(e);
          }

--- a/demos/tweetstore/cf-tweetstore-spring/src/main/java/org/jclouds/demo/tweetstore/functions/KeyToStoredTweetStatus.java
+++ b/demos/tweetstore/cf-tweetstore-spring/src/main/java/org/jclouds/demo/tweetstore/functions/KeyToStoredTweetStatus.java
@@ -59,7 +59,7 @@ public class KeyToStoredTweetStatus implements Function<String, StoredTweetStatu
          Blob blob = map.get(id);
          status = ((System.currentTimeMillis() - start) + "ms");
          from = blob.getMetadata().getUserMetadata().get(TweetStoreConstants.SENDER_NAME);
-         tweet = toStringAndClose(blob.getPayload().getInput());
+         tweet = toString(blob.getPayload());
       } catch (Exception e) {
          logger.error(e, "Error listing container %s//%s/%s", service, container, id);
          status = (e.getMessage());

--- a/demos/tweetstore/cf-tweetstore-spring/src/test/java/org/jclouds/demo/tweetstore/controller/StoreTweetsControllerTest.java
+++ b/demos/tweetstore/cf-tweetstore-spring/src/test/java/org/jclouds/demo/tweetstore/controller/StoreTweetsControllerTest.java
@@ -107,13 +107,13 @@ public class StoreTweetsControllerTest {
          assertEquals(frankBlob.getMetadata().getName(), "1");
          assertEquals(frankBlob.getMetadata().getUserMetadata().get(TweetStoreConstants.SENDER_NAME), "frank");
          assertEquals(frankBlob.getMetadata().getContentMetadata().getContentType(), "text/plain");
-         assertEquals(toStringAndClose(frankBlob.getPayload().getInput()), "I love beans!");
+         assertEquals(toString(frankBlob.getPayload()), "I love beans!");
 
          Blob jimmyBlob = map.get("2");
          assertEquals(jimmyBlob.getMetadata().getName(), "2");
          assertEquals(jimmyBlob.getMetadata().getUserMetadata().get(TweetStoreConstants.SENDER_NAME), "jimmy");
          assertEquals(jimmyBlob.getMetadata().getContentMetadata().getContentType(), "text/plain");
-         assertEquals(toStringAndClose(jimmyBlob.getPayload().getInput()), "cloud is king");
+         assertEquals(toString(jimmyBlob.getPayload()), "cloud is king");
       }
 
    }

--- a/demos/tweetstore/gae-tweetstore-spring/src/main/java/org/jclouds/demo/tweetstore/functions/KeyToStoredTweetStatus.java
+++ b/demos/tweetstore/gae-tweetstore-spring/src/main/java/org/jclouds/demo/tweetstore/functions/KeyToStoredTweetStatus.java
@@ -59,7 +59,7 @@ public class KeyToStoredTweetStatus implements Function<String, StoredTweetStatu
          Blob blob = map.get(id);
          status = ((System.currentTimeMillis() - start) + "ms");
          from = blob.getMetadata().getUserMetadata().get(TweetStoreConstants.SENDER_NAME);
-         tweet = toStringAndClose(blob.getPayload().getInput());
+         tweet = toString(blob.getPayload());
       } catch (Exception e) {
          logger.error(e, "Error listing container %s//%s/%s", service, container, id);
          status = (e.getMessage());

--- a/demos/tweetstore/gae-tweetstore-spring/src/test/java/org/jclouds/demo/tweetstore/controller/StoreTweetsControllerTest.java
+++ b/demos/tweetstore/gae-tweetstore-spring/src/test/java/org/jclouds/demo/tweetstore/controller/StoreTweetsControllerTest.java
@@ -107,13 +107,13 @@ public class StoreTweetsControllerTest {
          assertEquals(frankBlob.getMetadata().getName(), "1");
          assertEquals(frankBlob.getMetadata().getUserMetadata().get(TweetStoreConstants.SENDER_NAME), "frank");
          assertEquals(frankBlob.getMetadata().getContentMetadata().getContentType(), "text/plain");
-         assertEquals(toStringAndClose(frankBlob.getPayload().getInput()), "I love beans!");
+         assertEquals(toString(frankBlob.getPayload()), "I love beans!");
 
          Blob jimmyBlob = map.get("2");
          assertEquals(jimmyBlob.getMetadata().getName(), "2");
          assertEquals(jimmyBlob.getMetadata().getUserMetadata().get(TweetStoreConstants.SENDER_NAME), "jimmy");
          assertEquals(jimmyBlob.getMetadata().getContentMetadata().getContentType(), "text/plain");
-         assertEquals(toStringAndClose(jimmyBlob.getPayload().getInput()), "cloud is king");
+         assertEquals(toString(jimmyBlob.getPayload()), "cloud is king");
       }
 
    }

--- a/demos/tweetstore/gae-tweetstore/src/main/java/org/jclouds/demo/tweetstore/functions/KeyToStoredTweetStatus.java
+++ b/demos/tweetstore/gae-tweetstore/src/main/java/org/jclouds/demo/tweetstore/functions/KeyToStoredTweetStatus.java
@@ -59,7 +59,7 @@ public class KeyToStoredTweetStatus implements Function<String, StoredTweetStatu
          Blob blob = map.get(id);
          status = ((System.currentTimeMillis() - start) + "ms");
          from = blob.getMetadata().getUserMetadata().get(TweetStoreConstants.SENDER_NAME);
-         tweet = toStringAndClose(blob.getPayload().getInput());
+         tweet = toString(blob.getPayload());
       } catch (Exception e) {
          logger.error(e, "Error listing container %s//%s/%s", service, container, id);
          status = (e.getMessage());

--- a/demos/tweetstore/gae-tweetstore/src/test/java/org/jclouds/demo/tweetstore/controller/StoreTweetsControllerTest.java
+++ b/demos/tweetstore/gae-tweetstore/src/test/java/org/jclouds/demo/tweetstore/controller/StoreTweetsControllerTest.java
@@ -107,13 +107,13 @@ public class StoreTweetsControllerTest {
          assertEquals(frankBlob.getMetadata().getName(), "1");
          assertEquals(frankBlob.getMetadata().getUserMetadata().get(TweetStoreConstants.SENDER_NAME), "frank");
          assertEquals(frankBlob.getMetadata().getContentMetadata().getContentType(), "text/plain");
-         assertEquals(toStringAndClose(frankBlob.getPayload().getInput()), "I love beans!");
+         assertEquals(toString(frankBlob.getPayload()), "I love beans!");
 
          Blob jimmyBlob = map.get("2");
          assertEquals(jimmyBlob.getMetadata().getName(), "2");
          assertEquals(jimmyBlob.getMetadata().getUserMetadata().get(TweetStoreConstants.SENDER_NAME), "jimmy");
          assertEquals(jimmyBlob.getMetadata().getContentMetadata().getContentType(), "text/plain");
-         assertEquals(toStringAndClose(jimmyBlob.getPayload().getInput()), "cloud is king");
+         assertEquals(toString(jimmyBlob.getPayload()), "cloud is king");
       }
 
    }

--- a/demos/tweetstore/heroku-tweetstore/src/main/java/org/jclouds/demo/tweetstore/functions/KeyToStoredTweetStatus.java
+++ b/demos/tweetstore/heroku-tweetstore/src/main/java/org/jclouds/demo/tweetstore/functions/KeyToStoredTweetStatus.java
@@ -59,7 +59,7 @@ public class KeyToStoredTweetStatus implements Function<String, StoredTweetStatu
          Blob blob = map.get(id);
          status = ((System.currentTimeMillis() - start) + "ms");
          from = blob.getMetadata().getUserMetadata().get(TweetStoreConstants.SENDER_NAME);
-         tweet = toStringAndClose(blob.getPayload().getInput());
+         tweet = toString(blob.getPayload());
       } catch (Exception e) {
          logger.error(e, "Error listing container %s//%s/%s", service, container, id);
          status = (e.getMessage());

--- a/demos/tweetstore/heroku-tweetstore/src/test/java/org/jclouds/demo/tweetstore/controller/StoreTweetsControllerTest.java
+++ b/demos/tweetstore/heroku-tweetstore/src/test/java/org/jclouds/demo/tweetstore/controller/StoreTweetsControllerTest.java
@@ -108,13 +108,13 @@ public class StoreTweetsControllerTest {
          assertEquals(frankBlob.getMetadata().getName(), "1");
          assertEquals(frankBlob.getMetadata().getUserMetadata().get(TweetStoreConstants.SENDER_NAME), "frank");
          assertEquals(frankBlob.getMetadata().getContentMetadata().getContentType(), "text/plain");
-         assertEquals(toStringAndClose(frankBlob.getPayload().getInput()), "I love beans!");
+         assertEquals(toString(frankBlob.getPayload()), "I love beans!");
 
          Blob jimmyBlob = map.get("2");
          assertEquals(jimmyBlob.getMetadata().getName(), "2");
          assertEquals(jimmyBlob.getMetadata().getUserMetadata().get(TweetStoreConstants.SENDER_NAME), "jimmy");
          assertEquals(jimmyBlob.getMetadata().getContentMetadata().getContentType(), "text/plain");
-         assertEquals(toStringAndClose(jimmyBlob.getPayload().getInput()), "cloud is king");
+         assertEquals(toString(jimmyBlob.getPayload()), "cloud is king");
       }
 
    }

--- a/demos/tweetstore/rhcloud-tweetstore/src/main/java/org/jclouds/demo/tweetstore/functions/KeyToStoredTweetStatus.java
+++ b/demos/tweetstore/rhcloud-tweetstore/src/main/java/org/jclouds/demo/tweetstore/functions/KeyToStoredTweetStatus.java
@@ -59,7 +59,7 @@ public class KeyToStoredTweetStatus implements Function<String, StoredTweetStatu
          Blob blob = map.get(id);
          status = ((System.currentTimeMillis() - start) + "ms");
          from = blob.getMetadata().getUserMetadata().get(TweetStoreConstants.SENDER_NAME);
-         tweet = toStringAndClose(blob.getPayload().getInput());
+         tweet = toString(blob.getPayload());
       } catch (Exception e) {
          logger.error(e, "Error listing container %s//%s/%s", service, container, id);
          status = (e.getMessage());

--- a/demos/tweetstore/rhcloud-tweetstore/src/test/java/org/jclouds/demo/tweetstore/controller/StoreTweetsControllerTest.java
+++ b/demos/tweetstore/rhcloud-tweetstore/src/test/java/org/jclouds/demo/tweetstore/controller/StoreTweetsControllerTest.java
@@ -107,13 +107,13 @@ public class StoreTweetsControllerTest {
          assertEquals(frankBlob.getMetadata().getName(), "1");
          assertEquals(frankBlob.getMetadata().getUserMetadata().get(TweetStoreConstants.SENDER_NAME), "frank");
          assertEquals(frankBlob.getMetadata().getContentMetadata().getContentType(), "text/plain");
-         assertEquals(toStringAndClose(frankBlob.getPayload().getInput()), "I love beans!");
+         assertEquals(toString(frankBlob.getPayload()), "I love beans!");
 
          Blob jimmyBlob = map.get("2");
          assertEquals(jimmyBlob.getMetadata().getName(), "2");
          assertEquals(jimmyBlob.getMetadata().getUserMetadata().get(TweetStoreConstants.SENDER_NAME), "jimmy");
          assertEquals(jimmyBlob.getMetadata().getContentMetadata().getContentType(), "text/plain");
-         assertEquals(toStringAndClose(jimmyBlob.getPayload().getInput()), "cloud is king");
+         assertEquals(toString(jimmyBlob.getPayload()), "cloud is king");
       }
 
    }

--- a/demos/tweetstore/runatcloud-tweetstore/src/main/java/org/jclouds/demo/tweetstore/functions/KeyToStoredTweetStatus.java
+++ b/demos/tweetstore/runatcloud-tweetstore/src/main/java/org/jclouds/demo/tweetstore/functions/KeyToStoredTweetStatus.java
@@ -59,7 +59,7 @@ public class KeyToStoredTweetStatus implements Function<String, StoredTweetStatu
          Blob blob = map.get(id);
          status = ((System.currentTimeMillis() - start) + "ms");
          from = blob.getMetadata().getUserMetadata().get(TweetStoreConstants.SENDER_NAME);
-         tweet = toStringAndClose(blob.getPayload().getInput());
+         tweet = toString(blob.getPayload());
       } catch (Exception e) {
          logger.error(e, "Error listing container %s//%s/%s", service, container, id);
          status = (e.getMessage());

--- a/demos/tweetstore/runatcloud-tweetstore/src/test/java/org/jclouds/demo/tweetstore/controller/StoreTweetsControllerTest.java
+++ b/demos/tweetstore/runatcloud-tweetstore/src/test/java/org/jclouds/demo/tweetstore/controller/StoreTweetsControllerTest.java
@@ -107,13 +107,13 @@ public class StoreTweetsControllerTest {
          assertEquals(frankBlob.getMetadata().getName(), "1");
          assertEquals(frankBlob.getMetadata().getUserMetadata().get(TweetStoreConstants.SENDER_NAME), "frank");
          assertEquals(frankBlob.getMetadata().getContentMetadata().getContentType(), "text/plain");
-         assertEquals(toStringAndClose(frankBlob.getPayload().getInput()), "I love beans!");
+         assertEquals(toString(frankBlob.getPayload()), "I love beans!");
 
          Blob jimmyBlob = map.get("2");
          assertEquals(jimmyBlob.getMetadata().getName(), "2");
          assertEquals(jimmyBlob.getMetadata().getUserMetadata().get(TweetStoreConstants.SENDER_NAME), "jimmy");
          assertEquals(jimmyBlob.getMetadata().getContentMetadata().getContentType(), "text/plain");
-         assertEquals(toStringAndClose(jimmyBlob.getPayload().getInput()), "cloud is king");
+         assertEquals(toString(jimmyBlob.getPayload()), "cloud is king");
       }
 
    }

--- a/drivers/gae/src/test/java/org/jclouds/gae/ConvertToJcloudsResponseTest.java
+++ b/drivers/gae/src/test/java/org/jclouds/gae/ConvertToJcloudsResponseTest.java
@@ -107,7 +107,7 @@ public class ConvertToJcloudsResponseTest {
       replay(gaeResponse);
       HttpResponse response = req.apply(gaeResponse);
       assertEquals(response.getStatusCode(), 200);
-      assertEquals(Strings2.toStringAndClose(response.getPayload().getInput()), "hello");
+      assertEquals(Strings2.toString(response.getPayload()), "hello");
       assertEquals(response.getHeaders().size(), 0);
       assertEquals(response.getPayload().getContentMetadata().getContentType(), "text/xml");
    }

--- a/drivers/jsch/src/test/java/org/jclouds/ssh/jsch/JschSshClientLiveTest.java
+++ b/drivers/jsch/src/test/java/org/jclouds/ssh/jsch/JschSshClientLiveTest.java
@@ -165,14 +165,14 @@ public class JschSshClientLiveTest {
       SshClient client = setupClient();
       client.put(temp.getAbsolutePath(), Payloads.newStringPayload("rabbit"));
       Payload input = setupClient().get(temp.getAbsolutePath());
-      String contents = Strings2.toStringAndClose(input.getInput());
+      String contents = Strings2.toString(input);
       assertEquals(contents, "rabbit");
    }
 
    @Test
    public void testGetEtcPassword() throws IOException {
       Payload input = setupClient().get("/etc/passwd");
-      String contents = Strings2.toStringAndClose(input.getInput());
+      String contents = Strings2.toString(input);
       assert contents.indexOf("root") >= 0 : "no root in " + contents;
    }
 

--- a/drivers/sshj/src/test/java/org/jclouds/sshj/SshjSshClientLiveTest.java
+++ b/drivers/sshj/src/test/java/org/jclouds/sshj/SshjSshClientLiveTest.java
@@ -152,13 +152,13 @@ public class SshjSshClientLiveTest {
       SshClient client = setupClient();
       client.put(temp.getAbsolutePath(), Payloads.newStringPayload("rabbit"));
       Payload input = client.get(temp.getAbsolutePath());
-      String contents = Strings2.toStringAndClose(input.getInput());
+      String contents = Strings2.toString(input);
       assertEquals(contents, "rabbit");
    }
 
    public void testGetEtcPassword() throws IOException {
       Payload input = setupClient().get("/etc/passwd");
-      String contents = Strings2.toStringAndClose(input.getInput());
+      String contents = Strings2.toString(input);
       assert contents.indexOf("root") >= 0 : "no root in " + contents;
    }
 

--- a/labs/glesys/src/main/java/org/jclouds/glesys/handlers/GleSYSErrorHandler.java
+++ b/labs/glesys/src/main/java/org/jclouds/glesys/handlers/GleSYSErrorHandler.java
@@ -80,7 +80,7 @@ public class GleSYSErrorHandler implements HttpErrorHandler {
       if (response.getPayload() == null)
          return null;
       try {
-         return Strings2.toStringAndClose(response.getPayload().getInput());
+         return Strings2.toString(response.getPayload());
       } catch (IOException e) {
          throw new RuntimeException(e);
       } finally {

--- a/labs/savvis-symphonyvpdc/src/main/java/org/jclouds/savvis/vpdc/handlers/VPDCErrorHandler.java
+++ b/labs/savvis-symphonyvpdc/src/main/java/org/jclouds/savvis/vpdc/handlers/VPDCErrorHandler.java
@@ -84,7 +84,7 @@ public class VPDCErrorHandler implements HttpErrorHandler {
       if (response.getPayload() == null)
          return null;
       try {
-         return Strings2.toStringAndClose(response.getPayload().getInput());
+         return Strings2.toString(response.getPayload());
       } catch (IOException e) {
          throw new RuntimeException(e);
       } finally {

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/HttpClientLiveTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/HttpClientLiveTest.java
@@ -83,7 +83,7 @@ public class HttpClientLiveTest extends BaseVCloudDirectorApiLiveTest {
       assertTrue(sessionWithToken.getSession().getLinks().size() > 0);
       assertNotNull(sessionWithToken.getToken());
 
-      OrgList orgList = parser.fromXML(Strings2.toStringAndClose(response.getPayload().getInput()), OrgList.class);
+      OrgList orgList = parser.fromXML(Strings2.toString(response.getPayload()), OrgList.class);
 
       assertTrue(orgList.getOrgs().size() > 0, "must have orgs");
 
@@ -99,7 +99,7 @@ public class HttpClientLiveTest extends BaseVCloudDirectorApiLiveTest {
             .addHeader("x-vcloud-authorization", sessionWithToken.getToken())
             .addHeader("Accept", "*/*").build());
 
-      String schema = Strings2.toStringAndClose(response.getPayload().getInput());
+      String schema = Strings2.toString(response.getPayload());
 
       // TODO: asserting something about the schema
    }

--- a/providers/azureblob/src/test/java/org/jclouds/azureblob/AzureBlobClientLiveTest.java
+++ b/providers/azureblob/src/test/java/org/jclouds/azureblob/AzureBlobClientLiveTest.java
@@ -265,7 +265,7 @@ public class AzureBlobClientLiveTest extends BaseBlobStoreIntegrationTest {
 
       // Test GET of object (including updated metadata)
       AzureBlob getBlob = getApi().getBlob(privateContainer, object.getProperties().getName());
-      assertEquals(Strings2.toStringAndClose(getBlob.getPayload().getInput()), data);
+      assertEquals(Strings2.toString(getBlob.getPayload()), data);
       // TODO assertEquals(getBlob.getName(), object.getProperties().getName());
       assertEquals(getBlob.getPayload().getContentMetadata().getContentLength(), new Long(data.length()));
       assertEquals(getBlob.getProperties().getContentMetadata().getContentType(), "text/plain");

--- a/providers/slicehost/src/main/java/org/jclouds/slicehost/handlers/ParseSlicehostErrorFromHttpResponse.java
+++ b/providers/slicehost/src/main/java/org/jclouds/slicehost/handlers/ParseSlicehostErrorFromHttpResponse.java
@@ -118,7 +118,7 @@ public class ParseSlicehostErrorFromHttpResponse implements HttpErrorHandler {
       // slicehost returns " " which is unparsable
       if (response.getPayload() != null) {
          try {
-            String payload = Strings2.toStringAndClose(response.getPayload().getInput()).trim();
+            String payload = Strings2.toString(response.getPayload()).trim();
             return payload.indexOf("xml") != -1 ? errorParser.parse(payload) : payload;
          } catch (IOException e) {
          }

--- a/providers/softlayer/src/main/java/org/jclouds/softlayer/handlers/SoftLayerErrorHandler.java
+++ b/providers/softlayer/src/main/java/org/jclouds/softlayer/handlers/SoftLayerErrorHandler.java
@@ -80,7 +80,7 @@ public class SoftLayerErrorHandler implements HttpErrorHandler {
       if (response.getPayload() == null)
          return null;
       try {
-         return Strings2.toStringAndClose(response.getPayload().getInput());
+         return Strings2.toString(response.getPayload());
       } catch (IOException e) {
          throw new RuntimeException(e);
       } finally {

--- a/sandbox-providers/boxdotnet/src/main/java/org/jclouds/boxdotnet/handlers/BoxDotNetErrorHandler.java
+++ b/sandbox-providers/boxdotnet/src/main/java/org/jclouds/boxdotnet/handlers/BoxDotNetErrorHandler.java
@@ -76,7 +76,7 @@ public class BoxDotNetErrorHandler implements HttpErrorHandler {
       if (response.getPayload() == null)
          return null;
       try {
-         return Strings2.toStringAndClose(response.getPayload().getInput());
+         return Strings2.toString(response.getPayload());
       } catch (IOException e) {
          throw new RuntimeException(e);
       } finally {

--- a/sandbox-providers/ibm-smartcloud/src/main/java/org/jclouds/ibm/smartcloud/handlers/IBMSmartCloudErrorHandler.java
+++ b/sandbox-providers/ibm-smartcloud/src/main/java/org/jclouds/ibm/smartcloud/handlers/IBMSmartCloudErrorHandler.java
@@ -86,6 +86,6 @@ public class IBMSmartCloudErrorHandler implements HttpErrorHandler {
    public String parseMessage(HttpResponse response) throws IOException {
       if (response.getPayload() == null)
          return null;
-      return Strings2.toStringAndClose(response.getPayload().getInput());
+      return Strings2.toString(response.getPayload());
    }
 }


### PR DESCRIPTION
These ensure that inputs are closed properly.

Updated with: find -name *.java | xargs sed -i
's/toStringAndClose((.*).getInput())/toString(\1)/'
