### PR TITLE
Reduce HP Cloud authentication token timeout

### DIFF
--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/KeystoneAuthenticationModule.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/KeystoneAuthenticationModule.java
@@ -186,11 +186,11 @@ public class KeystoneAuthenticationModule extends AbstractModule {
    }
 
    // TODO: what is the timeout of the session token? modify default accordingly
-   // PROPERTY_SESSION_INTERVAL is default to 60 seconds, but we have this here at 23 hours for now.
+   // PROPERTY_SESSION_INTERVAL is default to 60 seconds, but we have this here at 11 hours for now.
    @Provides
    @Singleton
    public LoadingCache<Credentials, Access> provideAccessCache(Function<Credentials, Access> getAccess) {
-      return CacheBuilder.newBuilder().expireAfterWrite(23, TimeUnit.HOURS).build(CacheLoader.from(getAccess));
+      return CacheBuilder.newBuilder().expireAfterWrite(11, TimeUnit.HOURS).build(CacheLoader.from(getAccess));
    }
 
    // Temporary conversion of a cache to a supplier until there is a single-element cache


### PR DESCRIPTION
I see a 12 hour expiry when requesting a new authentication token.
Reducing this timeout should not hurt in any case.
