### PR TITLE
Use consistent and latest version of commons-io

### DIFF
--- a/apis/filesystem/pom.xml
+++ b/apis/filesystem/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.4</version>
+            <version>2.4</version>
         </dependency>
         <dependency>
             <groupId>org.jclouds</groupId>

--- a/drivers/jsch/pom.xml
+++ b/drivers/jsch/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.4</version>
+            <version>2.4</version>
         </dependency>
     </dependencies>
 

--- a/drivers/sshj/pom.xml
+++ b/drivers/sshj/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.0</version>
+            <version>2.4</version>
         </dependency>
     </dependencies>
 

--- a/labs/virtualbox/pom.xml
+++ b/labs/virtualbox/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>1.4</version>
+      <version>2.4</version>
     </dependency>
     <dependency>
       <groupId>org.jclouds.driver</groupId>

--- a/sandbox-apis/libvirt/pom.xml
+++ b/sandbox-apis/libvirt/pom.xml
@@ -54,7 +54,7 @@
                 <dependency>
                     <groupId>commons-io</groupId>
                     <artifactId>commons-io</artifactId>
-                    <version>1.4</version>
+                    <version>2.4</version>
                 </dependency>
 
 		<dependency>


### PR DESCRIPTION
Changelogs:
http://commons.apache.org/io/upgradeto2_0.html
http://commons.apache.org/io/upgradeto2_2.html
http://commons.apache.org/io/upgradeto2_4.html
