### PR TITLE
Made getting a header by field-name case-insensitive

### DIFF
--- a/core/src/main/java/org/jclouds/functions/ToLowerCase.java
+++ b/core/src/main/java/org/jclouds/functions/ToLowerCase.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.functions;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import javax.inject.Singleton;
+
+import com.google.common.base.Function;
+
+/**
+ * @author Everett Toews
+ */
+@Singleton
+public class ToLowerCase implements Function<String, String> {
+
+	@Override
+	public String apply(String input) {
+		checkNotNull(input, "input cannot be null");
+		return input.toLowerCase();
+	}
+
+}

--- a/core/src/main/java/org/jclouds/http/HttpMessage.java
+++ b/core/src/main/java/org/jclouds/http/HttpMessage.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.util.Collection;
 
+import org.jclouds.functions.ToLowerCase;
 import org.jclouds.http.internal.PayloadEnclosingImpl;
 import org.jclouds.io.Payload;
 import org.jclouds.io.Payloads;
@@ -32,7 +33,6 @@ import org.jclouds.util.Multimaps2;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
-import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 
@@ -186,25 +186,15 @@ public class HttpMessage extends PayloadEnclosingImpl {
       return headers;
    }
 
-   private Multimap<String, String> getLowercaseHeaders() {
-	   Multimap<String, String> lowercaseHeaders = HashMultimap.create(getHeaders().keys().size(), 1);
-	   
-	   for (String header: getHeaders().keys()) {
-		   for (String value: getHeaders().get(header)) {
-			   lowercaseHeaders.put(header.toLowerCase(), value);
-		   }
-	   }
-	   
-	   return lowercaseHeaders;
-   }
-
    /**
     * try to get the value, then try as lowercase.
     */
    public String getFirstHeaderOrNull(String string) {
       Collection<String> values = headers.get(string);
-      if (values.size() == 0)
-         values = getLowercaseHeaders().get(string.toLowerCase());
+      if (values.size() == 0) {
+         Multimap<String, String> lowerCaseHeaders = Multimaps2.transformKeys(getHeaders(), new ToLowerCase()); 
+         values = lowerCaseHeaders.get(string.toLowerCase());
+      }
       return (values.size() >= 1) ? values.iterator().next() : null;
    }
 

--- a/core/src/main/java/org/jclouds/util/Multimaps2.java
+++ b/core/src/main/java/org/jclouds/util/Multimaps2.java
@@ -22,7 +22,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.Map.Entry;
 
+import com.google.common.base.Function;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
@@ -88,5 +90,29 @@ public class Multimaps2 {
    
    public static <K, V> Multimap<K, V> withoutKeys(Multimap<K, V> fromMultimap, Set<K> keys) {
       return Multimaps.<K, V> filterKeys(fromMultimap, Predicates.not(Predicates.in(keys)));
+   }
+   
+   /**
+    * change the keys but keep the values in-tact.
+    * 
+    * @param <K1>
+    *           input key type
+    * @param <K2>
+    *           output key type
+    * @param <V>
+    *           value type
+    * @param in
+    *           input map to transform
+    * @param fn
+    *           how to transform the values
+    * @return immutableMap with the new keys.
+    */
+   public static <K1, K2, V> Multimap<K2, V> transformKeys(Multimap<K1, V> in, Function<K1, K2> fn) {
+      checkNotNull(in, "input map");
+      checkNotNull(fn, "function");
+      Builder<K2, V> returnVal = ImmutableMultimap.builder();
+      for (Entry<K1, V> entry : in.entries())
+         returnVal.put(fn.apply(entry.getKey()), entry.getValue());
+      return returnVal.build();
    }
 }

--- a/core/src/test/java/org/jclouds/util/Multimaps2Test.java
+++ b/core/src/test/java/org/jclouds/util/Multimaps2Test.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.util;
+
+import static org.testng.Assert.assertEquals;
+
+import org.jclouds.functions.ToLowerCase;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+
+/**
+ * @author Everett Toews
+ */
+@Test(groups = "unit")
+public class Multimaps2Test {
+	public void testTransformKeysToLowerCase() {
+		Multimap<String, String> map = ImmutableMultimap.of("oNe", "1", "TWO", "2", "three", "3", "Three", "3.0");
+		Multimap<String, String> expected = ImmutableMultimap.of("one", "1", "two", "2", "three", "3", "three", "3.0");
+		Multimap<String, String> transformed = Multimaps2.transformKeys(map, new ToLowerCase());
+		
+		assertEquals(transformed, expected);
+	}
+}


### PR DESCRIPTION
to address the issue from

https://groups.google.com/forum/?fromgroups#!topic/jclouds/lEZjqhbudX4

This is the proper way to handle it as RFC 2616, "Hypertext Transfer Protocol -- HTTP/1.1", Section 4.2, "Message Headers" states,

Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.
