### PR TITLE
Updating Nova to allow easier definition of OpenStack API providers with extensions

### DIFF
--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/config/NovaRestClientModule.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/config/NovaRestClientModule.java
@@ -78,6 +78,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 import com.google.inject.Provides;
 
 /**
@@ -86,11 +87,13 @@ import com.google.inject.Provides;
  * @author Adrian Cole
  */
 @ConfiguresRestClient
-public class NovaRestClientModule extends RestClientModule<NovaApi, NovaAsyncApi> {
+public class NovaRestClientModule<S extends NovaApi, A extends NovaAsyncApi> extends RestClientModule<S, A> {
 
    public static final Map<Class<?>, Class<?>> DELEGATE_MAP = ImmutableMap.<Class<?>, Class<?>> builder()
-         .put(ServerApi.class, ServerAsyncApi.class).put(FlavorApi.class, FlavorAsyncApi.class)
-         .put(ImageApi.class, ImageAsyncApi.class).put(ExtensionApi.class, ExtensionAsyncApi.class)
+         .put(ServerApi.class, ServerAsyncApi.class)
+         .put(FlavorApi.class, FlavorAsyncApi.class)
+         .put(ImageApi.class, ImageAsyncApi.class)
+         .put(ExtensionApi.class, ExtensionAsyncApi.class)
          .put(FloatingIPApi.class, FloatingIPAsyncApi.class)
          .put(SecurityGroupApi.class, SecurityGroupAsyncApi.class)
          .put(KeyPairApi.class, KeyPairAsyncApi.class)
@@ -106,9 +109,14 @@ public class NovaRestClientModule extends RestClientModule<NovaApi, NovaAsyncApi
          .put(QuotaClassApi.class, QuotaClassAsyncApi.class)
          .put(VolumeTypeApi.class, VolumeTypeAsyncApi.class)
          .build();
-
+   
    public NovaRestClientModule() {
-      super(DELEGATE_MAP);
+      super(TypeToken.class.cast(TypeToken.of(NovaApi.class)), TypeToken.class.cast(TypeToken.of(NovaAsyncApi.class)), DELEGATE_MAP);
+   }
+
+   protected NovaRestClientModule(TypeToken<S> syncClientType, TypeToken<A> asyncClientType,
+            Map<Class<?>, Class<?>> sync2Async) {
+      super(syncClientType, asyncClientType, sync2Async);
    }
 
    @Override

--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/features/ServerApi.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/features/ServerApi.java
@@ -54,7 +54,7 @@ public interface ServerApi {
     * 
     * @return all servers (all details)
     */
-   Set<Server> listServersInDetail();
+   Set<? extends Server> listServersInDetail();
 
    /**
     * List details of the specified server

--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/features/ServerAsyncApi.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/features/ServerAsyncApi.java
@@ -86,7 +86,7 @@ public interface ServerAsyncApi {
    @Consumes(MediaType.APPLICATION_JSON)
    @Path("/servers/detail")
    @ExceptionParser(ReturnEmptySetOnNotFoundOr404.class)
-   ListenableFuture<Set<Server>> listServersInDetail();
+   ListenableFuture<? extends Set<? extends Server>> listServersInDetail();
 
    /**
     * @see ServerApi#getServer
@@ -96,7 +96,7 @@ public interface ServerAsyncApi {
    @Consumes(MediaType.APPLICATION_JSON)
    @Path("/servers/{id}")
    @ExceptionParser(ReturnNullOnNotFoundOr404.class)
-   ListenableFuture<Server> getServer(@PathParam("id") String id);
+   ListenableFuture<? extends Server> getServer(@PathParam("id") String id);
 
    /**
     * @see ServerApi#deleteServer


### PR DESCRIPTION
Initially only for ServerApi, but I expect to make similar changes to other APIs in the near future. This is useful because the OpenStack API is designed for extension, and the changes are modelled on the way EC2 and AWS EC2 et al are designed in jclouds.
