### PR TITLE
Making more OpenStack Nova APIs extensible using generic return values

### DIFF
--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/compute/NovaComputeServiceAdapter.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/compute/NovaComputeServiceAdapter.java
@@ -159,12 +159,12 @@ public class NovaComputeServiceAdapter implements
       Set<String> zones = zoneIds.get();
       checkState(zones.size() > 0, "no zones found in supplier %s", zoneIds);
       for (final String zoneId : zones) {
-         Set<Image> images = novaApi.getImageApiForZone(zoneId).listImagesInDetail();
+         Set<? extends Image> images = novaApi.getImageApiForZone(zoneId).listImagesInDetail();
          if (images.size() == 0) {
             logger.debug("no images found in zone %s", zoneId);
             continue;
          }
-         Iterable<Image> active = filter(images, ImagePredicates.statusEquals(Image.Status.ACTIVE));
+         Iterable<? extends Image> active = filter(images, ImagePredicates.statusEquals(Image.Status.ACTIVE));
          if (images.size() == 0) {
             logger.debug("no images with status active in zone %s; non-active: %s", zoneId,
                      transform(active, new Function<Image, String>() {

--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/features/FlavorApi.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/features/FlavorApi.java
@@ -50,7 +50,7 @@ public interface FlavorApi {
     * 
     * @return all flavors (all details)
     */
-   Set<Flavor> listFlavorsInDetail();
+   Set<? extends Flavor> listFlavorsInDetail();
 
    /**
     * List details of the specified flavor

--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/features/FlavorAsyncApi.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/features/FlavorAsyncApi.java
@@ -71,7 +71,7 @@ public interface FlavorAsyncApi {
    @Consumes(MediaType.APPLICATION_JSON)
    @Path("/flavors/detail")
    @ExceptionParser(ReturnEmptySetOnNotFoundOr404.class)
-   ListenableFuture<Set<Flavor>> listFlavorsInDetail();
+   ListenableFuture<? extends Set<? extends Flavor>> listFlavorsInDetail();
 
    /**
     * @see FlavorApi#getFlavor
@@ -81,6 +81,6 @@ public interface FlavorAsyncApi {
    @Consumes(MediaType.APPLICATION_JSON)
    @Path("/flavors/{id}")
    @ExceptionParser(ReturnNullOnNotFoundOr404.class)
-   ListenableFuture<Flavor> getFlavor(@PathParam("id") String id);
+   ListenableFuture<? extends Flavor> getFlavor(@PathParam("id") String id);
 
 }

--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/features/ImageApi.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/features/ImageApi.java
@@ -50,7 +50,7 @@ public interface ImageApi {
     * 
     * @return all images (all details)
     */
-   Set<Image> listImagesInDetail();
+   Set<? extends Image> listImagesInDetail();
 
    /**
     * List details of the specified image

--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/features/ImageAsyncApi.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/features/ImageAsyncApi.java
@@ -69,7 +69,7 @@ public interface ImageAsyncApi {
    @Consumes(MediaType.APPLICATION_JSON)
    @Path("/images/detail")
    @ExceptionParser(ReturnEmptySetOnNotFoundOr404.class)
-   ListenableFuture<Set<Image>> listImagesInDetail();
+   ListenableFuture<? extends Set<? extends Image>> listImagesInDetail();
 
    /**
     * @see ImageApi#getImage
@@ -79,7 +79,7 @@ public interface ImageAsyncApi {
    @Consumes(MediaType.APPLICATION_JSON)
    @Path("/images/{id}")
    @ExceptionParser(ReturnNullOnNotFoundOr404.class)
-   ListenableFuture<Image> getImage(@PathParam("id") String id);
+   ListenableFuture<? extends Image> getImage(@PathParam("id") String id);
 
    /**
     * @see ImageApi#deleteImage

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/features/FlavorApiLiveTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/features/FlavorApiLiveTest.java
@@ -66,7 +66,7 @@ public class FlavorApiLiveTest extends BaseNovaApiLiveTest {
    public void testListFlavorsInDetail() throws Exception {
       for (String zoneId : novaContext.getApi().getConfiguredZones()) {
          FlavorApi api = novaContext.getApi().getFlavorApiForZone(zoneId);
-         Set<Flavor> response = api.listFlavorsInDetail();
+         Set<? extends Flavor> response = api.listFlavorsInDetail();
          assert null != response;
          assertTrue(response.size() >= 0);
          for (Flavor flavor : response) {

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/features/ImageApiLiveTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/features/ImageApiLiveTest.java
@@ -58,7 +58,7 @@ public class ImageApiLiveTest extends BaseNovaApiLiveTest {
    public void testListImagesInDetail() throws Exception {
       for (String zoneId : novaContext.getApi().getConfiguredZones()) {
          ImageApi api = novaContext.getApi().getImageApiForZone(zoneId);
-         Set<Image> response = api.listImagesInDetail();
+         Set<? extends Image> response = api.listImagesInDetail();
          assertNotNull(response);
          assertTrue(response.size() >= 0);
          for (Image image : response) {


### PR DESCRIPTION
Adding more Apis not included in yesterday's PR. Further patches to include similar changes to all Api classes. I will raise the idea of refactoring the base classes to make them more extensible on-list.
