### PR TITLE
More features for smartos-ssh

### DIFF
--- a/labs/smartos-ssh/src/main/java/org/jclouds/smartos/compute/domain/VmSpecification.java
+++ b/labs/smartos-ssh/src/main/java/org/jclouds/smartos/compute/domain/VmSpecification.java
@@ -26,6 +26,18 @@ public class VmSpecification {
    protected final String dnsDomain;
    protected final String quota;
 
+   @SerializedName("max_physical_memory")
+   protected final int maxPhysicalMemory;
+
+   @SerializedName("max_locked_memory")
+   protected final int maxLockedMemory;
+
+   @SerializedName("max_swap")
+   protected final int maxSwap;
+
+   @SerializedName("tmpfs")
+   protected final int tmpFs;
+
    protected final List<VmNIC> nics;
 
    public static Builder builder() {
@@ -42,7 +54,12 @@ public class VmSpecification {
       protected String brand = "joyent";
       protected DataSet dataset;
       protected String dnsDomain = "local";
-      protected String quota = "10";
+      protected String quota = "0";
+
+      protected int maxPhysicalMemory = 256;
+      protected int maxLockedMemory = 256;
+      protected int maxSwap = 256;
+      protected int tmpFs = 256;
 
       protected List<VmNIC> nics = new ArrayList<VmNIC>();
 
@@ -71,7 +88,7 @@ public class VmSpecification {
          return this;
       }
 
-      public Builder nics(Collection<VmNIC> nic) {
+      public Builder nics(Collection<VmNIC> nics) {
          this.nics.addAll(nics);
          return this;
       }
@@ -81,23 +98,56 @@ public class VmSpecification {
          return this;
       }
 
+      public Builder maxPhysicalMemory(int maxPhysicalMemory) {
+         this.maxPhysicalMemory = maxPhysicalMemory;
+         return this;
+      }
+
+      public Builder maxLockedMemory(int maxLockedMemory) {
+         this.maxLockedMemory = maxLockedMemory;
+         return this;
+      }
+
+      public Builder maxSwap(int maxSwap) {
+         this.maxSwap = maxSwap;
+         return this;
+      }
+
+      public Builder tmpFs(int tmpFs) {
+         this.tmpFs = tmpFs;
+         return this;
+      }
+
+      public Builder ram(int ram) {
+         this.maxPhysicalMemory = ram;
+         this.maxLockedMemory = ram;
+         this.maxSwap = ram;
+         this.tmpFs = ram;
+         return this;
+      }
+
       public VmSpecification build() {
-         return new VmSpecification(alias, brand, dataset, dnsDomain, quota, nics);
+         return new VmSpecification(alias, brand, dataset, dnsDomain, quota, maxPhysicalMemory, maxLockedMemory, maxSwap, tmpFs, nics);
       }
 
       public Builder fromVmSpecification(VmSpecification in) {
          return alias(in.getAlias()).brand(in.getBrand()).dataset(in.getDataset()).dnsDomain(in.getDnsDomain())
-                  .quota(in.getQuota()).nics(in.getNics());
+                  .quota(in.getQuota()).maxPhysicalMemory(in.getMaxPhysicalMemory()).maxLockedMemory(in.getMaxLockedMemory())
+                  .maxSwap(in.getMaxSwap()).tmpFs(in.getTmpFs()).nics(in.getNics());
       }
    }
 
    protected VmSpecification(String alias, String brand, DataSet dataset, String dnsDomain, String quota,
-            List<VmNIC> nics) {
+                             int maxPhysicalMemory, int maxLockedMemory, int maxSwap, int tmpFs, List<VmNIC> nics) {
       this.alias = alias;
       this.brand = brand;
       this.dataset = dataset;
       this.dnsDomain = dnsDomain;
       this.quota = quota;
+      this.maxPhysicalMemory = maxPhysicalMemory;
+      this.maxLockedMemory = maxLockedMemory;
+      this.maxSwap = maxSwap;
+      this.tmpFs = tmpFs;
       this.nics = nics;
    }
 
@@ -119,6 +169,22 @@ public class VmSpecification {
 
    public String getQuota() {
       return quota;
+   }
+
+   public int getMaxPhysicalMemory() {
+      return maxPhysicalMemory;
+   }
+
+   public int getMaxLockedMemory() {
+      return maxLockedMemory;
+   }
+
+   public int getMaxSwap() {
+      return maxSwap;
+   }
+
+   public int getTmpFs() {
+      return tmpFs;
    }
 
    public List<VmNIC> getNics() {

--- a/labs/smartos-ssh/src/main/java/org/jclouds/smartos/compute/functions/VmSpecificationToHardware.java
+++ b/labs/smartos-ssh/src/main/java/org/jclouds/smartos/compute/functions/VmSpecificationToHardware.java
@@ -37,10 +37,10 @@ public class VmSpecificationToHardware implements Function<VmSpecification, Hard
    @Override
    public Hardware apply(VmSpecification from) {
       HardwareBuilder builder = new HardwareBuilder();
-      builder.ids("AnID");
+      builder.ids(from.getAlias());
       builder.name(from.getAlias());
       builder.processors(ImmutableList.of(new Processor(1, 1.0)));
-      builder.ram(256);
+      builder.ram(from.getMaxPhysicalMemory());
       // builder.volumes(ImmutableList.<Volume> of(new VolumeImpl(from.disk, true, false)));
       return builder.build();
    }

--- a/labs/smartos-ssh/src/main/java/org/jclouds/smartos/compute/strategy/SmartOSComputeServiceAdapter.java
+++ b/labs/smartos-ssh/src/main/java/org/jclouds/smartos/compute/strategy/SmartOSComputeServiceAdapter.java
@@ -20,13 +20,16 @@ package org.jclouds.smartos.compute.strategy;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import org.jclouds.compute.ComputeService;
 import org.jclouds.compute.ComputeServiceAdapter;
 import org.jclouds.compute.domain.Template;
@@ -47,10 +50,34 @@ import com.google.common.collect.ImmutableSet;
 @Singleton
 public class SmartOSComputeServiceAdapter implements ComputeServiceAdapter<VM, VmSpecification, DataSet, SmartOSHost> {
    private final SmartOSHost host;
+   private final Map<String, VmSpecification> specificationMap;
+
 
    @Inject
    public SmartOSComputeServiceAdapter(SmartOSHost host) {
       this.host = checkNotNull(host, "host");
+
+      Collection<VmSpecification> specifications = new ArrayList<VmSpecification>();
+
+       specifications.add(VmSpecification.builder().alias("Standard Joyent VM, 1Gb RAM / 2Gb SWAP").ram(1024).maxSwap(2048)
+               .nic(VmNIC.builder().simpleDHCPNic().build()).build());
+
+       specifications.add(VmSpecification.builder().alias("Standard Joyent VM, 2Gb RAM / 4Gb SWAP").ram(2048).maxSwap(4096)
+               .nic(VmNIC.builder().simpleDHCPNic().build()).build());
+
+       specifications.add(VmSpecification.builder().alias("Standard Joyent VM, 4Gb RAM / 8Gb SWAP").ram(4096).maxSwap(8192)
+               .nic(VmNIC.builder().simpleDHCPNic().build()).build());
+
+       specifications.add(VmSpecification.builder().alias("Standard Joyent VM, 8Gb RAM / 16Gb SWAP").ram(8192).maxSwap(16384)
+               .nic(VmNIC.builder().simpleDHCPNic().build()).build());
+
+      specificationMap = Maps.uniqueIndex(specifications, new Function<VmSpecification,String>() {
+          @Override
+          public String apply(@Nullable VmSpecification input) {
+              return input.getAlias();
+          }
+      });
+
    }
 
    private SmartOSHost getHost() {
@@ -59,9 +86,19 @@ public class SmartOSComputeServiceAdapter implements ComputeServiceAdapter<VM, V
 
    @Override
    public NodeAndInitialCredentials<VM> createNodeWithGroupEncodedIntoName(String tag, String name, Template template) {
-      VmSpecification specification = VmSpecification.builder().alias(name)
+
+      VmSpecification.Builder builder = VmSpecification.builder();
+      String providerId = template.getHardware().getProviderId();
+
+      if( specificationMap.containsKey(providerId) ) {
+          builder.fromVmSpecification( specificationMap.get(providerId) );
+      } else {
+          builder.nic(VmNIC.builder().simpleDHCPNic().build());
+      }
+
+      VmSpecification specification = builder.alias(name)
                .dataset(getHost().getDataSet(UUID.fromString(template.getImage().getProviderId())))
-               .nic(VmNIC.builder().simpleDHCPNic().build()).build();
+               .build();
 
       VM from = getHost().createVM(specification);
 
@@ -69,16 +106,11 @@ public class SmartOSComputeServiceAdapter implements ComputeServiceAdapter<VM, V
                .password("smartos").build());
    }
 
+
+
    @Override
    public Iterable<VmSpecification> listHardwareProfiles() {
-      List<VmSpecification> specificationList = new ArrayList<VmSpecification>();
-
-      VmSpecification vs = VmSpecification.builder().alias("Standard Joyent VM")
-               .nic(VmNIC.builder().simpleDHCPNic().build()).build();
-
-      specificationList.add(vs);
-
-      return specificationList;
+      return specificationMap.values();
    }
 
    @Override


### PR DESCRIPTION
Correct the ComputeServiceAdapter to use information from the template
hardware provider ID to match the correct VmSpecification.

Provide some additional nice default templates.

Signed-off-by: Nigel Magnay nigel.magnay@gmail.com
