### PR TITLE
Prefer valueOf over explicit object creation

### DIFF
--- a/apis/atmos/src/main/java/org/jclouds/atmos/options/ListOptions.java
+++ b/apis/atmos/src/main/java/org/jclouds/atmos/options/ListOptions.java
@@ -72,7 +72,7 @@ public class ListOptions extends BaseHttpRequestOptions {
 
    public Integer getLimit() {
       String maxresults = getFirstHeaderOrNull("x-emc-limit");
-      return (maxresults != null) ? new Integer(maxresults) : null;
+      return (maxresults != null) ? Integer.valueOf(maxresults) : null;
    }
 
    public static class Builder {

--- a/apis/atmos/src/test/java/org/jclouds/atmos/AtmosClientLiveTest.java
+++ b/apis/atmos/src/test/java/org/jclouds/atmos/AtmosClientLiveTest.java
@@ -251,7 +251,7 @@ public class AtmosClientLiveTest extends BaseBlobStoreIntegrationTest {
    }
 
    private static void verifyMetadata(String metadataValue, AtmosObject getBlob) {
-      assertEquals(getBlob.getContentMetadata().getContentLength(), new Long(16));
+      assertEquals(getBlob.getContentMetadata().getContentLength(), Long.valueOf(16));
       assert getBlob.getContentMetadata().getContentType().startsWith("text/plain");
       assertEquals(getBlob.getUserMetadata().getMetadata().get("Metadata"), metadataValue);
       SystemMetadata md = getBlob.getSystemMetadata();

--- a/apis/cloudloadbalancers/src/test/java/org/jclouds/cloudloadbalancers/features/LoadBalancerClientLiveTest.java
+++ b/apis/cloudloadbalancers/src/test/java/org/jclouds/cloudloadbalancers/features/LoadBalancerClientLiveTest.java
@@ -136,7 +136,7 @@ public class LoadBalancerClientLiveTest extends BaseCloudLoadBalancersClientLive
       assertEquals(lb.getRegion(), region);
       assertEquals(lb.getName(), name);
       assertEquals(lb.getProtocol(), "HTTP");
-      assertEquals(lb.getPort(), new Integer(80));
+      assertEquals(lb.getPort(), Integer.valueOf(80));
       assertEquals(Iterables.get(lb.getVirtualIPs(), 0).getType(), Type.PUBLIC);
    }
 

--- a/apis/cloudservers/src/test/java/org/jclouds/cloudservers/CloudServersClientLiveTest.java
+++ b/apis/cloudservers/src/test/java/org/jclouds/cloudservers/CloudServersClientLiveTest.java
@@ -344,8 +344,8 @@ public class CloudServersClientLiveTest extends BaseComputeServiceContextLiveTes
       assertNotNull(server.getHostId());
       assertEquals(server.getStatus(), ServerStatus.ACTIVE);
       assert server.getProgress() >= 0 : "newDetails.getProgress()" + server.getProgress();
-      assertEquals(new Integer(14362), server.getImageId());
-      assertEquals(new Integer(1), server.getFlavorId());
+      assertEquals(Integer.valueOf(14362), server.getImageId());
+      assertEquals(Integer.valueOf(1), server.getFlavorId());
       assertNotNull(server.getAddresses());
       // listAddresses tests..
       assertEquals(client.getAddresses(serverId), server.getAddresses());
@@ -445,7 +445,7 @@ public class CloudServersClientLiveTest extends BaseComputeServiceContextLiveTes
       blockUntilServerActive(serverId2);
       assertIpConfigured(server, adminPass2);
       assert server.getAddresses().getPublicAddresses().contains(ip) : server.getAddresses() + " doesn't contain " + ip;
-      assertEquals(server.getSharedIpGroupId(), new Integer(sharedIpGroupId));
+      assertEquals(server.getSharedIpGroupId(), Integer.valueOf(sharedIpGroupId));
    }
 
    private void assertIpConfigured(Server server, String password) {
@@ -518,7 +518,7 @@ public class CloudServersClientLiveTest extends BaseComputeServiceContextLiveTes
    public void testCreateImage() throws Exception {
       Image image = client.createImageFromServer("hoofie", serverId);
       assertEquals("hoofie", image.getName());
-      assertEquals(new Integer(serverId), image.getServerId());
+      assertEquals(Integer.valueOf(serverId), image.getServerId());
       imageId = image.getId();
       blockUntilImageActive(imageId);
    }
@@ -528,7 +528,7 @@ public class CloudServersClientLiveTest extends BaseComputeServiceContextLiveTes
       client.rebuildServer(serverId, new RebuildServerOptions().withImage(imageId));
       blockUntilServerActive(serverId);
       // issue Web Hosting #119580 imageId comes back incorrect after rebuild
-      assert !new Integer(imageId).equals(client.getServer(serverId).getImageId());
+      assert !Integer.valueOf(imageId).equals(client.getServer(serverId).getImageId());
    }
 
    @Test(timeOut = 10 * 60 * 1000, dependsOnMethods = "testRebuildServer")
@@ -549,7 +549,7 @@ public class CloudServersClientLiveTest extends BaseComputeServiceContextLiveTes
       blockUntilServerVerifyResize(serverId);
       client.revertResizeServer(serverId);
       blockUntilServerActive(serverId);
-      assertEquals(new Integer(1), client.getServer(serverId).getFlavorId());
+      assertEquals(Integer.valueOf(1), client.getServer(serverId).getFlavorId());
    }
 
    @Test(timeOut = 10 * 60 * 1000, dependsOnMethods = "testRebootSoft")
@@ -558,7 +558,7 @@ public class CloudServersClientLiveTest extends BaseComputeServiceContextLiveTes
       blockUntilServerVerifyResize(serverId2);
       client.confirmResizeServer(serverId2);
       blockUntilServerActive(serverId2);
-      assertEquals(new Integer(2), client.getServer(serverId2).getFlavorId());
+      assertEquals(Integer.valueOf(2), client.getServer(serverId2).getFlavorId());
    }
 
    @Test(timeOut = 10 * 60 * 1000, dependsOnMethods = { "testRebootSoft", "testRevertResize", "testConfirmResize" })

--- a/apis/cloudservers/src/test/java/org/jclouds/cloudservers/functions/ParseFlavorListFromJsonResponseTest.java
+++ b/apis/cloudservers/src/test/java/org/jclouds/cloudservers/functions/ParseFlavorListFromJsonResponseTest.java
@@ -67,13 +67,13 @@ public class ParseFlavorListFromJsonResponseTest {
       List<Flavor> response = parser.apply(HttpResponse.builder().statusCode(200).message("ok").payload(is).build());
       assertEquals(response.get(0).getId(), 1);
       assertEquals(response.get(0).getName(), "256 MB Server");
-      assertEquals(response.get(0).getDisk(), new Integer(10));
-      assertEquals(response.get(0).getRam(), new Integer(256));
+      assertEquals(response.get(0).getDisk(), Integer.valueOf(10));
+      assertEquals(response.get(0).getRam(), Integer.valueOf(256));
 
       assertEquals(response.get(1).getId(), 2);
       assertEquals(response.get(1).getName(), "512 MB Server");
-      assertEquals(response.get(1).getDisk(), new Integer(20));
-      assertEquals(response.get(1).getRam(), new Integer(512));
+      assertEquals(response.get(1).getDisk(), Integer.valueOf(20));
+      assertEquals(response.get(1).getRam(), Integer.valueOf(512));
 
    }
 

