### PR TITLE
Fixed Issue 1063.

### DIFF
--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/features/ServerAsyncApi.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/features/ServerAsyncApi.java
@@ -144,7 +144,7 @@ public interface ServerAsyncApi {
    @Path("/servers/{id}/action")
    @Consumes
    @Produces(MediaType.APPLICATION_JSON)
-   @Payload("%7B\"resize\":%7B\"flavorId\":{flavorId}%7D%7D")
+   @Payload("%7B\"resize\":%7B\"flavorRef\":{flavorId}%7D%7D")
    ListenableFuture<Void> resizeServer(@PathParam("id") String id, @PayloadParam("flavorId") String flavorId);
 
    /**


### PR DESCRIPTION
Fixed Issue 1063. See http://code.google.com/p/jclouds/issues/detail?id=1063

Old code was using flavorId in the request body when what is required is flavorRef. See http://docs.openstack.org/api/openstack-compute/2/content/Resize_Server-d1e3707.html
