### PR TITLE
issue 830: fixing vAppTemplateApi*Test, vAppApiLiveTest and vmApiLiveTest

### DIFF
--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/network/NetworkConnection.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/network/NetworkConnection.java
@@ -222,8 +222,8 @@ public class NetworkConnection {
       this.externalIpAddress = externalIpAddress;
       this.isConnected = connected;
       this.macAddress = macAddress;
-      this.ipAddressAllocationMode = ipAddressAllocationMode;
-      this.network = network;
+      this.ipAddressAllocationMode = checkNotNull(ipAddressAllocationMode, "ipAddressAllocationMode");
+      this.network = checkNotNull(network, "network");
       this.needsCustomization = needsCustomization;
    }
 

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/features/VAppTemplateApi.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/features/VAppTemplateApi.java
@@ -166,20 +166,6 @@ public interface VAppTemplateApi {
    CustomizationSection getCustomizationSection(URI templateUri);
 
    /**
-    * Modifies the vApp template customization information.
-    * 
-    * <pre>
-    * PUT /vAppTemplate/{id}/customizationSection
-    * </pre>
-    * 
-    * @param templateUri the URI of the template
-    * @param section the new configuration to apply
-    * @return the task performing the action. This operation is asynchronous and the user should monitor the returned
-    *         task status in order to check when it is completed.
-    */
-   Task modifyCustomizationSection(URI templateUri, CustomizationSection section);
-
-   /**
     * Retrieves the Guest Customization Section of a VM
     * 
     * <pre>
@@ -244,20 +230,6 @@ public interface VAppTemplateApi {
    NetworkConfigSection getNetworkConfigSection(URI templateUri);
 
    /**
-    * Modifies the network config section of a vApp.
-    * 
-    * <pre>
-    * PUT /vAppTemplate/{id}/networkConfigSection
-    * </pre>
-    * 
-    * @param templateUri the URI of the template
-    * @param section the new configuration to apply
-    * @return the task performing the action. This operation is asynchronous and the user should monitor the returned
-    *         task status in order to check when it is completed.
-    */
-   Task modifyNetworkConfigSection(URI templateUri, NetworkConfigSection section);
-
-   /**
     * Retrieves the network connection section of a VM
     * 
     * <pre>
@@ -268,20 +240,6 @@ public interface VAppTemplateApi {
     * @return the network connection section requested
     */
    NetworkConnectionSection getNetworkConnectionSection(URI templateUri);
-
-   /**
-    * Modifies the network connection section of a VM.
-    * 
-    * <pre>
-    * PUT /vAppTemplate/{id}/networkConnectionSection
-    * </pre>
-    * 
-    * @param templateUri the URI of the template
-    * @param section the new configuration to apply
-    * @return the task performing the action. This operation is asynchronous and the user should monitor the returned
-    *         task status in order to check when it is completed.
-    */
-   Task modifyNetworkConnectionSection(URI templateUri, NetworkConnectionSection section);
 
    /**
     * Retrieves the network section of a vApp or vApp template.

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/features/VAppTemplateAsyncApi.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/features/VAppTemplateAsyncApi.java
@@ -148,17 +148,6 @@ public interface VAppTemplateAsyncApi {
    ListenableFuture<CustomizationSection> getCustomizationSection(@EndpointParam URI templateURI);
 
    /**
-    * @see VAppTemplateApi#modifyCustomizationSection(URI, CustomizationSection)
-    */
-   @PUT
-   @Produces(CUSTOMIZATION_SECTION)
-   @Consumes(TASK)
-   @Path("/customizationSection")
-   @JAXBResponseParser
-   ListenableFuture<Task> modifyCustomizationSection(@EndpointParam URI templateURI,
-                                                     @BinderParam(BindToXMLPayload.class) CustomizationSection sectionType);
-
-   /**
     * @see VAppTemplateApi#getGuestCustomizationSection(URI)
     */
    @GET
@@ -221,17 +210,6 @@ public interface VAppTemplateAsyncApi {
    ListenableFuture<NetworkConfigSection> getNetworkConfigSection(@EndpointParam URI templateURI);
 
    /**
-    * @see VAppTemplateApi#modifyNetworkConfigSection(URI, NetworkConfigSection)
-    */
-   @PUT
-   @Produces(NETWORK_CONFIG_SECTION)
-   @Consumes(TASK)
-   @Path("/networkConfigSection")
-   @JAXBResponseParser
-   ListenableFuture<Task> modifyNetworkConfigSection(@EndpointParam URI templateURI,
-                                                     @BinderParam(BindToXMLPayload.class) NetworkConfigSection section);
-
-   /**
     * @see VAppTemplateApi#getNetworkConnectionSection(URI)
     */
    @GET
@@ -240,17 +218,6 @@ public interface VAppTemplateAsyncApi {
    @JAXBResponseParser
    @ExceptionParser(ReturnNullOnNotFoundOr404.class)
    ListenableFuture<NetworkConnectionSection> getVAppTemplateNetworkConnectionSection(@EndpointParam URI templateURI);
-
-   /**
-    * @see VAppTemplateApi#modifyNetworkConnectionSection(URI, NetworkConnectionSection)
-    */
-   @PUT
-   @Produces(NETWORK_CONNECTION_SECTION)
-   @Consumes(TASK)
-   @Path("/networkConnectionSection")
-   @JAXBResponseParser
-   ListenableFuture<Task> modifyNetworkConnectionSection(@EndpointParam URI templateURI,
-                                                         @BinderParam(BindToXMLPayload.class) NetworkConnectionSection section);
 
    /**
     * @see VAppTemplateApi#getNetworkSection(URI)

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/AbstractVAppApiLiveTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/AbstractVAppApiLiveTest.java
@@ -47,6 +47,7 @@ import org.jclouds.vcloud.director.v1_5.domain.VAppTemplate;
 import org.jclouds.vcloud.director.v1_5.domain.Vdc;
 import org.jclouds.vcloud.director.v1_5.domain.Vm;
 import org.jclouds.vcloud.director.v1_5.domain.dmtf.RasdItem;
+import org.jclouds.vcloud.director.v1_5.domain.params.UndeployVAppParams;
 import org.jclouds.vcloud.director.v1_5.domain.section.GuestCustomizationSection;
 import org.jclouds.vcloud.director.v1_5.domain.section.NetworkConnectionSection;
 import org.jclouds.vcloud.director.v1_5.features.CatalogApi;
@@ -112,7 +113,6 @@ public abstract class AbstractVAppApiLiveTest extends BaseVCloudDirectorApiLiveT
     * @see BaseVCloudDirectorApiLiveTest#setupRequiredApis()
     */
    @Override
-   @BeforeClass(alwaysRun = true, description = "Retrieves the required apis from the REST API context")
    protected void setupRequiredApis() {
       assertNotNull(context.getApi());
 
@@ -122,14 +122,13 @@ public abstract class AbstractVAppApiLiveTest extends BaseVCloudDirectorApiLiveT
       vAppTemplateApi = context.getApi().getVAppTemplateApi();
       vdcApi = context.getApi().getVdcApi();
       vmApi = context.getApi().getVmApi();
-
-      setupEnvironment();
    }
-
+   
    /**
     * Sets up the environment. Retrieves the test {@link Vdc} and {@link VAppTemplate} from their
     * configured {@link URI}s. Instantiates a new test VApp.
     */
+   @BeforeClass(alwaysRun = true, description = "Retrieves the required apis from the REST API context")
    protected void setupEnvironment() {
       // Get the configured Vdc for the tests
       vdc = vdcApi.getVdc(vdcURI);
@@ -295,9 +294,10 @@ public abstract class AbstractVAppApiLiveTest extends BaseVCloudDirectorApiLiveT
    protected Vm powerOffVm(final URI testVmURI) {
       Vm test = vmApi.getVm(testVmURI);
       Status status = test.getStatus();
-      if (status != Status.POWERED_OFF) {
-         Task powerOff = vmApi.powerOff(vm.getHref());
-         assertTaskSucceedsLong(powerOff);
+      if (status != Status.POWERED_OFF || test.isDeployed()) {
+         UndeployVAppParams undeployParams = UndeployVAppParams.builder().build();
+         Task shutdownVapp = vAppApi.undeploy(test.getHref(), undeployParams);
+         assertTaskSucceedsLong(shutdownVapp);
       }
       test = vmApi.getVm(testVmURI);
       assertStatus(VM, test, Status.POWERED_OFF);

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/VAppApiLiveTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/VAppApiLiveTest.java
@@ -103,7 +103,7 @@ public class VAppApiLiveTest extends AbstractVAppApiLiveTest {
    private boolean mediaCreated = false;
    private boolean testUserCreated = false;
    
-   @BeforeClass(alwaysRun = true, dependsOnMethods = { "setupRequiredApis" })
+   @BeforeClass(alwaysRun = true)
    protected void setupRequiredEntities() {
       Set<Link> links = vdcApi.getVdc(vdcURI).getLinks();
 

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/VAppTemplateApiExpectTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/VAppTemplateApiExpectTest.java
@@ -49,24 +49,10 @@ import org.jclouds.vcloud.director.v1_5.domain.Owner;
 import org.jclouds.vcloud.director.v1_5.domain.Reference;
 import org.jclouds.vcloud.director.v1_5.domain.Task;
 import org.jclouds.vcloud.director.v1_5.domain.VAppTemplate;
-import org.jclouds.vcloud.director.v1_5.domain.network.FirewallRule;
-import org.jclouds.vcloud.director.v1_5.domain.network.FirewallRuleProtocols;
-import org.jclouds.vcloud.director.v1_5.domain.network.FirewallService;
-import org.jclouds.vcloud.director.v1_5.domain.network.IpRange;
-import org.jclouds.vcloud.director.v1_5.domain.network.IpRanges;
-import org.jclouds.vcloud.director.v1_5.domain.network.IpScope;
-import org.jclouds.vcloud.director.v1_5.domain.network.NatOneToOneVmRule;
-import org.jclouds.vcloud.director.v1_5.domain.network.NatRule;
-import org.jclouds.vcloud.director.v1_5.domain.network.NatService;
-import org.jclouds.vcloud.director.v1_5.domain.network.Network.FenceMode;
-import org.jclouds.vcloud.director.v1_5.domain.network.NetworkConfiguration;
-import org.jclouds.vcloud.director.v1_5.domain.network.NetworkFeatures;
-import org.jclouds.vcloud.director.v1_5.domain.network.VAppNetworkConfiguration;
 import org.jclouds.vcloud.director.v1_5.domain.params.RelocateParams;
 import org.jclouds.vcloud.director.v1_5.domain.section.CustomizationSection;
 import org.jclouds.vcloud.director.v1_5.domain.section.GuestCustomizationSection;
 import org.jclouds.vcloud.director.v1_5.domain.section.LeaseSettingsSection;
-import org.jclouds.vcloud.director.v1_5.domain.section.NetworkConfigSection;
 import org.jclouds.vcloud.director.v1_5.internal.VCloudDirectorAdminApiExpectTest;
 import org.testng.annotations.Test;
 
@@ -256,27 +242,6 @@ public class VAppTemplateApiExpectTest extends VCloudDirectorAdminApiExpectTest 
       api.relocateVm(uri, params);
    }
 
-   @Test
-   public void testCustomizationSection() {
-      final String templateId = "/vAppTemplate/vappTemplate-ef4415e6-d413-4cbb-9262-f9bbec5f2ea9";
-      URI uri = URI.create(endpoint + templateId);
-
-      VAppTemplateApi api = orderedRequestsSendResponses(loginRequest, sessionResponse,
-            new VcloudHttpRequestPrimer().apiCommand("GET", templateId + "/customizationSection").acceptMedia(CUSTOMIZATION_SECTION).httpRequestBuilder().build(),
-            new VcloudHttpResponsePrimer().xmlFilePayload("/vapptemplate/customizationSection.xml", CUSTOMIZATION_SECTION).httpResponseBuilder().build(),
-            new VcloudHttpRequestPrimer().apiCommand("PUT", templateId + "/customizationSection").xmlFilePayload("/vapptemplate/customizationSection.xml", CUSTOMIZATION_SECTION).acceptMedia(TASK).httpRequestBuilder().build(),
-            new VcloudHttpResponsePrimer().xmlFilePayload("/task/task.xml", TASK).httpResponseBuilder().build()
-      ).getVAppTemplateApi();
-
-      assertNotNull(api);
-      CustomizationSection section = api.getCustomizationSection(uri);
-
-      assertEquals(section, exampleCustomizationSection());
-
-      Task task = api.modifyCustomizationSection(uri, exampleCustomizationSection());
-      assertNotNull(task);
-   }
-
    public void testErrorGetCustomizationSection() {
       final String templateId = "/vAppTemplate/vappTemplate-ef4415e6-d413-4cbb-9262-f9bbec5f2ea9";
       URI uri = URI.create(endpoint + templateId);
@@ -286,18 +251,6 @@ public class VAppTemplateApiExpectTest extends VCloudDirectorAdminApiExpectTest 
             new VcloudHttpResponsePrimer().xmlFilePayload("/vapptemplate/error403.xml", ERROR).httpResponseBuilder().statusCode(403).build()).getVAppTemplateApi();
 
       assertNull(api.getCustomizationSection(uri));
-   }
-   
-   @Test(expectedExceptions = ResourceNotFoundException.class)
-   public void testErrorEditCustomizationSection() {
-      final String templateId = "/vAppTemplate/vappTemplate-ef4415e6-d413-4cbb-9262-f9bbec5f2ea9";
-      URI uri = URI.create(endpoint + templateId);
-
-      VAppTemplateApi api = orderedRequestsSendResponses(loginRequest, sessionResponse,
-            new VcloudHttpRequestPrimer().apiCommand("PUT", templateId + "/customizationSection").xmlFilePayload("/vapptemplate/customizationSection.xml", CUSTOMIZATION_SECTION).acceptMedia(TASK).httpRequestBuilder().build(),
-            new VcloudHttpResponsePrimer().xmlFilePayload("/vapptemplate/error403.xml", ERROR).httpResponseBuilder().statusCode(403).build()).getVAppTemplateApi();
-
-      api.modifyCustomizationSection(uri, exampleCustomizationSection());
    }
    
    public void testGuestCustomizationSection() {
@@ -490,27 +443,6 @@ public class VAppTemplateApiExpectTest extends VCloudDirectorAdminApiExpectTest 
 
       api.getMetadataApi().deleteMetadataEntry(uri, "12345");
    }
-   
-   public void testNetworkConfigSection() throws ParseException {
-      final String templateId = "/vAppTemplate/vappTemplate-ef4415e6-d413-4cbb-9262-f9bbec5f2ea9";
-      URI uri = URI.create(endpoint + templateId);
-
-      VAppTemplateApi api = orderedRequestsSendResponses(loginRequest, sessionResponse,
-            new VcloudHttpRequestPrimer().apiCommand("GET", templateId + "/networkConfigSection").acceptMedia(NETWORK_CONFIG_SECTION).httpRequestBuilder().build(),
-            new VcloudHttpResponsePrimer().xmlFilePayload("/vapptemplate/networkConfigSection.xml", NETWORK_CONFIG_SECTION).httpResponseBuilder().build(),
-            new VcloudHttpRequestPrimer().apiCommand("PUT", templateId + "/networkConfigSection").xmlFilePayload("/vapptemplate/networkConfigSection.xml", NETWORK_CONFIG_SECTION).acceptMedia(TASK).httpRequestBuilder().build(),
-            new VcloudHttpResponsePrimer().xmlFilePayload("/task/task.xml", TASK).httpResponseBuilder().build()
-      ).getVAppTemplateApi();
-
-      assertNotNull(api);
-
-      NetworkConfigSection section = api.getNetworkConfigSection(uri);
-
-      assertEquals(section, exampleNetworkConfigSection());
-
-      Task task = api.modifyNetworkConfigSection(uri, exampleNetworkConfigSection());
-      assertNotNull(task);
-   }
 
    @Test(expectedExceptions = VCloudDirectorException.class)
    public void testErrorGetNetworkConfigSection() {
@@ -522,18 +454,6 @@ public class VAppTemplateApiExpectTest extends VCloudDirectorAdminApiExpectTest 
             new VcloudHttpResponsePrimer().xmlFilePayload("/vapptemplate/error400.xml", ERROR).httpResponseBuilder().statusCode(400).build()).getVAppTemplateApi();
 
       api.getNetworkConfigSection(uri);
-   }
-
-   @Test(expectedExceptions = VCloudDirectorException.class)
-   public void testErrorEditNetworkConfigSection() throws ParseException {
-      final String templateId = "/vAppTemplate/vappTemplate-ef4415e6-d413-4cbb-9262-f9bbec5f2ea9";
-      URI uri = URI.create(endpoint + templateId);
-
-      VAppTemplateApi api = orderedRequestsSendResponses(loginRequest, sessionResponse,
-            new VcloudHttpRequestPrimer().apiCommand("PUT", templateId + "/networkConfigSection").xmlFilePayload("/vapptemplate/networkConfigSection.xml", NETWORK_CONFIG_SECTION).acceptMedia(TASK).httpRequestBuilder().build(),
-            new VcloudHttpResponsePrimer().xmlFilePayload("/vapptemplate/error400.xml", ERROR).httpResponseBuilder().statusCode(400).build()).getVAppTemplateApi();
-
-      api.modifyNetworkConfigSection(uri, exampleNetworkConfigSection());
    }
 
    private VAppTemplate exampleTemplate() {
@@ -572,20 +492,6 @@ public class VAppTemplateApiExpectTest extends VCloudDirectorAdminApiExpectTest 
             .owner(owner)
             .ovfDescriptorUploaded(true)
             .goldMaster(false)
-            .build();
-   }
-
-   private CustomizationSection exampleCustomizationSection() {
-      return CustomizationSection.builder()
-            .links(ImmutableSet.of(
-                  Link.builder().href(URI.create("https://vcloudbeta.bluelock.com/api/vAppTemplate/vappTemplate-ef4415e6-d413-4cbb-9262-f9bbec5f2ea9/customizationSection/"))
-                        .type("application/vnd.vmware.vcloud.customizationSection+xml").rel("edit").build()
-            ))
-            .type("application/vnd.vmware.vcloud.customizationSection+xml")
-            .info("VApp template customization section")
-            .customizeOnInstantiate(true)
-            .href(URI.create("https://vcloudbeta.bluelock.com/api/vAppTemplate/vappTemplate-ef4415e6-d413-4cbb-9262-f9bbec5f2ea9/customizationSection/"))
-            .required(false)
             .build();
    }
 
@@ -640,59 +546,4 @@ public class VAppTemplateApiExpectTest extends VCloudDirectorAdminApiExpectTest 
       return MetadataValue.builder().value("some value").build();
    }
 
-   private NetworkConfigSection exampleNetworkConfigSection() throws ParseException {
-      
-      FirewallService firewallService =
-            FirewallService.builder()
-                  .enabled(true)
-                  .firewallRules(
-                  ImmutableSet.of(
-                        FirewallRule.builder()
-                              .isEnabled(true)
-                              .description("FTP Rule")
-                              .policy("allow")
-                              .protocols(FirewallRuleProtocols.builder().tcp(true).build())
-                              .port(21)
-                              .destinationIp("10.147.115.1")
-                              .build(),
-                        FirewallRule.builder()
-                              .isEnabled(true)
-                              .description("SSH Rule")
-                              .policy("allow")
-                              .protocols(FirewallRuleProtocols.builder().tcp(true).build())
-                              .port(22)
-                              .destinationIp("10.147.115.1")
-                              .build())).build();
-
-      NatService natService = NatService.builder().enabled(true).natType("ipTranslation").policy("allowTraffic")
-            .natRules(ImmutableSet.of(NatRule.builder().oneToOneVmRule(
-                  NatOneToOneVmRule.builder().mappingMode("manual").externalIpAddress("64.100.10.1").vAppScopedVmId("20ea086f-1a6a-4fb2-8e2e-23372facf7de").vmNicId(0).build()).build()
-            )).build();
-
-      NetworkConfiguration networkConfiguration = NetworkConfiguration.builder().ipScope(
-            IpScope.builder()
-                  .isInherited(false)
-                  .gateway("10.147.56.253")
-                  .netmask("255.255.255.0")
-                  .dns1("10.147.115.1")
-                  .dns2("10.147.115.2")
-                  .dnsSuffix("example.com")
-                  .ipRanges(IpRanges.builder().ipRange(IpRange.builder().startAddress("10.147.56.1").endAddress("10.147.56.1").build()).build())
-                  .build())
-            .parentNetwork(Reference.builder().href(URI.create("http://vcloud.example.com/api/v1.0/network/54")).type("application/vnd.vmware.vcloud.network+xml").name("Internet").build())
-            .fenceMode(FenceMode.NAT_ROUTED)
-            .features(NetworkFeatures.builder().services(ImmutableSet.of(firewallService, natService)).build())
-            .build();
-      
-      return NetworkConfigSection.builder()
-            .info("Configuration parameters for logical networks")
-            .networkConfigs(
-                  ImmutableSet.of(
-                        VAppNetworkConfiguration.builder()
-                              .networkName("vAppNetwork")
-                              .configuration(
-                                    networkConfiguration
-                              ).build()
-                  )).build();
-   }
 }


### PR DESCRIPTION
Using bluelock this is the situation,

Tests run: 216, Failures: 19, Errors: 0, Skipped: 60
