### PR TITLE
DescribeSnapshotsResponseHandler bug parsing tags

### DIFF
--- a/apis/ec2/src/main/java/org/jclouds/ec2/xml/DescribeSnapshotsResponseHandler.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/xml/DescribeSnapshotsResponseHandler.java
@@ -37,6 +37,7 @@ public class DescribeSnapshotsResponseHandler extends ParseSax.HandlerWithResult
 
    private Set<Snapshot> snapshots = Sets.newLinkedHashSet();
    private final SnapshotHandler snapshotHandler;
+   private int itemDepth = 0;
 
    @Inject
    public DescribeSnapshotsResponseHandler(SnapshotHandler snapshotHandler) {
@@ -50,13 +51,16 @@ public class DescribeSnapshotsResponseHandler extends ParseSax.HandlerWithResult
    @Override
    public void startElement(String uri, String localName, String qName, Attributes attributes)
             throws SAXException {
+      itemDepth++;
       snapshotHandler.startElement(uri, localName, qName, attributes);
    }
 
    @Override
    public void endElement(String uri, String localName, String qName) throws SAXException {
       snapshotHandler.endElement(uri, localName, qName);
-      if (qName.equals("item")) {
+      itemDepth--;
+
+      if (qName.equals("item") && itemDepth == 2) {
          this.snapshots.add(snapshotHandler.getResult());
       }
    }

--- a/apis/ec2/src/test/resources/describe_snapshots.xml
+++ b/apis/ec2/src/test/resources/describe_snapshots.xml
@@ -9,6 +9,12 @@
             <ownerId>218213537122</ownerId>
             <volumeSize>10</volumeSize>
             <description>Daily Backup</description>
+            <tagSet>
+                <item>
+                    <key>Name</key>
+                    <value>example_name_tag</value>
+                </item>
+            </tagSet>
         </item>
     </snapshotSet>
 </DescribeSnapshotsResponse>


### PR DESCRIPTION
Related issue: http://code.google.com/p/jclouds/issues/detail?id=1033

DescribeSnapshotsResponseHandler behaved incorrectly when a snapshot had
metadata tags added - it would stop parsing and start the next Snapshot
object every time it saw an </item> tag. Since metadata tags contain
</item>, each tag would cause a new Snapshot object in the response
containing all nulls. Fixed by counting the tag nesting depth and only
responding to </item> at the correct nesting level.
