### PR TITLE
Miscellaneous local blobstore cleanups

### DIFF
--- a/apis/filesystem/src/main/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImpl.java
+++ b/apis/filesystem/src/main/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImpl.java
@@ -116,6 +116,7 @@ public class FilesystemStorageStrategyImpl implements LocalStorageStrategy {
    }
 
    public boolean createContainer(String container) {
+      filesystemContainerNameValidator.validate(container);
       return createContainerInLocation(container, null);
    }
 
@@ -277,6 +278,11 @@ public class FilesystemStorageStrategyImpl implements LocalStorageStrategy {
    @Override
    public Location getLocation(final String containerName) {
       return null;
+   }
+
+   @Override
+   public String getSeparator() {
+      return File.separator;
    }
 
    public boolean directoryExists(String container, String directory) {

--- a/blobstore/src/main/java/org/jclouds/blobstore/LocalStorageStrategy.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/LocalStorageStrategy.java
@@ -127,4 +127,7 @@ public interface LocalStorageStrategy {
      * @return Location of container or null
      */
     Location getLocation(String containerName);
+
+    /** @return path separator, either / or \ */
+    String getSeparator();
 }

--- a/blobstore/src/main/java/org/jclouds/blobstore/TransientAsyncBlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/TransientAsyncBlobStore.java
@@ -181,7 +181,7 @@ public class TransientAsyncBlobStore extends BaseAsyncBlobStore {
             }
          }
 
-         final String delimiter = options.isRecursive() ? null : "/";
+         final String delimiter = options.isRecursive() ? null : storageStrategy.getSeparator();
          if (delimiter != null) {
             SortedSet<String> commonPrefixes = newTreeSet(
                    transform(contents, new CommonPrefixes(prefix, delimiter)));
@@ -238,7 +238,12 @@ public class TransientAsyncBlobStore extends BaseAsyncBlobStore {
    }
 
    /**
-    * {@inheritDoc}
+    * Override parent method because it uses strange futures and listenables
+    * that creates problem in the test if more than one test that deletes the
+    * container is executed
+    *
+    * @param container
+    * @return
     */
    @Override
    public ListenableFuture<Void> deleteContainer(final String container) {

--- a/blobstore/src/main/java/org/jclouds/blobstore/TransientStorageStrategy.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/TransientStorageStrategy.java
@@ -143,6 +143,11 @@ public class TransientStorageStrategy implements LocalStorageStrategy {
       return containerToLocation.get(containerName);
    }
 
+   @Override
+   public String getSeparator() {
+      return "/";
+   }
+
    private Blob createUpdatedCopyOfBlobInContainer(String containerName, Blob in) {
       checkNotNull(in, "blob");
       checkNotNull(in.getPayload(), "blob.payload");


### PR DESCRIPTION
There are no more functional differences between the filesystem and
transient blobstores.  This is the last commit before introducing a
unified LocalAsyncBlobStore class.