--- a/apis/cloudservers/src/test/java/org/jclouds/cloudservers/functions/ParseImageFromJsonResponseTest.java
+++ b/apis/cloudservers/src/test/java/org/jclouds/cloudservers/functions/ParseImageFromJsonResponseTest.java
@@ -63,8 +63,8 @@ public class ParseImageFromJsonResponseTest {
       assertEquals(response.getId(), 2);
       assertEquals(response.getName(), "CentOS 5.2");
       assertEquals(response.getCreated(), dateService.iso8601SecondsDateParse("2010-08-10T12:00:00Z"));
-      assertEquals(response.getProgress(), new Integer(80));
-      assertEquals(response.getServerId(), new Integer(12));
+      assertEquals(response.getProgress(), Integer.valueOf(80));
+      assertEquals(response.getServerId(), Integer.valueOf(12));
       assertEquals(response.getStatus(), ImageStatus.SAVING);
       assertEquals(response.getUpdated(), dateService.iso8601SecondsDateParse(("2010-10-10T12:00:00Z")));
 

--- a/apis/cloudservers/src/test/java/org/jclouds/cloudservers/functions/ParseImageListFromJsonResponseTest.java
+++ b/apis/cloudservers/src/test/java/org/jclouds/cloudservers/functions/ParseImageListFromJsonResponseTest.java
@@ -91,8 +91,8 @@ public class ParseImageListFromJsonResponseTest {
       assertEquals(response.get(1).getName(), "My Server Backup");
       assertEquals(response.get(1).getCreated(), dateService.iso8601SecondsDateParse("2009-07-07T09:56:16-05:00"));
       ;
-      assertEquals(response.get(1).getProgress(), new Integer(80));
-      assertEquals(response.get(1).getServerId(), new Integer(12));
+      assertEquals(response.get(1).getProgress(), Integer.valueOf(80));
+      assertEquals(response.get(1).getServerId(), Integer.valueOf(12));
       assertEquals(response.get(1).getStatus(), ImageStatus.SAVING);
       assertEquals(response.get(1).getUpdated(), dateService.iso8601SecondsDateParse("2010-10-10T12:00:00Z"));
    }

--- a/apis/cloudservers/src/test/java/org/jclouds/cloudservers/functions/ParseServerFromJsonResponseTest.java
+++ b/apis/cloudservers/src/test/java/org/jclouds/cloudservers/functions/ParseServerFromJsonResponseTest.java
@@ -52,11 +52,11 @@ public class ParseServerFromJsonResponseTest {
 
       assertEquals(response.getId(), 1234);
       assertEquals(response.getName(), "sample-server");
-      assertEquals(response.getImageId(), new Integer(2));
-      assertEquals(response.getFlavorId(), new Integer(1));
+      assertEquals(response.getImageId(), Integer.valueOf(2));
+      assertEquals(response.getFlavorId(), Integer.valueOf(1));
       assertEquals(response.getHostId(), "e4d909c290d0fb1ca068ffaddf22cbd0");
       assertEquals(response.getStatus(), ServerStatus.BUILD);
-      assertEquals(response.getProgress(), new Integer(60));
+      assertEquals(response.getProgress(), Integer.valueOf(60));
       List<String> publicAddresses = Lists.newArrayList("67.23.10.132", "67.23.10.131");
       List<String> privateAddresses = Lists.newArrayList("10.176.42.16");
       Addresses addresses1 = new Addresses();

--- a/apis/cloudservers/src/test/java/org/jclouds/cloudservers/functions/ParseServerListFromJsonResponseTest.java
+++ b/apis/cloudservers/src/test/java/org/jclouds/cloudservers/functions/ParseServerListFromJsonResponseTest.java
@@ -73,11 +73,11 @@ public class ParseServerListFromJsonResponseTest {
 
       assertEquals(response.get(0).getId(), 1234);
       assertEquals(response.get(0).getName(), "sample-server");
-      assertEquals(response.get(0).getImageId(), new Integer(2));
-      assertEquals(response.get(0).getFlavorId(), new Integer(1));
+      assertEquals(response.get(0).getImageId(), Integer.valueOf(2));
+      assertEquals(response.get(0).getFlavorId(), Integer.valueOf(1));
       assertEquals(response.get(0).getHostId(), "e4d909c290d0fb1ca068ffaddf22cbd0");
       assertEquals(response.get(0).getStatus(), ServerStatus.BUILD);
-      assertEquals(response.get(0).getProgress(), new Integer(60));
+      assertEquals(response.get(0).getProgress(), Integer.valueOf(60));
       List<String> publicAddresses = Lists.newArrayList("67.23.10.132", "67.23.10.131");
       List<String> privateAddresses = Lists.newArrayList("10.176.42.16");
       Addresses addresses1 = new Addresses();
@@ -87,8 +87,8 @@ public class ParseServerListFromJsonResponseTest {
       assertEquals(response.get(0).getMetadata(), ImmutableMap.of("Server Label", "Web Head 1", "Image Version", "2.1"));
       assertEquals(response.get(1).getId(), 5678);
       assertEquals(response.get(1).getName(), "sample-server2");
-      assertEquals(response.get(1).getImageId(), new Integer(2));
-      assertEquals(response.get(1).getFlavorId(), new Integer(1));
+      assertEquals(response.get(1).getImageId(), Integer.valueOf(2));
+      assertEquals(response.get(1).getFlavorId(), Integer.valueOf(1));
       assertEquals(response.get(1).getHostId(), "9e107d9d372bb6826bd81d3542a419d6");
       assertEquals(response.get(1).getStatus(), ServerStatus.ACTIVE);
       assertEquals(response.get(1).getProgress(), null);

--- a/apis/cloudsigma/src/main/java/org/jclouds/cloudsigma/functions/MapToDriveInfo.java
+++ b/apis/cloudsigma/src/main/java/org/jclouds/cloudsigma/functions/MapToDriveInfo.java
@@ -69,7 +69,7 @@ public class MapToDriveInfo implements Function<Map<String, String>, DriveInfo> 
       if (from.containsKey("readers"))
          builder.readers(Splitter.on(' ').split(from.get("readers")));
       if (from.containsKey("size"))
-         builder.size(new Long(from.get("size")));
+         builder.size(Long.valueOf(from.get("size")));
       Map<String, String> metadata = Maps.newLinkedHashMap();
       for (Entry<String, String> entry : from.entrySet()) {
          if (entry.getKey().startsWith("user:"))
@@ -78,7 +78,7 @@ public class MapToDriveInfo implements Function<Map<String, String>, DriveInfo> 
       if (from.containsKey("use"))
          builder.use(Splitter.on(' ').split(from.get("use")));
       if (from.containsKey("bits"))
-         builder.bits(new Integer(from.get("bits")));
+         builder.bits(Integer.valueOf(from.get("bits")));
       if (from.containsKey("url"))
          builder.url(URI.create(from.get("url")));
       builder.encryptionKey(from.get("encryption:key"));
@@ -88,9 +88,9 @@ public class MapToDriveInfo implements Function<Map<String, String>, DriveInfo> 
       if (from.containsKey("drive_type"))
          builder.driveType(Splitter.on(',').split(from.get("drive_type")));
       if (from.containsKey("autoexpanding"))
-         builder.autoexpanding(new Boolean(from.get("autoexpanding")));
+         builder.autoexpanding(Boolean.valueOf(from.get("autoexpanding")));
       if (from.containsKey("free"))
-         builder.free(new Boolean(from.get("free")));
+         builder.free(Boolean.valueOf(from.get("free")));
       if (from.containsKey("type"))
          builder.type(DriveType.fromValue(from.get("type")));
       try {
@@ -104,13 +104,13 @@ public class MapToDriveInfo implements Function<Map<String, String>, DriveInfo> 
    protected DriveMetrics buildMetrics(Map<String, String> from) {
       DriveMetrics.Builder metricsBuilder = new DriveMetrics.Builder();
       if (from.containsKey("read:bytes"))
-         metricsBuilder.readBytes(new Long(from.get("read:bytes")));
+         metricsBuilder.readBytes(Long.valueOf(from.get("read:bytes")));
       if (from.containsKey("read:requests"))
-         metricsBuilder.readRequests(new Long(from.get("read:requests")));
+         metricsBuilder.readRequests(Long.valueOf(from.get("read:requests")));
       if (from.containsKey("write:bytes"))
-         metricsBuilder.writeBytes(new Long(from.get("write:bytes")));
+         metricsBuilder.writeBytes(Long.valueOf(from.get("write:bytes")));
       if (from.containsKey("write:requests"))
-         metricsBuilder.writeRequests(new Long(from.get("write:requests")));
+         metricsBuilder.writeRequests(Long.valueOf(from.get("write:requests")));
       return metricsBuilder.build();
    }
 }

--- a/apis/cloudsigma/src/main/java/org/jclouds/cloudsigma/functions/MapToDriveMetrics.java
+++ b/apis/cloudsigma/src/main/java/org/jclouds/cloudsigma/functions/MapToDriveMetrics.java
@@ -74,13 +74,13 @@ public class MapToDriveMetrics implements Function<Map<String, String>, Map<Stri
    protected DriveMetrics buildMetrics(String key, Map<String, String> from) {
       DriveMetrics.Builder builder = new DriveMetrics.Builder();
       if (from.containsKey(key + ":read:bytes"))
-         builder.readBytes(new Long(from.get(key + ":read:bytes")));
+         builder.readBytes(Long.valueOf(from.get(key + ":read:bytes")));
       if (from.containsKey(key + ":read:requests"))
-         builder.readRequests(new Long(from.get(key + ":read:requests")));
+         builder.readRequests(Long.valueOf(from.get(key + ":read:requests")));
       if (from.containsKey(key + ":write:bytes"))
-         builder.writeBytes(new Long(from.get(key + ":write:bytes")));
+         builder.writeBytes(Long.valueOf(from.get(key + ":write:bytes")));
       if (from.containsKey(key + ":write:requests"))
-         builder.writeRequests(new Long(from.get(key + ":write:requests")));
+         builder.writeRequests(Long.valueOf(from.get(key + ":write:requests")));
       return builder.build();
    }
 }

--- a/apis/cloudsigma/src/main/java/org/jclouds/cloudsigma/functions/MapToServerInfo.java
+++ b/apis/cloudsigma/src/main/java/org/jclouds/cloudsigma/functions/MapToServerInfo.java
@@ -68,12 +68,12 @@ public class MapToServerInfo implements Function<Map<String, String>, ServerInfo
       if (from.containsKey("status"))
          builder.status(ServerStatus.fromValue(from.get("status")));
       if (from.containsKey("smp") && !"auto".equals(from.get("smp")))
-         builder.smp(new Integer(from.get("smp")));
+         builder.smp(Integer.valueOf(from.get("smp")));
       builder.cpu(Integer.parseInt(from.get("cpu")));
       builder.mem(Integer.parseInt(from.get("mem")));
       builder.user(from.get("user"));
       if (from.containsKey("started"))
-         builder.started(new Date(new Long(from.get("started"))));
+         builder.started(new Date(Long.valueOf(from.get("started"))));
       builder.uuid(from.get("server"));
       builder.vnc(new VNC(from.get("vnc:ip"), from.get("vnc:password"), from.containsKey("vnc:tls")
             && Boolean.valueOf(from.get("vnc:tls"))));

--- a/apis/cloudsigma/src/main/java/org/jclouds/cloudsigma/functions/MapToServerMetrics.java
+++ b/apis/cloudsigma/src/main/java/org/jclouds/cloudsigma/functions/MapToServerMetrics.java
@@ -44,13 +44,13 @@ public class MapToServerMetrics implements Function<Map<String, String>, ServerM
    public ServerMetrics apply(Map<String, String> from) {
       ServerMetrics.Builder metricsBuilder = new ServerMetrics.Builder();
       if (from.containsKey("tx:packets"))
-         metricsBuilder.txPackets(new Long(from.get("tx:packets")));
+         metricsBuilder.txPackets(Long.valueOf(from.get("tx:packets")));
       if (from.containsKey("tx"))
-         metricsBuilder.tx(new Long(from.get("tx")));
+         metricsBuilder.tx(Long.valueOf(from.get("tx")));
       if (from.containsKey("rx:packets"))
-         metricsBuilder.rxPackets(new Long(from.get("rx:packets")));
+         metricsBuilder.rxPackets(Long.valueOf(from.get("rx:packets")));
       if (from.containsKey("rx"))
-         metricsBuilder.rx(new Long(from.get("rx")));
+         metricsBuilder.rx(Long.valueOf(from.get("rx")));
       metricsBuilder.driveMetrics(mapToDriveMetrics.apply(from));
 
       ServerMetrics metrics = metricsBuilder.build();

--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/domain/Account.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/domain/Account.java
@@ -103,7 +103,7 @@ public class Account extends ForwardingSet<User> {
       }
 
       public static Type fromValue(String type) {
-         Integer code = new Integer(checkNotNull(type, "type"));
+         Integer code = Integer.valueOf(checkNotNull(type, "type"));
          return INDEX.containsKey(code) ? INDEX.get(code) : UNRECOGNIZED;
       }
 
@@ -473,7 +473,7 @@ public class Account extends ForwardingSet<User> {
    }
 
    private static Long toLongNullIfUnlimited(String in) {
-      return in == null || "Unlimited".equals(in) ? null : new Long(in);
+      return in == null || "Unlimited".equals(in) ? null : Long.valueOf(in);
    }
 
    protected Account(String id, @Nullable Account.Type type, @Nullable String networkDomain, @Nullable String domain,

--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/domain/Capacity.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/domain/Capacity.java
@@ -75,7 +75,7 @@ public class Capacity implements Comparable<Capacity> {
       }
 
       public static Type fromValue(String type) {
-         Integer code = new Integer(checkNotNull(type, "type"));
+         Integer code = Integer.valueOf(checkNotNull(type, "type"));
          return INDEX.containsKey(code) ? INDEX.get(code) : UNRECOGNIZED;
       }
    }

--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/domain/ResourceLimit.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/domain/ResourceLimit.java
@@ -91,7 +91,7 @@ public class ResourceLimit {
       }
 
       public static ResourceType fromValue(String resourceType) {
-         Integer code = new Integer(checkNotNull(resourceType, "resourcetype"));
+         Integer code = Integer.valueOf(checkNotNull(resourceType, "resourcetype"));
          return INDEX.containsKey(code) ? INDEX.get(code) : UNRECOGNIZED;
       }
    }

--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/domain/UsageRecord.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/domain/UsageRecord.java
@@ -80,7 +80,7 @@ public class UsageRecord {
       }
 
       public static UsageType fromValue(String usageType) {
-         Integer code = new Integer(checkNotNull(usageType, "usageType"));
+         Integer code = Integer.valueOf(checkNotNull(usageType, "usageType"));
          return INDEX.containsKey(code) ? INDEX.get(code) : UNRECOGNIZED;
       }
 

--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/domain/Volume.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/domain/Volume.java
@@ -108,7 +108,7 @@ public class Volume {
       }
 
       public static Type fromValue(String resourceType) {
-         Integer code = new Integer(checkNotNull(resourceType, "resourcetype"));
+         Integer code = Integer.valueOf(checkNotNull(resourceType, "resourcetype"));
          return INDEX.containsKey(code) ? INDEX.get(code) : UNRECOGNIZED;
       }
 

--- a/apis/deltacloud/src/main/java/org/jclouds/deltacloud/xml/HardwarePropertyHandler.java
+++ b/apis/deltacloud/src/main/java/org/jclouds/deltacloud/xml/HardwarePropertyHandler.java
@@ -87,7 +87,7 @@ public class HardwarePropertyHandler extends ParseSax.HandlerWithResult<Hardware
       if (DOUBLE.matcher(in).matches())
          return new Double(in);
       else if (LONG.matcher(in).matches())
-         return new Long(in);
+         return Long.valueOf(in);
       return null;
    }
 

--- a/apis/deltacloud/src/test/java/org/jclouds/deltacloud/xml/HardwareProfileHandlerTest.java
+++ b/apis/deltacloud/src/test/java/org/jclouds/deltacloud/xml/HardwareProfileHandlerTest.java
@@ -65,13 +65,13 @@ public class HardwareProfileHandlerTest {
       HardwareProfile expects = new HardwareProfile(
             URI.create("http://localhost:3001/api/hardware_profiles/m1-xlarge"), "m1-xlarge", "m1-xlarge",
             ImmutableSet.<HardwareProperty> of(
-                  new FixedHardwareProperty("cpu", "count", new Long(4)),
-                  new RangeHardwareProperty("memory", "MB", new Long(12288), new HardwareParameter(URI
+                  new FixedHardwareProperty("cpu", "count", Long.valueOf(4)),
+                  new RangeHardwareProperty("memory", "MB", Long.valueOf(12288), new HardwareParameter(URI
                         .create("http://localhost:3001/api/instances"), "post", "hwp_memory", "create"),
-                        new Long(12288), new Long(32768)),
-                  new EnumHardwareProperty("storage", "GB", new Long(1024), new HardwareParameter(URI
+                        Long.valueOf(12288), Long.valueOf(32768)),
+                  new EnumHardwareProperty("storage", "GB", Long.valueOf(1024), new HardwareParameter(URI
                         .create("http://localhost:3001/api/instances"), "post", "hwp_storage", "create"),
-                        ImmutableSet.<Object> of(new Long(1024), new Long(2048), new Long(4096))),
+                        ImmutableSet.<Object> of(Long.valueOf(1024), Long.valueOf(2048), Long.valueOf(4096))),
                   new FixedHardwareProperty("architecture", "label", "x86_64"))
       );
       assertEquals(parseHardwareProfile(), expects);

--- a/apis/deltacloud/src/test/java/org/jclouds/deltacloud/xml/HardwareProfilesHandlerTest.java
+++ b/apis/deltacloud/src/test/java/org/jclouds/deltacloud/xml/HardwareProfilesHandlerTest.java
@@ -50,27 +50,27 @@ public class HardwareProfilesHandlerTest extends BaseHandlerTest {
       Set<? extends HardwareProfile> expects = ImmutableSet.of(
             new HardwareProfile(URI.create("http://localhost:3001/api/hardware_profiles/m1-small"), "m1-small",
                   "m1-small", ImmutableSet.<HardwareProperty> of(
-                        new FixedHardwareProperty("cpu", "count", new Long(1)), new FixedHardwareProperty("memory",
-                              "MB", new Double(1740.8)), new FixedHardwareProperty("storage", "GB", new Long(160)),
+                        new FixedHardwareProperty("cpu", "count", Long.valueOf(1)), new FixedHardwareProperty("memory",
+                              "MB", new Double(1740.8)), new FixedHardwareProperty("storage", "GB", Long.valueOf(160)),
                         new FixedHardwareProperty("architecture", "label", "i386"))),
             new HardwareProfile(URI.create("http://localhost:3001/api/hardware_profiles/m1-large"), "m1-large",
                   "m1-large", ImmutableSet.<HardwareProperty> of(
-                        new FixedHardwareProperty("cpu", "count", new Long(2)),
-                        new RangeHardwareProperty("memory", "MB", new Long(10240), new HardwareParameter(URI
+                        new FixedHardwareProperty("cpu", "count", Long.valueOf(2)),
+                        new RangeHardwareProperty("memory", "MB", Long.valueOf(10240), new HardwareParameter(URI
                               .create("http://localhost:3001/api/instances"), "post", "hwp_memory", "create"),
-                              new Double(7680.0), new Long(15360)), new EnumHardwareProperty("storage", "GB", new Long(
+                              new Double(7680.0), Long.valueOf(15360)), new EnumHardwareProperty("storage", "GB", Long.valueOf(
                               850), new HardwareParameter(URI.create("http://localhost:3001/api/instances"), "post",
-                              "hwp_storage", "create"), ImmutableSet.<Object> of(new Long(850), new Long(1024))),
+                              "hwp_storage", "create"), ImmutableSet.<Object> of(Long.valueOf(850), Long.valueOf(1024))),
                         new FixedHardwareProperty("architecture", "label", "x86_64"))),
             new HardwareProfile(URI.create("http://localhost:3001/api/hardware_profiles/m1-xlarge"), "m1-xlarge",
                   "m1-xlarge", ImmutableSet.<HardwareProperty> of(
-                        new FixedHardwareProperty("cpu", "count", new Long(4)),
-                        new RangeHardwareProperty("memory", "MB", new Long(12288), new HardwareParameter(URI
+                        new FixedHardwareProperty("cpu", "count", Long.valueOf(4)),
+                        new RangeHardwareProperty("memory", "MB", Long.valueOf(12288), new HardwareParameter(URI
                               .create("http://localhost:3001/api/instances"), "post", "hwp_memory", "create"),
-                              new Long(12288), new Long(32768)),
-                        new EnumHardwareProperty("storage", "GB", new Long(1024), new HardwareParameter(URI
+                              Long.valueOf(12288), Long.valueOf(32768)),
+                        new EnumHardwareProperty("storage", "GB", Long.valueOf(1024), new HardwareParameter(URI
                               .create("http://localhost:3001/api/instances"), "post", "hwp_storage", "create"),
-                              ImmutableSet.<Object> of(new Long(1024), new Long(2048), new Long(4096))),
+                              ImmutableSet.<Object> of(Long.valueOf(1024), Long.valueOf(2048), Long.valueOf(4096))),
                         new FixedHardwareProperty("architecture", "label", "x86_64"))),
             new HardwareProfile(URI.create("http://localhost:3001/api/hardware_profiles/opaque"), "opaque", "opaque",
                   ImmutableSet.<HardwareProperty> of()));

--- a/apis/elasticstack/src/main/java/org/jclouds/elasticstack/functions/MapToDriveInfo.java
+++ b/apis/elasticstack/src/main/java/org/jclouds/elasticstack/functions/MapToDriveInfo.java
@@ -65,7 +65,7 @@ public class MapToDriveInfo implements Function<Map<String, String>, DriveInfo> 
       if (from.containsKey("readers"))
          builder.readers(Splitter.on(' ').split(from.get("readers")));
       if (from.containsKey("size"))
-         builder.size(new Long(from.get("size")));
+         builder.size(Long.valueOf(from.get("size")));
       Map<String, String> metadata = Maps.newLinkedHashMap();
       for (Entry<String, String> entry : from.entrySet()) {
          if (entry.getKey().startsWith("user:"))
@@ -83,13 +83,13 @@ public class MapToDriveInfo implements Function<Map<String, String>, DriveInfo> 
    protected DriveMetrics buildMetrics(Map<String, String> from) {
       DriveMetrics.Builder metricsBuilder = new DriveMetrics.Builder();
       if (from.containsKey("read:bytes"))
-         metricsBuilder.readBytes(new Long(from.get("read:bytes")));
+         metricsBuilder.readBytes(Long.valueOf(from.get("read:bytes")));
       if (from.containsKey("read:requests"))
-         metricsBuilder.readRequests(new Long(from.get("read:requests")));
+         metricsBuilder.readRequests(Long.valueOf(from.get("read:requests")));
       if (from.containsKey("write:bytes"))
-         metricsBuilder.writeBytes(new Long(from.get("write:bytes")));
+         metricsBuilder.writeBytes(Long.valueOf(from.get("write:bytes")));
       if (from.containsKey("write:requests"))
-         metricsBuilder.writeRequests(new Long(from.get("write:requests")));
+         metricsBuilder.writeRequests(Long.valueOf(from.get("write:requests")));
       return metricsBuilder.build();
    }
 }

--- a/apis/elasticstack/src/main/java/org/jclouds/elasticstack/functions/MapToDriveMetrics.java
+++ b/apis/elasticstack/src/main/java/org/jclouds/elasticstack/functions/MapToDriveMetrics.java
@@ -74,13 +74,13 @@ public class MapToDriveMetrics implements Function<Map<String, String>, Map<Stri
    protected DriveMetrics buildMetrics(String key, Map<String, String> from) {
       DriveMetrics.Builder builder = new DriveMetrics.Builder();
       if (from.containsKey(key + ":read:bytes"))
-         builder.readBytes(new Long(from.get(key + ":read:bytes")));
+         builder.readBytes(Long.valueOf(from.get(key + ":read:bytes")));
       if (from.containsKey(key + ":read:requests"))
-         builder.readRequests(new Long(from.get(key + ":read:requests")));
+         builder.readRequests(Long.valueOf(from.get(key + ":read:requests")));
       if (from.containsKey(key + ":write:bytes"))
-         builder.writeBytes(new Long(from.get(key + ":write:bytes")));
+         builder.writeBytes(Long.valueOf(from.get(key + ":write:bytes")));
       if (from.containsKey(key + ":write:requests"))
-         builder.writeRequests(new Long(from.get(key + ":write:requests")));
+         builder.writeRequests(Long.valueOf(from.get(key + ":write:requests")));
       return builder.build();
    }
 }

--- a/apis/elasticstack/src/main/java/org/jclouds/elasticstack/functions/MapToServerInfo.java
+++ b/apis/elasticstack/src/main/java/org/jclouds/elasticstack/functions/MapToServerInfo.java
@@ -68,16 +68,16 @@ public class MapToServerInfo implements Function<Map<String, String>, ServerInfo
 
 
       if (from.containsKey("smp:cores")) {
-            builder.smp(new Integer(from.get("smp:cores")));
+            builder.smp(Integer.valueOf(from.get("smp:cores")));
       } else if (from.containsKey("smp") && !"auto".equals(from.get("smp"))) {
-            builder.smp(new Integer(from.get("smp")));
+            builder.smp(Integer.valueOf(from.get("smp")));
       }
 
       builder.cpu(Integer.parseInt(from.get("cpu")));
       builder.mem(Integer.parseInt(from.get("mem")));
       builder.user(from.get("user"));
       if (from.containsKey("started"))
-         builder.started(new Date(new Long(from.get("started"))));
+         builder.started(new Date(Long.valueOf(from.get("started"))));
       builder.uuid(from.get("server"));
       if (from.containsKey("boot"))
          builder.bootDeviceIds(Splitter.on(' ').split(from.get("boot")));

--- a/apis/elasticstack/src/main/java/org/jclouds/elasticstack/functions/MapToServerMetrics.java
+++ b/apis/elasticstack/src/main/java/org/jclouds/elasticstack/functions/MapToServerMetrics.java
@@ -44,13 +44,13 @@ public class MapToServerMetrics implements Function<Map<String, String>, ServerM
    public ServerMetrics apply(Map<String, String> from) {
       ServerMetrics.Builder metricsBuilder = new ServerMetrics.Builder();
       if (from.containsKey("tx:packets"))
-         metricsBuilder.txPackets(new Long(from.get("tx:packets")));
+         metricsBuilder.txPackets(Long.valueOf(from.get("tx:packets")));
       if (from.containsKey("tx"))
-         metricsBuilder.tx(new Long(from.get("tx")));
+         metricsBuilder.tx(Long.valueOf(from.get("tx")));
       if (from.containsKey("rx:packets"))
-         metricsBuilder.rxPackets(new Long(from.get("rx:packets")));
+         metricsBuilder.rxPackets(Long.valueOf(from.get("rx:packets")));
       if (from.containsKey("rx"))
-         metricsBuilder.rx(new Long(from.get("rx")));
+         metricsBuilder.rx(Long.valueOf(from.get("rx")));
       metricsBuilder.driveMetrics(mapToDriveMetrics.apply(from));
 
       ServerMetrics metrics = metricsBuilder.build();

--- a/apis/filesystem/src/main/java/org/jclouds/filesystem/FilesystemAsyncBlobStore.java
+++ b/apis/filesystem/src/main/java/org/jclouds/filesystem/FilesystemAsyncBlobStore.java
@@ -567,7 +567,7 @@ public class FilesystemAsyncBlobStore extends BaseAsyncBlobStore {
             byte[] byteArray = out.toByteArray();
             blob.setPayload(byteArray);
             HttpUtils.copy(cmd, blob.getPayload().getContentMetadata());
-            blob.getPayload().getContentMetadata().setContentLength(new Long(byteArray.length));
+            blob.getPayload().getContentMetadata().setContentLength(Long.valueOf(byteArray.length));
          }
       }
       checkNotNull(blob.getPayload(), "payload " + blob);

--- a/apis/filesystem/src/test/java/org/jclouds/filesystem/FilesystemAsyncBlobStoreTest.java
+++ b/apis/filesystem/src/test/java/org/jclouds/filesystem/FilesystemAsyncBlobStoreTest.java
@@ -656,7 +656,7 @@ public class FilesystemAsyncBlobStoreTest {
         assertEquals(metadata.getUserMetadata().size(), 0, "Wrong blob UserMetadata");
         // metadata.getLastModified()
         File file = new File(TARGET_CONTAINER_NAME + File.separator + BLOB_KEY);
-        assertEquals(metadata.getContentMetadata().getContentLength(), new Long(file.length()), "Wrong blob size");
+        assertEquals(metadata.getContentMetadata().getContentLength(), Long.valueOf(file.length()), "Wrong blob size");
     }
 
     public void testDeleteContainer_NotExistingContainer() {

--- a/apis/nova/src/test/java/org/jclouds/openstack/nova/NovaClientLiveTest.java
+++ b/apis/nova/src/test/java/org/jclouds/openstack/nova/NovaClientLiveTest.java
@@ -264,8 +264,8 @@ public class NovaClientLiveTest extends BaseComputeServiceContextLiveTest {
       assertNotNull(server.getHostId());
       assertEquals(server.getStatus(), ServerStatus.ACTIVE);
       assert server.getProgress() >= 0 : "newDetails.getProgress()" + server.getProgress();
-      assertEquals(new Integer(14362), server.getImage());
-      assertEquals(new Integer(1), server.getFlavor());
+      assertEquals(Integer.valueOf(14362), server.getImage());
+      assertEquals(Integer.valueOf(1), server.getFlavor());
       assertNotNull(server.getAddresses());
       // listAddresses tests..
       assertEquals(client.getAddresses(serverId), server.getAddresses());
@@ -332,7 +332,7 @@ public class NovaClientLiveTest extends BaseComputeServiceContextLiveTest {
    public void testCreateImage() throws Exception {
       Image image = client.createImageFromServer("hoofie", serverId);
       assertEquals("hoofie", image.getName());
-      assertEquals(new Integer(serverId), image.getServerRef());
+      assertEquals(Integer.valueOf(serverId), image.getServerRef());
       createdImageRef = image.getId()+"";
       blockUntilImageActive(createdImageRef);
    }
@@ -341,7 +341,7 @@ public class NovaClientLiveTest extends BaseComputeServiceContextLiveTest {
    public void testRebuildServer() throws Exception {
       client.rebuildServer(serverId, new RebuildServerOptions().withImage(createdImageRef));
       blockUntilServerActive(serverId);
-      assertEquals(new Integer(createdImageRef).intValue(),client.getServer(serverId).getImage().getId());
+      assertEquals(Integer.valueOf(createdImageRef).intValue(),client.getServer(serverId).getImage().getId());
    }
 
    @Test(timeOut = 10 * 60 * 1000, dependsOnMethods = "testRebuildServer")
@@ -362,7 +362,7 @@ public class NovaClientLiveTest extends BaseComputeServiceContextLiveTest {
       blockUntilServerVerifyResize(serverId);
       client.revertResizeServer(serverId);
       blockUntilServerActive(serverId);
-      assertEquals(new Integer(1), client.getServer(serverId).getFlavorRef());
+      assertEquals(Integer.valueOf(1), client.getServer(serverId).getFlavorRef());
    }
 
    @Test(timeOut = 10 * 60 * 1000, dependsOnMethods = "testRebootSoft")
@@ -371,7 +371,7 @@ public class NovaClientLiveTest extends BaseComputeServiceContextLiveTest {
       blockUntilServerVerifyResize(serverId2);
       client.confirmResizeServer(serverId2);
       blockUntilServerActive(serverId2);
-      assertEquals(new Integer(2), client.getServer(serverId2).getFlavorRef());
+      assertEquals(Integer.valueOf(2), client.getServer(serverId2).getFlavorRef());
    }
 
    @Test(timeOut = 10 * 60 * 1000, dependsOnMethods = { "testRebootSoft", "testRevertResize", "testConfirmResize" })

--- a/apis/nova/src/test/java/org/jclouds/openstack/nova/functions/ParseImageFromJsonResponseTest.java
+++ b/apis/nova/src/test/java/org/jclouds/openstack/nova/functions/ParseImageFromJsonResponseTest.java
@@ -64,7 +64,7 @@ public class ParseImageFromJsonResponseTest {
       assertEquals(response.getId(), 2);
       assertEquals(response.getName(), "CentOS 5.2");
       assertEquals(response.getCreated(), dateService.iso8601SecondsDateParse("2010-08-10T12:00:00Z"));
-      assertEquals(response.getProgress(), new Integer(80));
+      assertEquals(response.getProgress(), Integer.valueOf(80));
       assertEquals(response.getStatus(), ImageStatus.SAVING);
       assertEquals(response.getUpdated(), dateService.iso8601SecondsDateParse(("2010-10-10T12:00:00Z")));
       assertEquals(response.getServerRef(), "http://servers.api.openstack.org/v1.1/1234/servers/12");

--- a/apis/nova/src/test/java/org/jclouds/openstack/nova/functions/ParseImageListFromJsonResponseTest.java
+++ b/apis/nova/src/test/java/org/jclouds/openstack/nova/functions/ParseImageListFromJsonResponseTest.java
@@ -96,7 +96,7 @@ public class ParseImageListFromJsonResponseTest {
       assertEquals(response.get(1).getName(), "My Server Backup");
       assertEquals(response.get(1).getCreated(), dateService.iso8601SecondsDateParse("2009-07-07T09:56:16Z"));
 
-      assertEquals(response.get(1).getProgress(), new Integer(80));
+      assertEquals(response.get(1).getProgress(), Integer.valueOf(80));
       assertEquals(response.get(1).getStatus(), ImageStatus.SAVING);
       assertEquals(response.get(1).getUpdated(), dateService.iso8601SecondsDateParse("2010-10-10T12:00:00Z"));
       assertEquals(response.get(1).getServerRef(), "http://servers.api.openstack.org/v1.1/1234/servers/12");

--- a/apis/nova/src/test/java/org/jclouds/openstack/nova/functions/ParseServerFromJsonResponseDiabloTest.java
+++ b/apis/nova/src/test/java/org/jclouds/openstack/nova/functions/ParseServerFromJsonResponseDiabloTest.java
@@ -64,7 +64,7 @@ public class ParseServerFromJsonResponseDiabloTest {
       assertEquals(response.getFlavor().getURI(), new URI("http://servers.api.openstack.org/1234/flavors/1"));
       assertEquals(response.getHostId(), "e4d909c290d0fb1ca068ffaddf22cbd0");
       assertEquals(response.getStatus(), ServerStatus.BUILD);
-      assertEquals(response.getProgress(), new Integer(60));
+      assertEquals(response.getProgress(), Integer.valueOf(60));
       SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
       dateFormat.setTimeZone(new SimpleTimeZone(0, "GMT"));
       assertEquals(response.getCreated(), dateFormat.parse("2010-08-10T12:00:00Z"));

--- a/apis/nova/src/test/java/org/jclouds/openstack/nova/functions/ParseServerFromJsonResponseTest.java
+++ b/apis/nova/src/test/java/org/jclouds/openstack/nova/functions/ParseServerFromJsonResponseTest.java
@@ -65,7 +65,7 @@ public class ParseServerFromJsonResponseTest {
       assertEquals(response.getFlavorRef(), "http://servers.api.openstack.org/1234/flavors/1");
       assertEquals(response.getHostId(), "e4d909c290d0fb1ca068ffaddf22cbd0");
       assertEquals(response.getStatus(), ServerStatus.BUILD);
-      assertEquals(response.getProgress(), new Integer(60));
+      assertEquals(response.getProgress(), Integer.valueOf(60));
       SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
       dateFormat.setTimeZone(new SimpleTimeZone(0, "GMT"));
       assertEquals(response.getCreated(), dateFormat.parse("2010-08-10T12:00:00Z"));

--- a/apis/nova/src/test/java/org/jclouds/openstack/nova/functions/ParseServerListFromJsonResponseTest.java
+++ b/apis/nova/src/test/java/org/jclouds/openstack/nova/functions/ParseServerListFromJsonResponseTest.java
@@ -88,7 +88,7 @@ public class ParseServerListFromJsonResponseTest {
       assertEquals(response.get(0).getHostId(), "e4d909c290d0fb1ca068ffaddf22cbd0");
       assertEquals(response.get(0).getUuid(), "d84e2086-fc0d-11e0-8e08-2837371c69ae");
       assertEquals(response.get(0).getStatus(), ServerStatus.BUILD);
-      assertEquals(response.get(0).getProgress(), new Integer(60));
+      assertEquals(response.get(0).getProgress(), Integer.valueOf(60));
 
       List<Address> publicAddresses = ImmutableList.copyOf(Iterables.transform(
                ImmutableList.of("67.23.10.132", "::babe:67.23.10.132", "67.23.10.131", "::babe:4317:0A83"),

--- a/apis/s3/src/main/java/org/jclouds/s3/options/ListBucketOptions.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/options/ListBucketOptions.java
@@ -85,7 +85,7 @@ public class ListBucketOptions extends BaseHttpRequestOptions {
 
    public Integer getMaxResults() {
       String returnVal = getFirstQueryOrNull("max-keys");
-      return (returnVal != null) ? new Integer(returnVal) : null;
+      return (returnVal != null) ? Integer.valueOf(returnVal) : null;
    }
 
    /**

--- a/apis/s3/src/main/java/org/jclouds/s3/xml/ListBucketHandler.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/xml/ListBucketHandler.java
@@ -104,7 +104,7 @@ public class ListBucketHandler extends ParseSax.HandlerWithResult<ListBucketResp
          builder.eTag(currentETag);
          builder.contentMD5(CryptoStreams.hex(Strings2.replaceAll(currentETag, '"', "")));
       } else if (qName.equals("Size")) {
-         builder.contentLength(new Long(currentOrNull(currentText)));
+         builder.contentLength(Long.valueOf(currentOrNull(currentText)));
       } else if (qName.equals("Owner")) {
          builder.owner(currentOwner);
          currentOwner = null;

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/blobstore/strategy/internal/ParallelMultipartUploadStrategy.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/blobstore/strategy/internal/ParallelMultipartUploadStrategy.java
@@ -164,7 +164,7 @@ public class ParallelMultipartUploadStrategy implements AsyncMultipartUploadStra
                                 CountDownLatch latch = new CountDownLatch(effectiveParts);
                                 int part;
                                 while ((part = algorithm.getNextPart()) <= parts) {
-                                    Integer partKey = new Integer(part);
+                                    Integer partKey = Integer.valueOf(part);
                                     activeParts.put(partKey);
 
                                     prepareUploadPart(container, blob, key, partKey, payload,
@@ -173,7 +173,7 @@ public class ParallelMultipartUploadStrategy implements AsyncMultipartUploadStra
                                             blob2Object);
                                 }
                                 if (remaining > 0) {
-                                    Integer partKey = new Integer(part);
+                                    Integer partKey = Integer.valueOf(part);
                                     activeParts.put(partKey);
                                     prepareUploadPart(container, blob, key, partKey, payload,
                                             algorithm.getNextChunkOffset(), remaining, etags,
@@ -187,7 +187,7 @@ public class ParallelMultipartUploadStrategy implements AsyncMultipartUploadStra
                                     CountDownLatch retryLatch = new CountDownLatch(atOnce);
                                     for (int i = 0; i < atOnce; i++) {
                                         Part failedPart = toRetry.poll();
-                                        Integer partKey = new Integer(failedPart.getPart());
+                                        Integer partKey = Integer.valueOf(failedPart.getPart());
                                         activeParts.put(partKey);
                                         prepareUploadPart(container, blob, key, partKey, payload,
                                                 failedPart.getOffset(), failedPart.getSize(), etags,

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/options/ListContainerOptions.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/options/ListContainerOptions.java
@@ -57,7 +57,7 @@ public class ListContainerOptions extends BaseHttpRequestOptions {
 
    public int getMaxResults() {
       String val = getFirstQueryOrNull("limit");
-      return val != null ? new Integer(val) : 10000;
+      return val != null ? Integer.valueOf(val) : 10000;
    }
 
    /**

--- a/apis/swift/src/test/java/org/jclouds/openstack/swift/CommonSwiftClientLiveTest.java
+++ b/apis/swift/src/test/java/org/jclouds/openstack/swift/CommonSwiftClientLiveTest.java
@@ -204,7 +204,7 @@ public abstract class CommonSwiftClientLiveTest<C extends CommonSwiftClient> ext
          MutableObjectInfoWithMetadata metadata = getApi().getObjectInfo(containerName, object.getInfo().getName());
          assertEquals(metadata.getName(), object.getInfo().getName());
 
-         assertEquals(metadata.getBytes(), new Long(data.length()));
+         assertEquals(metadata.getBytes(), Long.valueOf(data.length()));
          assert metadata.getContentType().startsWith("text/plain") : metadata.getContentType();
 
          assertEquals(CryptoStreams.hex(md5), CryptoStreams.hex(metadata.getHash()));
@@ -225,7 +225,7 @@ public abstract class CommonSwiftClientLiveTest<C extends CommonSwiftClient> ext
          assertEquals(Strings2.toString(getBlob.getPayload()), data);
          // TODO assertEquals(getBlob.getName(),
          // object.getMetadata().getName());
-         assertEquals(getBlob.getInfo().getBytes(), new Long(data.length()));
+         assertEquals(getBlob.getInfo().getBytes(), Long.valueOf(data.length()));
          testGetObjectContentType(getBlob);
          assertEquals(CryptoStreams.hex(md5), CryptoStreams.hex(getBlob.getInfo().getHash()));
          assertEquals(CryptoStreams.hex(newEtag), getBlob.getInfo().getHash());

--- a/apis/vcloud/src/main/java/org/jclouds/vcloud/xml/NetworkConnectionSectionHandler.java
+++ b/apis/vcloud/src/main/java/org/jclouds/vcloud/xml/NetworkConnectionSectionHandler.java
@@ -85,7 +85,7 @@ public class NetworkConnectionSectionHandler extends ParseSax.HandlerWithResult<
       } else if (qName.endsWith("Info")) {
          this.info = currentOrNull();
       } else if (qName.endsWith("PrimaryNetworkConnectionIndex")) {
-         this.primaryNetworkConnectionIndex = new Integer(currentOrNull());
+         this.primaryNetworkConnectionIndex = Integer.valueOf(currentOrNull());
       }
       currentText = new StringBuilder();
    }

--- a/apis/vcloud/src/test/java/org/jclouds/vcloud/xml/GuestCustomizationSectionHandlerTest.java
+++ b/apis/vcloud/src/test/java/org/jclouds/vcloud/xml/GuestCustomizationSectionHandlerTest.java
@@ -55,18 +55,18 @@ public class GuestCustomizationSectionHandlerTest extends BaseHandlerTest {
       assertEquals(result.getHref(),
             URI.create("https://vcenterprise.bluelock.com/api/v1.0/vApp/vm-2087535248/guestCustomizationSection/"));
       assertEquals(result.getInfo(), "Specifies Guest OS Customization Settings");
-      assertEquals(result.isEnabled(), new Boolean(true));
-      assertEquals(result.shouldChangeSid(), new Boolean(false));
+      assertEquals(result.isEnabled(), Boolean.TRUE);
+      assertEquals(result.shouldChangeSid(), Boolean.FALSE);
       assertEquals(result.getVirtualMachineId(), "2087535248");
-      assertEquals(result.isJoinDomainEnabled(), new Boolean(false));
-      assertEquals(result.useOrgSettings(), new Boolean(false));
+      assertEquals(result.isJoinDomainEnabled(), Boolean.FALSE);
+      assertEquals(result.useOrgSettings(), Boolean.FALSE);
       assertEquals(result.getDomainName(), null);
       assertEquals(result.getDomainUserName(), null);
       assertEquals(result.getDomainUserPassword(), null);
-      assertEquals(result.isAdminPasswordEnabled(), new Boolean(true));
-      assertEquals(result.isAdminPasswordAuto(), new Boolean(true));
+      assertEquals(result.isAdminPasswordEnabled(), Boolean.TRUE);
+      assertEquals(result.isAdminPasswordAuto(), Boolean.TRUE);
       assertEquals(result.getAdminPassword(), null);
-      assertEquals(result.isResetPasswordRequired(), new Boolean(false));
+      assertEquals(result.isResetPasswordRequired(), Boolean.FALSE);
       assertEquals(result.getCustomizationScript(), "cat > /root/foo.txt<<EOF\nI '\"love\"' {asc|!}*&\nEOF\n");
       assertEquals(result.getComputerName(), "RHEL5");
       assertEquals(

--- a/apis/vcloud/src/test/java/org/jclouds/vcloud/xml/NetworkConnectionSectionHandlerTest.java
+++ b/apis/vcloud/src/test/java/org/jclouds/vcloud/xml/NetworkConnectionSectionHandlerTest.java
@@ -57,7 +57,7 @@ public class NetworkConnectionSectionHandlerTest {
                .create("https://vcenterprise.bluelock.com/api/v1.0/vApp/vm-2087535248/networkConnectionSection/"));
       assertEquals(result.getType(), VCloudMediaType.NETWORKCONNECTIONSECTION_XML);
       assertEquals(result.getInfo(), "Specifies the available VM network connections");
-      assertEquals(result.getPrimaryNetworkConnectionIndex(), new Integer(0));
+      assertEquals(result.getPrimaryNetworkConnectionIndex(), Integer.valueOf(0));
       assertEquals(result.getEdit(), new ReferenceTypeImpl(null, VCloudMediaType.NETWORKCONNECTIONSECTION_XML, URI
                .create("https://vcenterprise.bluelock.com/api/v1.0/vApp/vm-2087535248/networkConnectionSection/")));
       NetworkConnectionHandlerTest.checkNetworkConnection(Iterables.getOnlyElement(result.getConnections()));

--- a/apis/vcloud/src/test/java/org/jclouds/vcloud/xml/VAppTemplateHandlerTest.java
+++ b/apis/vcloud/src/test/java/org/jclouds/vcloud/xml/VAppTemplateHandlerTest.java
@@ -86,18 +86,18 @@ public class VAppTemplateHandlerTest {
                URI
                         .create("https://vcenterprise.bluelock.com/api/v1.0/vAppTemplate/vm-172837194/guestCustomizationSection/"));
       assertEquals(guestC.getInfo(), "Specifies Guest OS Customization Settings");
-      assertEquals(guestC.isEnabled(), new Boolean(true));
-      assertEquals(guestC.shouldChangeSid(), new Boolean(false));
+      assertEquals(guestC.isEnabled(), Boolean.TRUE);
+      assertEquals(guestC.shouldChangeSid(), Boolean.FALSE);
       assertEquals(guestC.getVirtualMachineId(), "172837194");
-      assertEquals(guestC.isJoinDomainEnabled(), new Boolean(false));
-      assertEquals(guestC.useOrgSettings(), new Boolean(false));
+      assertEquals(guestC.isJoinDomainEnabled(), Boolean.FALSE);
+      assertEquals(guestC.useOrgSettings(), Boolean.FALSE);
       assertEquals(guestC.getDomainName(), null);
       assertEquals(guestC.getDomainUserName(), null);
       assertEquals(guestC.getDomainUserPassword(), null);
-      assertEquals(guestC.isAdminPasswordEnabled(), new Boolean(true));
-      assertEquals(guestC.isAdminPasswordAuto(), new Boolean(true));
+      assertEquals(guestC.isAdminPasswordEnabled(), Boolean.TRUE);
+      assertEquals(guestC.isAdminPasswordAuto(), Boolean.TRUE);
       assertEquals(guestC.getAdminPassword(), "%3eD%gmF");
-      assertEquals(guestC.isResetPasswordRequired(), new Boolean(false));
+      assertEquals(guestC.isResetPasswordRequired(), Boolean.FALSE);
       assertEquals(
                guestC.getCustomizationScript(),
                "#!/bin/bash if [ \"$1\" = \"postcustomization\" ]; then echo \"post customization\" touch /root/.postcustomization sleep 30 #regenerate keys /bin/rm /etc/ssh/ssh_host_* /usr/sbin/dpkg-reconfigure openssh-server echo \"completed\" fi");

--- a/apis/vcloud/src/test/java/org/jclouds/vcloud/xml/ovf/VCloudOperatingSystemSectionHandlerTest.java
+++ b/apis/vcloud/src/test/java/org/jclouds/vcloud/xml/ovf/VCloudOperatingSystemSectionHandlerTest.java
@@ -55,7 +55,7 @@ public class VCloudOperatingSystemSectionHandlerTest extends BaseHandlerTest {
       assertEquals(result.getEdit(), new ReferenceTypeImpl(null,
                "application/vnd.vmware.vcloud.operatingSystemSection+xml",
                URI.create("https://vcenterprise.bluelock.com/api/v1.0/vApp/vm-2087535248/operatingSystemSection/")));
-      assertEquals(result.getId(), new Integer(80));
+      assertEquals(result.getId(), Integer.valueOf(80));
       assertEquals(result.getVmwOsType(), "rhel5_64Guest");
       assertEquals(result.getType(), "application/vnd.vmware.vcloud.operatingSystemSection+xml");
       assertEquals(result.getInfo(), "Specifies the operating system installed");

--- a/blobstore/src/main/java/org/jclouds/blobstore/TransientAsyncBlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/TransientAsyncBlobStore.java
@@ -628,7 +628,7 @@ public class TransientAsyncBlobStore extends BaseAsyncBlobStore {
             byte[] byteArray = out.toByteArray();
             blob.setPayload(byteArray);
             HttpUtils.copy(cmd, blob.getPayload().getContentMetadata());
-            blob.getPayload().getContentMetadata().setContentLength(new Long(byteArray.length));
+            blob.getPayload().getContentMetadata().setContentLength(Long.valueOf(byteArray.length));
          }
       }
       checkNotNull(blob.getPayload(), "payload " + blob);

--- a/blobstore/src/test/java/org/jclouds/blobstore/binders/BindBlobToMultipartFormTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/binders/BindBlobToMultipartFormTest.java
@@ -66,7 +66,7 @@ public class BindBlobToMultipartFormTest {
       binder.bindToRequest(request, TEST_BLOB);
 
       assertEquals(Strings2.toString(request.getPayload()), EXPECTS);
-      assertEquals(request.getPayload().getContentMetadata().getContentLength(), new Long(113));
+      assertEquals(request.getPayload().getContentMetadata().getContentLength(), Long.valueOf(113));
 
       assertEquals(request.getPayload().getContentMetadata().getContentType(), "multipart/form-data; boundary="
             + BOUNDARY);

--- a/blobstore/src/test/java/org/jclouds/blobstore/functions/ParseBlobFromHeadersAndHttpContentTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/functions/ParseBlobFromHeadersAndHttpContentTest.java
@@ -85,7 +85,7 @@ public class ParseBlobFromHeadersAndHttpContentTest {
       replay(metadataParser);
 
       Blob object = callable.apply(response);
-      assertEquals(object.getPayload().getContentMetadata().getContentLength(), new Long(10485760));
+      assertEquals(object.getPayload().getContentMetadata().getContentLength(), Long.valueOf(10485760));
       assertEquals(object.getAllHeaders().get("Content-Range"), Collections.singletonList("0-10485759/20232760"));
 
    }

--- a/blobstore/src/test/java/org/jclouds/blobstore/functions/ReturnFalseOnContainerNotFoundTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/functions/ReturnFalseOnContainerNotFoundTest.java
@@ -33,7 +33,7 @@ public class ReturnFalseOnContainerNotFoundTest {
 
    @Test
    public void testFoundIsFalse() throws SecurityException, NoSuchMethodException {
-      assertEquals(fn.apply(new ContainerNotFoundException()), new Boolean(false));
+      assertEquals(fn.apply(new ContainerNotFoundException()), Boolean.FALSE);
    }
 
    @Test(expectedExceptions = { RuntimeException.class })

--- a/blobstore/src/test/java/org/jclouds/blobstore/functions/ReturnFalseOnKeyNotFoundTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/functions/ReturnFalseOnKeyNotFoundTest.java
@@ -33,7 +33,7 @@ public class ReturnFalseOnKeyNotFoundTest {
 
    @Test
    public void testFoundIsFalse() throws SecurityException, NoSuchMethodException {
-      assertEquals(fn.apply(new KeyNotFoundException()), new Boolean(false));
+      assertEquals(fn.apply(new KeyNotFoundException()), Boolean.FALSE);
    }
 
    @Test(expectedExceptions = { RuntimeException.class })

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobIntegrationTest.java
@@ -637,7 +637,7 @@ public class BaseBlobIntegrationTest extends BaseBlobStoreIntegrationTest {
    protected void validateMetadata(BlobMetadata metadata) throws IOException {
       assert metadata.getContentMetadata().getContentType().startsWith("text/plain") : metadata.getContentMetadata()
                .getContentType();
-      assertEquals(metadata.getContentMetadata().getContentLength(), new Long(TEST_STRING.length()));
+      assertEquals(metadata.getContentMetadata().getContentLength(), Long.valueOf(TEST_STRING.length()));
       assertEquals(metadata.getUserMetadata().get("adrian"), "powderpuff");
       checkMD5(metadata);
    }

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseContainerIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseContainerIntegrationTest.java
@@ -88,7 +88,7 @@ public class BaseContainerIntegrationTest extends BaseBlobStoreIntegrationTest {
 
          assert metadata.getContentMetadata().getContentType().startsWith("text/plain") : metadata.getContentMetadata()
                .getContentType();
-         assertEquals(metadata.getContentMetadata().getContentLength(), new Long(TEST_STRING.length()));
+         assertEquals(metadata.getContentMetadata().getContentLength(), Long.valueOf(TEST_STRING.length()));
          assertEquals(metadata.getUserMetadata().get("adrian"), "powderpuff");
          checkMD5(metadata);
       } finally {

--- a/blobstore/src/test/java/org/jclouds/blobstore/options/ListOptionsTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/options/ListOptionsTest.java
@@ -64,7 +64,7 @@ public class ListOptionsTest {
       ListContainerOptions options = new ListContainerOptions();
       options.inDirectory("test").maxResults(1);
       assertEquals(options.getDir(), "test");
-      assertEquals(options.getMaxResults(), new Integer(1));
+      assertEquals(options.getMaxResults(), Integer.valueOf(1));
 
    }
 
@@ -108,7 +108,7 @@ public class ListOptionsTest {
    public void testMaxResults() {
       ListContainerOptions options = new ListContainerOptions();
       options.maxResults(1000);
-      assertEquals(options.getMaxResults(), new Integer(1000));
+      assertEquals(options.getMaxResults(), Integer.valueOf(1000));
    }
 
    @Test
@@ -120,7 +120,7 @@ public class ListOptionsTest {
    @Test
    public void testMaxResultsStatic() {
       ListContainerOptions options = maxResults(1000);
-      assertEquals(options.getMaxResults(), new Integer(1000));
+      assertEquals(options.getMaxResults(), Integer.valueOf(1000));
    }
 
    @Test(expectedExceptions = IllegalArgumentException.class)

--- a/common/azure/src/main/java/org/jclouds/azure/storage/handlers/ParseAzureStorageErrorFromXmlContent.java
+++ b/common/azure/src/main/java/org/jclouds/azure/storage/handlers/ParseAzureStorageErrorFromXmlContent.java
@@ -67,7 +67,7 @@ public class ParseAzureStorageErrorFromXmlContent implements HttpErrorHandler {
          if (response.getPayload() != null) {
             String contentType = response.getPayload().getContentMetadata().getContentType();
             if (contentType != null && (contentType.indexOf("xml") != -1 || contentType.indexOf("unknown") != -1)
-                     && !new Long(0).equals(response.getPayload().getContentMetadata().getContentLength())) {
+                     && !Long.valueOf(0).equals(response.getPayload().getContentMetadata().getContentLength())) {
                try {
                   error = utils.parseAzureStorageErrorFromContent(command, response, response.getPayload().getInput());
                   if (error != null) {

--- a/common/azure/src/main/java/org/jclouds/azure/storage/options/ListOptions.java
+++ b/common/azure/src/main/java/org/jclouds/azure/storage/options/ListOptions.java
@@ -94,7 +94,7 @@ public class ListOptions extends BaseHttpRequestOptions {
 
    public Integer getMaxResults() {
       String maxresults = getFirstQueryOrNull("maxresults");
-      return (maxresults != null) ? new Integer(maxresults) : null;
+      return (maxresults != null) ? Integer.valueOf(maxresults) : null;
    }
 
    public static class Builder {

--- a/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/binders/BindVAppConfigurationToXmlPayload.java
+++ b/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/binders/BindVAppConfigurationToXmlPayload.java
@@ -137,7 +137,7 @@ public class BindVAppConfigurationToXmlPayload implements MapBinder, Function<Ob
    private void addDiskItems(XMLBuilder sectionBuilder, VApp vApp, VAppConfiguration configuration) {
       for (ResourceAllocationSettingData disk : filter(vApp.getResourceAllocations(), CIMPredicates
                .resourceTypeIn(ResourceType.DISK_DRIVE))) {
-         if (!configuration.getDisksToDelete().contains(new Integer(disk.getAddressOnParent()))) {
+         if (!configuration.getDisksToDelete().contains(Integer.valueOf(disk.getAddressOnParent()))) {
             addDiskWithQuantity(sectionBuilder, disk);
          }
       }

--- a/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/xml/VAppHandler.java
+++ b/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/xml/VAppHandler.java
@@ -91,7 +91,7 @@ public class VAppHandler extends ParseSax.HandlerWithResult<VApp> {
          String statusString = attributes.get("status");
          status = Status.fromValue(statusString);
          if (attributes.containsKey("size"))
-            size = new Long(attributes.get("size"));
+            size = Long.valueOf(attributes.get("size"));
       } else if (qName.equals("Link")) { // type should never be missing
          if (attributes.containsKey("type")) {
             if (attributes.get("type").equals(TerremarkVCloudMediaType.VDC_XML)) {

--- a/common/trmk/src/test/java/org/jclouds/trmk/vcloud_0_8/options/InstantiateVAppTemplateOptionsTest.java
+++ b/common/trmk/src/test/java/org/jclouds/trmk/vcloud_0_8/options/InstantiateVAppTemplateOptionsTest.java
@@ -52,13 +52,13 @@ public class InstantiateVAppTemplateOptionsTest {
    public void testCustomizeOnInstantiate() {
       InstantiateVAppTemplateOptions options = new InstantiateVAppTemplateOptions();
       options.customizeOnInstantiate(true);
-      assertEquals(options.shouldCustomizeOnInstantiate(), new Boolean(true));
+      assertEquals(options.shouldCustomizeOnInstantiate(), Boolean.TRUE);
    }
 
    @Test
    public void testCustomizeOnInstantiateStatic() {
       InstantiateVAppTemplateOptions options = customizeOnInstantiate(true);
-      assertEquals(options.shouldCustomizeOnInstantiate(), new Boolean(true));
+      assertEquals(options.shouldCustomizeOnInstantiate(), Boolean.TRUE);
    }
 
    @Test

--- a/common/trmk/src/test/java/org/jclouds/trmk/vcloud_0_8/xml/ovf/VAppHandlerTest.java
+++ b/common/trmk/src/test/java/org/jclouds/trmk/vcloud_0_8/xml/ovf/VAppHandlerTest.java
@@ -119,7 +119,7 @@ public class VAppHandlerTest extends BaseHandlerTest {
                         .virtualQuantity(104857l).build());
 
       VApp expects = new VAppImpl("centos53", URI
-               .create("http://10.150.4.49/api/v0.8/vApp/10"), Status.ON, new Long(104857), new ReferenceTypeImpl(null,
+               .create("http://10.150.4.49/api/v0.8/vApp/10"), Status.ON, Long.valueOf(104857), new ReferenceTypeImpl(null,
                "application/vnd.vmware.vcloud.vdc+xml", URI.create("http://10.150.4.49/api/v0.8/vdc/4")),
                networkToAddresses, null, "Other Linux (32-bit)", system, resourceAllocations);
       assertEquals(result.getHref(), expects.getHref());
@@ -167,7 +167,7 @@ public class VAppHandlerTest extends BaseHandlerTest {
                         .virtualQuantity(10485760l).build());
 
       VApp expects = new VAppImpl("m1", URI.create("http://localhost:8000/api/v0.8/vApp/80"),
-               Status.ON, new Long(10485760), new ReferenceTypeImpl(null, "application/vnd.vmware.vcloud.vdc+xml", URI
+               Status.ON, Long.valueOf(10485760), new ReferenceTypeImpl(null, "application/vnd.vmware.vcloud.vdc+xml", URI
                         .create("http://localhost:8000/api/v0.8/vdc/28")), networkToAddresses, null,
                "Microsoft Windows XP Professional (32-bit)", system, resourceAllocations);
       assertEquals(result.getHref(), expects.getHref());

--- a/compute/src/main/java/org/jclouds/cim/ResourceAllocationSettingData.java
+++ b/compute/src/main/java/org/jclouds/cim/ResourceAllocationSettingData.java
@@ -345,7 +345,7 @@ public class ResourceAllocationSettingData extends ManagedElement {
             });
 
       public static ResourceType fromValue(String type) {
-         return RESOURCE_TYPE_BY_ID.get(new Integer(checkNotNull(type, "type")));
+         return RESOURCE_TYPE_BY_ID.get(Integer.valueOf(checkNotNull(type, "type")));
       }
    }
 
@@ -394,7 +394,7 @@ public class ResourceAllocationSettingData extends ManagedElement {
             });
 
       public static ConsumerVisibility fromValue(String behavior) {
-         return MAPPING_BEHAVIOR_BY_ID.get(new Integer(checkNotNull(behavior, "behavior")));
+         return MAPPING_BEHAVIOR_BY_ID.get(Integer.valueOf(checkNotNull(behavior, "behavior")));
       }
    }
 
@@ -428,7 +428,7 @@ public class ResourceAllocationSettingData extends ManagedElement {
             });
 
       public static MappingBehavior fromValue(String behavior) {
-         return MAPPING_BEHAVIOR_BY_ID.get(new Integer(checkNotNull(behavior, "behavior")));
+         return MAPPING_BEHAVIOR_BY_ID.get(Integer.valueOf(checkNotNull(behavior, "behavior")));
       }
    }
 

--- a/compute/src/main/java/org/jclouds/cim/VirtualSystemSettingData.java
+++ b/compute/src/main/java/org/jclouds/cim/VirtualSystemSettingData.java
@@ -270,7 +270,7 @@ public class VirtualSystemSettingData extends ManagedElement {
                });
 
       public static AutomaticRecoveryAction fromValue(String automaticRecoveryAction) {
-         return AUTOMATIC_RECOVERY_ACTION_BY_ID.get(new Integer(checkNotNull(automaticRecoveryAction,
+         return AUTOMATIC_RECOVERY_ACTION_BY_ID.get(Integer.valueOf(checkNotNull(automaticRecoveryAction,
                   "automaticRecoveryAction")));
       }
    }
@@ -307,7 +307,7 @@ public class VirtualSystemSettingData extends ManagedElement {
                });
 
       public static AutomaticShutdownAction fromValue(String automaticShutdownAction) {
-         return AUTOMATIC_SHUTDOWN_ACTION_BY_ID.get(new Integer(checkNotNull(automaticShutdownAction,
+         return AUTOMATIC_SHUTDOWN_ACTION_BY_ID.get(Integer.valueOf(checkNotNull(automaticShutdownAction,
                   "automaticShutdownAction")));
       }
    }
@@ -344,7 +344,7 @@ public class VirtualSystemSettingData extends ManagedElement {
                });
 
       public static AutomaticStartupAction fromValue(String automaticStartupAction) {
-         return AUTOMATIC_STARTUP_ACTION_BY_ID.get(new Integer(checkNotNull(automaticStartupAction,
+         return AUTOMATIC_STARTUP_ACTION_BY_ID.get(Integer.valueOf(checkNotNull(automaticStartupAction,
                   "automaticStartupAction")));
       }
    }

--- a/compute/src/main/java/org/jclouds/cim/xml/ResourceAllocationSettingDataHandler.java
+++ b/compute/src/main/java/org/jclouds/cim/xml/ResourceAllocationSettingDataHandler.java
@@ -67,13 +67,13 @@ public class ResourceAllocationSettingDataHandler extends ParseSax.HandlerWithRe
          } else if (equalsOrSuffix(qName, "AllocationUnits")) {
             builder.allocationUnits(current);
          } else if (equalsOrSuffix(qName, "AutomaticAllocation")) {
-            builder.automaticAllocation(new Boolean(current));
+            builder.automaticAllocation(Boolean.valueOf(current));
          } else if (equalsOrSuffix(qName, "AutomaticDeallocation")) {
-            builder.automaticDeallocation(new Boolean(current));
+            builder.automaticDeallocation(Boolean.valueOf(current));
          } else if (equalsOrSuffix(qName, "ConsumerVisibility")) {
             builder.consumerVisibility(ConsumerVisibility.fromValue(current));
          } else if (equalsOrSuffix(qName, "Limit")) {
-            builder.limit(new Long(current));
+            builder.limit(Long.valueOf(current));
          } else if (equalsOrSuffix(qName, "MappingBehavior")) {
             builder.mappingBehavior(MappingBehavior.fromValue(current));
          } else if (equalsOrSuffix(qName, "OtherResourceType")) {
@@ -83,17 +83,17 @@ public class ResourceAllocationSettingDataHandler extends ParseSax.HandlerWithRe
          } else if (equalsOrSuffix(qName, "PoolID")) {
             builder.poolID(current);
          } else if (equalsOrSuffix(qName, "Reservation")) {
-            builder.reservation(new Long(current));
+            builder.reservation(Long.valueOf(current));
          } else if (equalsOrSuffix(qName, "ResourceSubType")) {
             builder.resourceSubType(current);
          } else if (equalsOrSuffix(qName, "ResourceType")) {
             builder.resourceType(ResourceType.fromValue(current));
          } else if (equalsOrSuffix(qName, "VirtualQuantity")) {
-            builder.virtualQuantity(new Long(current));
+            builder.virtualQuantity(Long.valueOf(current));
          } else if (equalsOrSuffix(qName, "VirtualQuantityUnits")) {
             builder.virtualQuantityUnits(current);
          } else if (equalsOrSuffix(qName, "Weight")) {
-            builder.weight(new Integer(current));
+            builder.weight(Integer.valueOf(current));
          } else if (equalsOrSuffix(qName, "Connection")) {
             builder.connection(current);
          } else if (equalsOrSuffix(qName, "HostResource")) {

--- a/compute/src/main/java/org/jclouds/cim/xml/VirtualSystemSettingDataHandler.java
+++ b/compute/src/main/java/org/jclouds/cim/xml/VirtualSystemSettingDataHandler.java
@@ -79,7 +79,7 @@ public class VirtualSystemSettingDataHandler extends ParseSax.HandlerWithResult<
             // TODO parse the format for intervals: ddddddddhhmmss.mmmmmm:000
             builder.automaticStartupActionDelay(null);
          } else if (equalsOrSuffix(qName, "AutomaticStartupActionSequenceNumber")) {
-            builder.automaticStartupActionSequenceNumber(new Integer(current));
+            builder.automaticStartupActionSequenceNumber(Integer.valueOf(current));
          } else if (equalsOrSuffix(qName, "ConfigurationDataRoot")) {
             builder.configurationDataRoot(URI.create(current));
          } else if (equalsOrSuffix(qName, "ConfigurationFile")) {

--- a/compute/src/main/java/org/jclouds/ovf/xml/DiskSectionHandler.java
+++ b/compute/src/main/java/org/jclouds/ovf/xml/DiskSectionHandler.java
@@ -67,7 +67,7 @@ public class DiskSectionHandler extends SectionHandler<DiskSection, DiskSection.
       Long val = null;
       if (toParse != null) {
          try {
-            val = new Long(toParse);
+            val = Long.valueOf(toParse);
          } catch (NumberFormatException e) {
             logger.warn("%s for disk %s not a number [%s]", key, diskId, toParse);
          }

--- a/compute/src/test/java/org/jclouds/cim/xml/VirtualSystemSettingDataHandlerTest.java
+++ b/compute/src/test/java/org/jclouds/cim/xml/VirtualSystemSettingDataHandlerTest.java
@@ -124,7 +124,7 @@ public class VirtualSystemSettingDataHandlerTest extends BaseHandlerTest {
    @Test(enabled = false)
    public static void checkOs(OperatingSystemSection result) {
       assertEquals(result.getDescription(), "Ubuntu Linux (64-bit)");
-      assertEquals(result.getId(), new Integer(94));
+      assertEquals(result.getId(), Integer.valueOf(94));
       assertEquals(result.getInfo(), "Specifies the operating system installed");
    }
 }

--- a/compute/src/test/java/org/jclouds/compute/internal/BaseComputeServiceLiveTest.java
+++ b/compute/src/test/java/org/jclouds/compute/internal/BaseComputeServiceLiveTest.java
@@ -634,7 +634,7 @@ public abstract class BaseComputeServiceLiveTest extends BaseComputeServiceConte
 
       Matcher matcher = parseReported.matcher(exec.getOutput());
       if (matcher.find())
-         stats.reportedStartupTimeMilliseconds = new Long(matcher.group(1));
+         stats.reportedStartupTimeMilliseconds = Long.valueOf(matcher.group(1));
 
       getAnonymousLogger().info(format("<< %s on node(%s) %s", bgProcess, node.getId(), stats));
       return stats;

--- a/core/src/main/java/org/jclouds/io/ContentMetadataCodec.java
+++ b/core/src/main/java/org/jclouds/io/ContentMetadataCodec.java
@@ -94,7 +94,7 @@ public interface ContentMetadataCodec {
          });
          for (Entry<String, String> header : headers.entries()) {
             if (!chunked && CONTENT_LENGTH.equalsIgnoreCase(header.getKey())) {
-               contentMetadata.setContentLength(new Long(header.getValue()));
+               contentMetadata.setContentLength(Long.valueOf(header.getValue()));
             } else if ("Content-MD5".equalsIgnoreCase(header.getKey())) {
                contentMetadata.setContentMD5(CryptoStreams.base64(header.getValue()));
             } else if (CONTENT_TYPE.equalsIgnoreCase(header.getKey())) {

--- a/core/src/main/java/org/jclouds/io/payloads/ByteArrayPayload.java
+++ b/core/src/main/java/org/jclouds/io/payloads/ByteArrayPayload.java
@@ -34,7 +34,7 @@ public class ByteArrayPayload extends BasePayload<byte[]> {
 
    public ByteArrayPayload(byte[] content, byte[] md5) {
       super(content);
-      getContentMetadata().setContentLength(new Long(checkNotNull(content, "content").length));
+      getContentMetadata().setContentLength(Long.valueOf(checkNotNull(content, "content").length));
       getContentMetadata().setContentMD5(md5);
       checkArgument(content.length >= 0, "length cannot me negative");
    }

--- a/core/src/main/java/org/jclouds/io/payloads/StringPayload.java
+++ b/core/src/main/java/org/jclouds/io/payloads/StringPayload.java
@@ -38,7 +38,7 @@ public class StringPayload extends BasePayload<String> {
    public StringPayload(String content) {
       super(content);
       this.bytes = content.getBytes(Charsets.UTF_8);
-      getContentMetadata().setContentLength(new Long(bytes.length));
+      getContentMetadata().setContentLength(Long.valueOf(bytes.length));
    }
 
    /**

--- a/core/src/test/java/org/jclouds/io/payloads/MultipartFormTest.java
+++ b/core/src/test/java/org/jclouds/io/payloads/MultipartFormTest.java
@@ -55,7 +55,7 @@ public class MultipartFormTest {
       MultipartForm multipartForm = new MultipartForm(boundary, newPart("hello"));
 
       assertEquals(Strings2.toString(multipartForm), expects);
-      assertEquals(multipartForm.getContentMetadata().getContentLength(), new Long(199));
+      assertEquals(multipartForm.getContentMetadata().getContentLength(), Long.valueOf(199));
    }
 
    public static class MockFilePayload extends FilePayload {
@@ -124,7 +124,7 @@ public class MultipartFormTest {
       // test repeatable
       assert multipartForm.isRepeatable();
       assertEquals(Strings2.toString(multipartForm), expects);
-      assertEquals(multipartForm.getContentMetadata().getContentLength(), new Long(352));
+      assertEquals(multipartForm.getContentMetadata().getContentLength(), Long.valueOf(352));
    }
 
 }

--- a/core/src/test/java/org/jclouds/io/payloads/StringPayloadTest.java
+++ b/core/src/test/java/org/jclouds/io/payloads/StringPayloadTest.java
@@ -33,7 +33,7 @@ import com.google.common.base.Charsets;
 public class StringPayloadTest {
    public void testLengthIsCorrectPerUTF8() {
       Payload stringPayload = new StringPayload("unic₪de");
-      assertEquals(stringPayload.getContentMetadata().getContentLength(), new Long(
+      assertEquals(stringPayload.getContentMetadata().getContentLength(), Long.valueOf(
             "unic₪de".getBytes(Charsets.UTF_8).length));
    }
 }

--- a/core/src/test/java/org/jclouds/rest/internal/BaseRestApiTest.java
+++ b/core/src/test/java/org/jclouds/rest/internal/BaseRestApiTest.java
@@ -112,7 +112,7 @@ public abstract class BaseRestApiTest {
             propagate(e);
          }
          assertEquals(payload, toMatch);
-         Long length = new Long(payload.getBytes().length);
+         Long length = Long.valueOf(payload.getBytes().length);
          try {
             assertContentHeadersEqual(request, contentType, contentDispositon, contentEncoding, contentLanguage,
                   length, contentMD5 ? CryptoStreams.md5(request.getPayload()) : null, expires);

--- a/core/src/test/java/org/jclouds/rest/internal/RestAnnotationProcessorTest.java
+++ b/core/src/test/java/org/jclouds/rest/internal/RestAnnotationProcessorTest.java
@@ -1274,7 +1274,7 @@ public class RestAnnotationProcessorTest extends BaseRestApiTest {
             .createResponseParser(parserFactory, injector, method, request);
 
       assertEquals(parser.apply(HttpResponse.builder().statusCode(200).message("ok")
-            .payload("{ \"destroyvirtualmachineresponse\" : {\"jobid\":4} }").build()), new Long(4));
+            .payload("{ \"destroyvirtualmachineresponse\" : {\"jobid\":4} }").build()), Long.valueOf(4));
    }
 
    @SuppressWarnings("unchecked")
@@ -1286,7 +1286,7 @@ public class RestAnnotationProcessorTest extends BaseRestApiTest {
             .createResponseParser(parserFactory, injector, method, request);
 
       assertEquals(parser.apply(HttpResponse.builder().statusCode(200).message("ok")
-            .payload("{ \"destroyvirtualmachineresponse\" : {\"jobid\":4} }").build()), new Long(5));
+            .payload("{ \"destroyvirtualmachineresponse\" : {\"jobid\":4} }").build()), Long.valueOf(5));
    }
    
    static class TestRequestFilter1 implements HttpRequestFilter {

--- a/demos/perftest/src/test/java/org/jclouds/aws/s3/BaseJCloudsPerformanceLiveTest.java
+++ b/demos/perftest/src/test/java/org/jclouds/aws/s3/BaseJCloudsPerformanceLiveTest.java
@@ -77,7 +77,7 @@ public abstract class BaseJCloudsPerformanceLiveTest extends BasePerformanceLive
       S3Object object = newObject(key);
       object.setPayload(data);
       try {
-         object.getPayload().getContentMetadata().setContentLength(new Long(data.available()));
+         object.getPayload().getContentMetadata().setContentLength(Long.valueOf(data.available()));
       } catch (IOException e) {
          Throwables.propagate(e);
       }

--- a/drivers/jsch/src/test/java/org/jclouds/ssh/jsch/JschSshClientLiveTest.java
+++ b/drivers/jsch/src/test/java/org/jclouds/ssh/jsch/JschSshClientLiveTest.java
@@ -276,6 +276,6 @@ public class JschSshClientLiveTest {
       } finally {
          Closeables.closeQuietly(response);
       }
-      assertEquals(response.getExitStatus().get(), new Integer(0));
+      assertEquals(response.getExitStatus().get(), Integer.valueOf(0));
    }
 }

--- a/drivers/sshj/src/test/java/org/jclouds/sshj/SshjSshClientLiveTest.java
+++ b/drivers/sshj/src/test/java/org/jclouds/sshj/SshjSshClientLiveTest.java
@@ -185,6 +185,6 @@ public class SshjSshClientLiveTest {
       } finally {
          Closeables.closeQuietly(response);
       }
-      assertEquals(response.getExitStatus().get(), new Integer(0));
+      assertEquals(response.getExitStatus().get(), Integer.valueOf(0));
    }
 }

--- a/labs/cdmi/src/main/java/org/jclouds/snia/cdmi/v1/options/ListContainersOptions.java
+++ b/labs/cdmi/src/main/java/org/jclouds/snia/cdmi/v1/options/ListContainersOptions.java
@@ -53,7 +53,7 @@ public class ListContainersOptions extends BaseHttpRequestOptions {
 
    public int getLimit() {
       String val = getFirstQueryOrNull("limit");
-      return val != null ? new Integer(val) : 10000;
+      return val != null ? Integer.valueOf(val) : 10000;
    }
 
    public static class Builder {

--- a/labs/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/options/ListContainersOptions.java
+++ b/labs/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/options/ListContainersOptions.java
@@ -53,7 +53,7 @@ public class ListContainersOptions extends BaseHttpRequestOptions {
 
    public int getLimit() {
       String val = getFirstQueryOrNull("limit");
-      return val != null ? new Integer(val) : 10000;
+      return val != null ? Integer.valueOf(val) : 10000;
    }
 
 

--- a/labs/rds/src/main/java/org/jclouds/rds/xml/InstanceHandler.java
+++ b/labs/rds/src/main/java/org/jclouds/rds/xml/InstanceHandler.java
@@ -110,7 +110,7 @@ public class InstanceHandler extends ParseSax.HandlerForGeneratedRequestWithResu
       } else if (equalsOrSuffix(qName, "Address")) {
          address = currentOrNull(currentText);
       } else if (equalsOrSuffix(qName, "Port")) {
-         port = new Integer(currentOrNull(currentText));
+         port = Integer.valueOf(currentOrNull(currentText));
       } else if (equalsOrSuffix(qName, "Endpoint")) {
          builder.endpoint(HostAndPort.fromParts(address, port));
          address = null;

--- a/labs/savvis-symphonyvpdc/src/main/java/org/jclouds/savvis/vpdc/xml/NetworkConfigSectionHandler.java
+++ b/labs/savvis-symphonyvpdc/src/main/java/org/jclouds/savvis/vpdc/xml/NetworkConfigSectionHandler.java
@@ -57,7 +57,7 @@ public class NetworkConfigSectionHandler extends SectionHandler<NetworkConfigSec
       if (equalsOrSuffix(qName, "FenceMode")) {
          builder.fenceMode(currentOrNull(currentText));
       } else if (equalsOrSuffix(qName, "Dhcp")) {
-         builder.dhcp(new Boolean(currentOrNull(currentText)));
+         builder.dhcp(Boolean.valueOf(currentOrNull(currentText)));
       }
       super.endElement(uri, localName, qName);
    }

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/MediaApiLiveTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/MediaApiLiveTest.java
@@ -151,7 +151,7 @@ public class MediaApiLiveTest extends BaseVCloudDirectorApiLiveTest {
       assertTrue(media.getFiles().size() == 1, String.format(OBJ_FIELD_LIST_SIZE_EQ, MEDIA, "files", 1, media.getFiles().size()));
       File uploadFile = getFirst(media.getFiles(), null);
       assertNotNull(uploadFile, String.format(OBJ_FIELD_REQ, MEDIA, "files.first"));
-      assertEquals(uploadFile.getSize(), new Long(iso.length));
+      assertEquals(uploadFile.getSize(), Long.valueOf(iso.length));
       assertEquals(uploadFile.getSize().longValue(), sourceMedia.getSize(),
             String.format(OBJ_FIELD_EQ, MEDIA, "uploadFile.size()", sourceMedia.getSize(), uploadFile.getSize()));
       

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/xml/LaunchSpecificationHandler.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/xml/LaunchSpecificationHandler.java
@@ -115,7 +115,7 @@ public class LaunchSpecificationHandler extends HandlerForGeneratedRequestWithRe
       } else if (qName.equals("enabled")) {
          String monitoringEnabled = currentOrNull();
          if (monitoringEnabled != null)
-            builder.monitoringEnabled(new Boolean(monitoringEnabled));
+            builder.monitoringEnabled(Boolean.valueOf(monitoringEnabled));
       }
       currentText = new StringBuilder();
    }

--- a/providers/aws-s3/src/main/java/org/jclouds/aws/s3/blobstore/strategy/internal/ParallelMultipartUploadStrategy.java
+++ b/providers/aws-s3/src/main/java/org/jclouds/aws/s3/blobstore/strategy/internal/ParallelMultipartUploadStrategy.java
@@ -190,14 +190,14 @@ public class ParallelMultipartUploadStrategy implements AsyncMultipartUploadStra
                         CountDownLatch latch = new CountDownLatch(effectiveParts);
                         int part;
                         while ((part = algorithm.getNextPart()) <= parts) {
-                           Integer partKey = new Integer(part);
+                           Integer partKey = Integer.valueOf(part);
                            activeParts.put(partKey);
                            prepareUploadPart(container, key, uploadId, partKey, payload, 
                                  algorithm.getNextChunkOffset(), chunkSize, etags, 
                                  activeParts, futureParts, errors, maxRetries, errorMap, toRetry, latch);
                         }
                         if (remaining > 0) {
-                           Integer partKey = new Integer(part);
+                           Integer partKey = Integer.valueOf(part);
                            activeParts.put(partKey);
                            prepareUploadPart(container, key, uploadId, partKey, payload, 
                                  algorithm.getNextChunkOffset(), remaining, etags, 
@@ -210,7 +210,7 @@ public class ParallelMultipartUploadStrategy implements AsyncMultipartUploadStra
                            CountDownLatch retryLatch = new CountDownLatch(atOnce);
                            for (int i = 0; i < atOnce; i++) {
                               Part failedPart = toRetry.poll();
-                              Integer partKey = new Integer(failedPart.getPart());
+                              Integer partKey = Integer.valueOf(failedPart.getPart());
                               activeParts.put(partKey);
                               prepareUploadPart(container, key, uploadId, partKey, payload, 
                                     failedPart.getOffset(), failedPart.getSize(), etags, 

--- a/providers/aws-s3/src/main/java/org/jclouds/aws/s3/blobstore/strategy/internal/SequentialMultipartUploadStrategy.java
+++ b/providers/aws-s3/src/main/java/org/jclouds/aws/s3/blobstore/strategy/internal/SequentialMultipartUploadStrategy.java
@@ -75,7 +75,7 @@ public class SequentialMultipartUploadStrategy implements MultipartUploadStrateg
       String eTag = null;
       try {
          eTag = client.uploadPart(container, key, part, uploadId, chunkedPart);
-         etags.put(new Integer(part), eTag);
+         etags.put(Integer.valueOf(part), eTag);
       } catch (KeyNotFoundException e) {
          // note that because of eventual consistency, the upload id may not be present yet
          // we may wish to add this condition to the retry handler
@@ -83,7 +83,7 @@ public class SequentialMultipartUploadStrategy implements MultipartUploadStrateg
          // we may also choose to implement ListParts and wait for the uploadId to become
          // available there.
          eTag = client.uploadPart(container, key, part, uploadId, chunkedPart);
-         etags.put(new Integer(part), eTag);
+         etags.put(Integer.valueOf(part), eTag);
       }
    }
 

--- a/providers/aws-s3/src/test/java/org/jclouds/aws/s3/blobstore/strategy/internal/SequentialMultipartUploadStrategyTest.java
+++ b/providers/aws-s3/src/test/java/org/jclouds/aws/s3/blobstore/strategy/internal/SequentialMultipartUploadStrategyTest.java
@@ -75,14 +75,14 @@ public class SequentialMultipartUploadStrategyTest {
       long chunkSize = MultipartUploadSlicingAlgorithm.DEFAULT_PART_SIZE;
       long remaining = 100L;
       SortedMap<Integer, String> etags = Maps.newTreeMap();
-      etags.put(new Integer(1), "eTag1");
-      etags.put(new Integer(2), "eTag2");
+      etags.put(Integer.valueOf(1), "eTag1");
+      etags.put(Integer.valueOf(2), "eTag2");
       
       expect(blob.getMetadata()).andReturn(blobMeta).atLeastOnce();
       expect(blobMeta.getName()).andReturn(key).atLeastOnce();
       expect(blob.getPayload()).andReturn(payload).atLeastOnce();
       expect(payload.getContentMetadata()).andReturn(contentMeta).atLeastOnce();
-      expect(contentMeta.getContentLength()).andReturn(new Long(chunkSize + remaining));
+      expect(contentMeta.getContentLength()).andReturn(Long.valueOf(chunkSize + remaining));
       expect(ablobStore.getContext()).andReturn(context).atLeastOnce();
       expect(context.unwrap(AWSS3ApiMetadata.CONTEXT_TOKEN)).andReturn(psc).atLeastOnce();
       expect(psc.getApi()).andReturn(client).atLeastOnce();
@@ -138,14 +138,14 @@ public class SequentialMultipartUploadStrategyTest {
       long chunkSize = MultipartUploadSlicingAlgorithm.DEFAULT_PART_SIZE;
       long remaining = 100L;
       SortedMap<Integer, String> etags = Maps.newTreeMap();
-      etags.put(new Integer(1), "eTag1");
-      etags.put(new Integer(2), "eTag2");
+      etags.put(Integer.valueOf(1), "eTag1");
+      etags.put(Integer.valueOf(2), "eTag2");
       
       expect(blob.getMetadata()).andReturn(blobMeta).atLeastOnce();
       expect(blobMeta.getName()).andReturn(key).atLeastOnce();
       expect(blob.getPayload()).andReturn(payload).atLeastOnce();
       expect(payload.getContentMetadata()).andReturn(contentMeta).atLeastOnce();
-      expect(contentMeta.getContentLength()).andReturn(new Long(chunkSize + remaining));
+      expect(contentMeta.getContentLength()).andReturn(Long.valueOf(chunkSize + remaining));
       expect(ablobStore.getContext()).andReturn(context).atLeastOnce();
       expect(context.unwrap(AWSS3ApiMetadata.CONTEXT_TOKEN)).andReturn(psc).atLeastOnce();
       expect(psc.getApi()).andReturn(client).atLeastOnce();

--- a/providers/azureblob/src/test/java/org/jclouds/azureblob/AzureBlobClientLiveTest.java
+++ b/providers/azureblob/src/test/java/org/jclouds/azureblob/AzureBlobClientLiveTest.java
@@ -267,7 +267,7 @@ public class AzureBlobClientLiveTest extends BaseBlobStoreIntegrationTest {
       AzureBlob getBlob = getApi().getBlob(privateContainer, object.getProperties().getName());
       assertEquals(Strings2.toString(getBlob.getPayload()), data);
       // TODO assertEquals(getBlob.getName(), object.getProperties().getName());
-      assertEquals(getBlob.getPayload().getContentMetadata().getContentLength(), new Long(data.length()));
+      assertEquals(getBlob.getPayload().getContentMetadata().getContentLength(), Long.valueOf(data.length()));
       assertEquals(getBlob.getProperties().getContentMetadata().getContentType(), "text/plain");
       assertEquals(CryptoStreams.hex(md5),
             CryptoStreams.hex(getBlob.getProperties().getContentMetadata().getContentMD5()));
@@ -310,7 +310,7 @@ public class AzureBlobClientLiveTest extends BaseBlobStoreIntegrationTest {
       object = getApi().newBlob();
       object.getProperties().setName("chunked-object");
       object.setPayload(bais);
-      object.getPayload().getContentMetadata().setContentLength(new Long(data.getBytes().length));
+      object.getPayload().getContentMetadata().setContentLength(Long.valueOf(data.getBytes().length));
       newEtag = getApi().putBlob(privateContainer, object);
       assertEquals(CryptoStreams.hex(md5),
             CryptoStreams.hex(getBlob.getProperties().getContentMetadata().getContentMD5()));

--- a/providers/gogrid/src/main/java/org/jclouds/gogrid/compute/strategy/GoGridComputeServiceAdapter.java
+++ b/providers/gogrid/src/main/java/org/jclouds/gogrid/compute/strategy/GoGridComputeServiceAdapter.java
@@ -154,19 +154,19 @@ public class GoGridComputeServiceAdapter implements ComputeServiceAdapter<Server
    
    @Override
    public void destroyNode(String id) {
-      client.getServerServices().deleteById(new Long(id));
+      client.getServerServices().deleteById(Long.valueOf(id));
    }
 
    @Override
    public void rebootNode(String id) {
       executeCommandOnServer(PowerCommand.RESTART, id);
-      Server server = Iterables.getOnlyElement(client.getServerServices().getServersById(new Long(id)));
+      Server server = Iterables.getOnlyElement(client.getServerServices().getServersById(Long.valueOf(id)));
       client.getServerServices().power(server.getName(), PowerCommand.START);
       serverLatestJobCompletedShort.apply(server);
    }
 
    private boolean executeCommandOnServer(PowerCommand command, String id) {
-      Server server = Iterables.getOnlyElement(client.getServerServices().getServersById(new Long(id)));
+      Server server = Iterables.getOnlyElement(client.getServerServices().getServersById(Long.valueOf(id)));
       client.getServerServices().power(server.getName(), command);
       return serverLatestJobCompleted.apply(server);
    }

--- a/providers/gogrid/src/test/java/org/jclouds/gogrid/compute/GoGridComputeServiceLiveTest.java
+++ b/providers/gogrid/src/test/java/org/jclouds/gogrid/compute/GoGridComputeServiceLiveTest.java
@@ -84,12 +84,12 @@ public class GoGridComputeServiceLiveTest extends BaseComputeServiceLiveTest {
       try {
          NodeMetadata node = getOnlyElement(client.createNodesInGroup(group, 1));
 
-         Server updatedServer = providerContext.getApi().getServerServices().editServerRam(new Long(node.getId()), ram);
+         Server updatedServer = providerContext.getApi().getServerServices().editServerRam(Long.valueOf(node.getId()), ram);
          assertNotNull(updatedServer);
          assert serverLatestJobCompleted.apply(updatedServer);
 
          assertEquals(
-               Iterables.getLast(providerContext.getApi().getServerServices().getServersById(new Long(node.getId())))
+               Iterables.getLast(providerContext.getApi().getServerServices().getServersById(Long.valueOf(node.getId())))
                      .getRam().getName(), ram);
 
       } finally {

--- a/providers/hpcloud-objectstorage/src/main/java/org/jclouds/hpcloud/objectstorage/functions/ParseContainerMetadataFromHeaders.java
+++ b/providers/hpcloud-objectstorage/src/main/java/org/jclouds/hpcloud/objectstorage/functions/ParseContainerMetadataFromHeaders.java
@@ -49,8 +49,8 @@ public class ParseContainerMetadataFromHeaders implements Function<HttpResponse,
       
       to.setReadACL(from.getFirstHeaderOrNull(SwiftHeaders.CONTAINER_READ));
  
-      to.setBytes(new Long(from.getFirstHeaderOrNull(SwiftHeaders.CONTAINER_BYTES_USED)));
-      to.setCount(new Long(from.getFirstHeaderOrNull(SwiftHeaders.CONTAINER_OBJECT_COUNT)));
+      to.setBytes(Long.valueOf(from.getFirstHeaderOrNull(SwiftHeaders.CONTAINER_BYTES_USED)));
+      to.setCount(Long.valueOf(from.getFirstHeaderOrNull(SwiftHeaders.CONTAINER_OBJECT_COUNT)));
       
       addUserMetadataTo(from, to);
       

--- a/providers/slicehost/src/test/java/org/jclouds/slicehost/SlicehostClientLiveTest.java
+++ b/providers/slicehost/src/test/java/org/jclouds/slicehost/SlicehostClientLiveTest.java
@@ -234,7 +234,7 @@ public class SlicehostClientLiveTest extends BaseComputeServiceContextLiveTest {
       Slice slice = client.getSlice(sliceId);
       assertEquals(slice.getStatus(), Slice.Status.ACTIVE);
       assert slice.getProgress() >= 0 : "newDetails.getProgress()" + slice.getProgress();
-      assertEquals(new Integer(14362), slice.getImageId());
+      assertEquals(Integer.valueOf(14362), slice.getImageId());
       assertEquals(1, slice.getFlavorId());
       assertNotNull(slice.getAddresses());
       checkPassOk(slice, rootPassword);

--- a/providers/softlayer/src/main/java/org/jclouds/softlayer/domain/Address.java
+++ b/providers/softlayer/src/main/java/org/jclouds/softlayer/domain/Address.java
@@ -89,7 +89,7 @@ public class Address implements Comparable<Address> {
 
    @Override
    public int compareTo(Address arg0) {
-      return new Integer(id).compareTo(arg0.getId());
+      return Integer.valueOf(id).compareTo(arg0.getId());
    }
 
    /**

--- a/providers/softlayer/src/main/java/org/jclouds/softlayer/domain/Datacenter.java
+++ b/providers/softlayer/src/main/java/org/jclouds/softlayer/domain/Datacenter.java
@@ -104,7 +104,7 @@ public class Datacenter implements Comparable<Datacenter> {
 
    @Override
    public int compareTo(Datacenter arg0) {
-      return new Integer(id).compareTo(arg0.getId());
+      return Integer.valueOf(id).compareTo(arg0.getId());
    }
 
    /**

--- a/providers/softlayer/src/main/java/org/jclouds/softlayer/domain/OperatingSystem.java
+++ b/providers/softlayer/src/main/java/org/jclouds/softlayer/domain/OperatingSystem.java
@@ -86,7 +86,7 @@ public class OperatingSystem implements Comparable<OperatingSystem> {
 
    @Override
    public int compareTo(OperatingSystem arg0) {
-      return new Integer(id).compareTo(arg0.getId());
+      return Integer.valueOf(id).compareTo(arg0.getId());
    }
 
    /**

--- a/providers/softlayer/src/main/java/org/jclouds/softlayer/domain/Password.java
+++ b/providers/softlayer/src/main/java/org/jclouds/softlayer/domain/Password.java
@@ -82,7 +82,7 @@ public class Password implements Comparable<Password> {
 
     @Override
    public int compareTo(Password arg0) {
-      return new Integer(id).compareTo(arg0.getId());
+      return Integer.valueOf(id).compareTo(arg0.getId());
    }
 
    /**

--- a/providers/softlayer/src/main/java/org/jclouds/softlayer/domain/ProductItem.java
+++ b/providers/softlayer/src/main/java/org/jclouds/softlayer/domain/ProductItem.java
@@ -130,7 +130,7 @@ public class ProductItem implements Comparable<ProductItem> {
 
    @Override
    public int compareTo(ProductItem arg0) {
-      return new Integer(id).compareTo(arg0.getId());
+      return Integer.valueOf(id).compareTo(arg0.getId());
    }
 
    /**

--- a/providers/softlayer/src/main/java/org/jclouds/softlayer/domain/ProductItemCategory.java
+++ b/providers/softlayer/src/main/java/org/jclouds/softlayer/domain/ProductItemCategory.java
@@ -83,7 +83,7 @@ public class ProductItemCategory implements Comparable<ProductItemCategory> {
 
    @Override
    public int compareTo(ProductItemCategory arg0) {
-      return new Integer(id).compareTo(arg0.getId());
+      return Integer.valueOf(id).compareTo(arg0.getId());
    }
 
    /**

--- a/providers/softlayer/src/main/java/org/jclouds/softlayer/domain/ProductItemPrice.java
+++ b/providers/softlayer/src/main/java/org/jclouds/softlayer/domain/ProductItemPrice.java
@@ -122,7 +122,7 @@ public class ProductItemPrice implements Comparable<ProductItemPrice> {
 
    @Override
    public int compareTo(ProductItemPrice arg0) {
-      return new Integer(id).compareTo(arg0.getId());
+      return Integer.valueOf(id).compareTo(arg0.getId());
    }
 
    /**

--- a/providers/softlayer/src/main/java/org/jclouds/softlayer/domain/ProductOrderReceipt.java
+++ b/providers/softlayer/src/main/java/org/jclouds/softlayer/domain/ProductOrderReceipt.java
@@ -67,7 +67,7 @@ public class ProductOrderReceipt implements Comparable<ProductOrderReceipt> {
 
    @Override
    public int compareTo(ProductOrderReceipt arg0) {
-      return new Integer(orderId).compareTo(arg0.getOrderId());
+      return Integer.valueOf(orderId).compareTo(arg0.getOrderId());
    }
 
    /**

--- a/providers/softlayer/src/main/java/org/jclouds/softlayer/domain/ProductPackage.java
+++ b/providers/softlayer/src/main/java/org/jclouds/softlayer/domain/ProductPackage.java
@@ -110,7 +110,7 @@ public class ProductPackage implements Comparable<ProductPackage> {
 
    @Override
    public int compareTo(ProductPackage arg0) {
-      return new Integer(id).compareTo(arg0.getId());
+      return Integer.valueOf(id).compareTo(arg0.getId());
    }
 
    /**

--- a/providers/softlayer/src/main/java/org/jclouds/softlayer/domain/Region.java
+++ b/providers/softlayer/src/main/java/org/jclouds/softlayer/domain/Region.java
@@ -76,7 +76,7 @@ public class Region implements Comparable<Region> {
 
    @Override
    public int compareTo(Region arg0) {
-      return new Integer(sortOrder).compareTo(arg0.sortOrder);
+      return Integer.valueOf(sortOrder).compareTo(arg0.sortOrder);
    }
 
    /**

--- a/providers/softlayer/src/main/java/org/jclouds/softlayer/domain/VirtualGuest.java
+++ b/providers/softlayer/src/main/java/org/jclouds/softlayer/domain/VirtualGuest.java
@@ -326,7 +326,7 @@ public class VirtualGuest implements Comparable<VirtualGuest> {
 
    @Override
    public int compareTo(VirtualGuest arg0) {
-      return new Integer(id).compareTo(arg0.getId());
+      return Integer.valueOf(id).compareTo(arg0.getId());
    }
 
    /**

--- a/providers/softlayer/src/test/java/org/jclouds/softlayer/compute/functions/ProductItemToImageTest.java
+++ b/providers/softlayer/src/test/java/org/jclouds/softlayer/compute/functions/ProductItemToImageTest.java
@@ -231,12 +231,12 @@ public class ProductItemToImageTest {
 
    @Test
    public void testOsBitsWithSpace() {
-      assertEquals(osBits().apply("a (32 bit) os"),new Integer(32));
+      assertEquals(osBits().apply("a (32 bit) os"),Integer.valueOf(32));
    }
 
    @Test
    public void testOsBitsNoSpace() {
-      assertEquals(osBits().apply("a (64bit) os"),new Integer(64));
+      assertEquals(osBits().apply("a (64bit) os"),Integer.valueOf(64));
    }
 
    @Test

--- a/providers/softlayer/src/test/java/org/jclouds/softlayer/features/ProductPackageClientLiveTest.java
+++ b/providers/softlayer/src/test/java/org/jclouds/softlayer/features/ProductPackageClientLiveTest.java
@@ -138,7 +138,7 @@ public class ProductPackageClientLiveTest extends BaseSoftLayerClientLiveTest {
       Map<Float, ProductItem> ramToProductItem = Maps.uniqueIndex(ramItems, ProductItems.capacity());
 
       ProductItemPrice price = ProductItems.price().apply(ramToProductItem.get(1.0f));
-      assert new Integer(1644).equals(price.getId());
+      assert Integer.valueOf(1644).equals(price.getId());
    }
 
    @Test
@@ -153,7 +153,7 @@ public class ProductPackageClientLiveTest extends BaseSoftLayerClientLiveTest {
       Map<Float, ProductItem> coresToProductItem = Maps.uniqueIndex(cpuItems, ProductItems.capacity());
 
       ProductItemPrice price = ProductItems.price().apply(coresToProductItem.get(2.0f));
-      assert new Integer(1963).equals(price.getId());
+      assert Integer.valueOf(1963).equals(price.getId());
    }
 
    @Test
@@ -165,7 +165,7 @@ public class ProductPackageClientLiveTest extends BaseSoftLayerClientLiveTest {
 
       ProductItemPrice price = ProductItems.price().apply(
             osToProductItem.get("Ubuntu Linux 8 LTS Hardy Heron - Minimal Install (64 bit)"));
-      assert new Integer(1693).equals(price.getId());
+      assert Integer.valueOf(1693).equals(price.getId());
    }
 
    private void checkProductItem(ProductItem item) {

--- a/providers/trmk-ecloud/src/main/java/org/jclouds/trmk/ecloud/xml/TagNameToUsageCountHandler.java
+++ b/providers/trmk-ecloud/src/main/java/org/jclouds/trmk/ecloud/xml/TagNameToUsageCountHandler.java
@@ -50,7 +50,7 @@ public class TagNameToUsageCountHandler extends ParseSax.HandlerWithResult<Map<S
       if (equalsOrSuffix(qName, "Name")) {
          name = currentOrNull(currentText);
       } else if (equalsOrSuffix(qName, "UsageCount")) {
-         builder.put(name, new Integer(currentOrNull(currentText)));
+         builder.put(name, Integer.valueOf(currentOrNull(currentText)));
       }
       currentText = new StringBuilder();
    }

--- a/sandbox-apis/libvirt/src/main/java/org/jclouds/libvirt/compute/functions/DomainToHardware.java
+++ b/sandbox-apis/libvirt/src/main/java/org/jclouds/libvirt/compute/functions/DomainToHardware.java
@@ -78,7 +78,7 @@ public class DomainToHardware implements Function<Domain, Hardware> {
 			for (int i = 0; i < nodes.getLength(); i++) {
 				StorageVol storageVol = from.getConnect().storageVolLookupByPath(diskFileName);
 				String id = storageVol.getKey();
-				float size = new Long(storageVol.getInfo().capacity).floatValue();
+				float size = Long.valueOf(storageVol.getInfo().capacity).floatValue();
 				volumes.add(new VolumeImpl(id, Volume.Type.LOCAL, size, null, true, false));
 			}
 			builder.volumes((List<Volume>) volumes);

--- a/sandbox-apis/pcs/src/test/java/org/jclouds/mezeo/pcs/PCSClientLiveTest.java
+++ b/sandbox-apis/pcs/src/test/java/org/jclouds/mezeo/pcs/PCSClientLiveTest.java
@@ -215,7 +215,7 @@ public class PCSClientLiveTest {
       // Test GET of object (including updated metadata)
       InputStream file = connection.downloadFile(objectURI);
       assertEquals(Strings2.toStringAndClose(file), data);
-      validateFileInfoAndNameIsInMetadata(container, objectURI, "object", new Long(data.length()));
+      validateFileInfoAndNameIsInMetadata(container, objectURI, "object", Long.valueOf(data.length()));
 
       try {
          connection.uploadFile(container, object);
@@ -235,15 +235,15 @@ public class PCSClientLiveTest {
       // try sending it in 2 parts
       object.getMetadata().setName(name);
       objectURI = connection.createFile(container, object);
-      validateFileInfoAndNameIsInMetadata(container, objectURI, name, new Long(0));
+      validateFileInfoAndNameIsInMetadata(container, objectURI, name, Long.valueOf(0));
 
       object.setPayload(data.substring(0, 2));
       connection.uploadBlock(objectURI, object, range(0, 2));
-      validateFileInfoAndNameIsInMetadata(container, objectURI, name, new Long(2));
+      validateFileInfoAndNameIsInMetadata(container, objectURI, name, Long.valueOf(2));
 
       object.setPayload(data.substring(2));
       connection.uploadBlock(objectURI, object, range(2, data.getBytes().length));
-      validateFileInfoAndNameIsInMetadata(container, objectURI, name, new Long(data.length()));
+      validateFileInfoAndNameIsInMetadata(container, objectURI, name, Long.valueOf(data.length()));
 
       file = connection.downloadFile(objectURI);
       assertEquals(Strings2.toStringAndClose(file), data);
@@ -252,7 +252,7 @@ public class PCSClientLiveTest {
       data = "Here is my datum";
       object.setPayload(data.substring(2));
       connection.uploadBlock(objectURI, object, range(2, data.getBytes().length));
-      validateFileInfoAndNameIsInMetadata(container, objectURI, name, new Long(data.length()));
+      validateFileInfoAndNameIsInMetadata(container, objectURI, name, Long.valueOf(data.length()));
 
       file = connection.downloadFile(objectURI);
       assertEquals(Strings2.toStringAndClose(file), data);

--- a/sandbox-apis/pcs/src/test/java/org/jclouds/mezeo/pcs/binders/BindContainerNameToXmlPayloadTest.java
+++ b/sandbox-apis/pcs/src/test/java/org/jclouds/mezeo/pcs/binders/BindContainerNameToXmlPayloadTest.java
@@ -40,7 +40,7 @@ public class BindContainerNameToXmlPayloadTest {
       binder.bindToRequest(request, "foo");
 
       assertEquals(request.getPayload().getRawContent(), "<container><name>foo</name></container>");
-      assertEquals(request.getPayload().getContentMetadata().getContentLength(), new Long(
+      assertEquals(request.getPayload().getContentMetadata().getContentLength(), Long.valueOf(
                "<container><name>foo</name></container>".getBytes().length));
       assertEquals(request.getPayload().getContentMetadata().getContentType(), "application/unknown");
 


### PR DESCRIPTION
This allows use of cached values.  Patched with:

find -name *.java | xargs sed -i 's/new Boolean(false)/Boolean.FALSE/g'
find -name *.java | xargs sed -i 's/new Boolean(true)/Boolean.TRUE/g'
find -name *.java | xargs sed -i 's/new Boolean(/Boolean.valueOf(/g'
find -name *.java | xargs sed -i 's/new Integer(/Integer.valueOf(/g'
find -name *.java | xargs sed -i 's/new Long(/Long.valueOf(/g'
