### PR TITLE
OpenStack test descriptions

### DIFF
--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/features/ExtensionApiLiveTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/features/ExtensionApiLiveTest.java
@@ -19,7 +19,8 @@
 package org.jclouds.openstack.nova.v2_0.features;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 
 import java.util.Set;
 
@@ -29,35 +30,57 @@ import org.jclouds.openstack.v2_0.features.ExtensionApi;
 import org.testng.annotations.Test;
 
 /**
- * Tests behavior of {@code ExtensionApi}
+ * Tests behavior of {@link ExtensionApi}
  * 
  * @author Adrian Cole
  */
 @Test(groups = "live", testName = "ExtensionApiLiveTest")
 public class ExtensionApiLiveTest extends BaseNovaApiLiveTest {
 
-   /**
-    * Tests the listing of Extensions (getExtension() is tested too!)
-    * 
-    * @throws Exception
-    */
-   @Test
-   public void testListExtensions() throws Exception {
-      for (String zoneId : novaContext.getApi().getConfiguredZones()) {
-         ExtensionApi api = novaContext.getApi().getExtensionApiForZone(zoneId);
-         Set<? extends Extension> response = api.listExtensions();
-         assert null != response;
-         assertTrue(response.size() >= 0);
-         for (Extension extension : response) {
-            Extension newDetails = api.getExtensionByAlias(extension.getId());
-            assertEquals(newDetails.getId(), extension.getId());
-            assertEquals(newDetails.getName(), extension.getName());
-            assertEquals(newDetails.getDescription(), extension.getDescription());
-            assertEquals(newDetails.getNamespace(), extension.getNamespace());
-            assertEquals(newDetails.getUpdated(), extension.getUpdated());
-            assertEquals(newDetails.getLinks(), extension.getLinks());
-         }
-      }
-   }
+    /**
+     * Tests the listing of Extensions.
+     * 
+     * @throws Exception
+     */
+    @Test(description = "GET /v${apiVersion}/{tenantId}/extensions")
+    public void testListExtensions() throws Exception {
+       for (String zoneId : zones) {
+          ExtensionApi api = novaContext.getApi().getExtensionApiForZone(zoneId);
+          Set<? extends Extension> response = api.listExtensions();
+          assertNotNull(response);
+          assertFalse(response.isEmpty());
+           for (Extension extension : response) {
+              assertNotNull(extension.getId());
+              assertNotNull(extension.getName());
+              assertNotNull(extension.getDescription());
+              assertNotNull(extension.getNamespace());
+              assertNotNull(extension.getUpdated());
+              assertNotNull(extension.getLinks());
+           }
+       }
+    }
+
+    /**
+     * Tests retrieval of Extensions using their alias.
+     * 
+     * @throws Exception
+     */
+    @Test(description = "GET /v${apiVersion}/{tenantId}/extensions/{alias}", dependsOnMethods = { "testListExtensions" })
+    public void testGetExtensionByAlias() throws Exception {
+       for (String zoneId : zones) {
+           ExtensionApi api = novaContext.getApi().getExtensionApiForZone(zoneId);
+           Set<? extends Extension> response = api.listExtensions();
+           for (Extension extension : response) {
+              Extension details = api.getExtensionByAlias(extension.getId());
+              assertNotNull(details);
+              assertEquals(details.getId(), extension.getId());
+              assertEquals(details.getName(), extension.getName());
+              assertEquals(details.getDescription(), extension.getDescription());
+              assertEquals(details.getNamespace(), extension.getNamespace());
+              assertEquals(details.getUpdated(), extension.getUpdated());
+              assertEquals(details.getLinks(), extension.getLinks());
+           }
+        }
+    }
 
 }

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/features/FlavorApiLiveTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/features/FlavorApiLiveTest.java
@@ -19,6 +19,8 @@
 package org.jclouds.openstack.nova.v2_0.features;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 import java.util.Set;
@@ -29,7 +31,7 @@ import org.jclouds.openstack.v2_0.domain.Resource;
 import org.testng.annotations.Test;
 
 /**
- * Tests behavior of {@code FlavorApi}
+ * Tests behavior of {@link FlavorApi}
  * 
  * @author Jeremy Daggett
  */
@@ -37,49 +39,69 @@ import org.testng.annotations.Test;
 public class FlavorApiLiveTest extends BaseNovaApiLiveTest {
 
    /**
-    * Tests the listing of Flavors (getFlavor() is tested too!)
+    * Tests the listing of Flavors.
     * 
     * @throws Exception
     */
-   @Test
+   @Test(description = "GET /v${apiVersion}/{tenantId}/flavors")
    public void testListFlavors() throws Exception {
-      for (String zoneId : novaContext.getApi().getConfiguredZones()) {
+      for (String zoneId : zones) {
          FlavorApi api = novaContext.getApi().getFlavorApiForZone(zoneId);
          Set<? extends Resource> response = api.listFlavors();
-         assert null != response;
-         assertTrue(response.size() >= 0);
+         assertNotNull(response);
+         assertFalse(response.isEmpty());
          for (Resource flavor : response) {
-            Flavor newDetails = api.getFlavor(flavor.getId());
-            assertEquals(newDetails.getId(), flavor.getId());
-            assertEquals(newDetails.getName(), flavor.getName());
-            assertEquals(newDetails.getLinks(), flavor.getLinks());
+            assertNotNull(flavor.getId());
+            assertNotNull(flavor.getName());
+            assertNotNull(flavor.getLinks());
          }
       }
    }
 
    /**
-    * Tests the listing of Flavors in detail (getFlavor() is tested too!)
+    * Tests the listing of Flavors in detail.
     * 
     * @throws Exception
     */
-   @Test
+   @Test(description = "GET /v${apiVersion}/{tenantId}/flavors/detail")
    public void testListFlavorsInDetail() throws Exception {
-      for (String zoneId : novaContext.getApi().getConfiguredZones()) {
+      for (String zoneId : zones) {
          FlavorApi api = novaContext.getApi().getFlavorApiForZone(zoneId);
          Set<? extends Flavor> response = api.listFlavorsInDetail();
-         assert null != response;
-         assertTrue(response.size() >= 0);
+         assertNotNull(response);
+         assertFalse(response.isEmpty());
          for (Flavor flavor : response) {
-            Flavor newDetails = api.getFlavor(flavor.getId());
-            assertEquals(newDetails.getId(), flavor.getId());
-            assertEquals(newDetails.getName(), flavor.getName());
-            assertEquals(newDetails.getLinks(), flavor.getLinks());
-            assertEquals(newDetails.getRam(), flavor.getRam());
-            assertEquals(newDetails.getDisk(), flavor.getDisk());
-            assertEquals(newDetails.getVcpus(), flavor.getVcpus());
+             assertNotNull(flavor.getId());
+             assertNotNull(flavor.getName());
+             assertNotNull(flavor.getLinks());
+             assertTrue(flavor.getRam() > 0);
+             assertTrue(flavor.getDisk() > 0);
+             assertTrue(flavor.getVcpus() > 0);
          }
       }
+   }
 
+   /**
+    * Tests getting Flavors by id.
+    * 
+    * @throws Exception
+    */
+   @Test(description = "GET /v${apiVersion}/{tenantId}/flavors/{id}", dependsOnMethods = { "testListFlavorsInDetail" })
+   public void testGetFlavorById() throws Exception {
+      for (String zoneId : zones) {
+         FlavorApi api = novaContext.getApi().getFlavorApiForZone(zoneId);
+         Set<? extends Flavor> response = api.listFlavorsInDetail();
+         for (Flavor flavor : response) {
+            Flavor details = api.getFlavor(flavor.getId());
+            assertNotNull(details);
+            assertEquals(details.getId(), flavor.getId());
+            assertEquals(details.getName(), flavor.getName());
+            assertEquals(details.getLinks(), flavor.getLinks());
+            assertEquals(details.getRam(), flavor.getRam());
+            assertEquals(details.getDisk(), flavor.getDisk());
+            assertEquals(details.getVcpus(), flavor.getVcpus());
+         }
+      }
    }
 
 }

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/features/ImageApiLiveTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/features/ImageApiLiveTest.java
@@ -19,6 +19,7 @@
 package org.jclouds.openstack.nova.v2_0.features;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -30,52 +31,72 @@ import org.jclouds.openstack.v2_0.domain.Resource;
 import org.testng.annotations.Test;
 
 /**
- * Tests behavior of {@code ImageApi}
+ * Tests behavior of {@link ImageApi}
  * 
  * @author Michael Arnold
  */
 @Test(groups = "live", testName = "ImageApiLiveTest")
 public class ImageApiLiveTest extends BaseNovaApiLiveTest {
 
-   @Test
+   @Test(description = "GET /v${apiVersion}/{tenantId}/images")
    public void testListImages() throws Exception {
-      for (String zoneId : novaContext.getApi().getConfiguredZones()) {
+      for (String zoneId : zones) {
          ImageApi api = novaContext.getApi().getImageApiForZone(zoneId);
          Set<? extends Resource> response = api.listImages();
          assertNotNull(response);
-         assertTrue(response.size() >= 0);
+         assertFalse(response.isEmpty());
          for (Resource image : response) {
-            Image newDetails = api.getImage(image.getId());
-            assertNotNull(newDetails);
-            assertEquals(newDetails.getId(), image.getId());
-            assertEquals(newDetails.getName(), image.getName());
-            assertEquals(newDetails.getLinks(), image.getLinks());
+            assertNotNull(image.getId());
+            assertNotNull(image.getName());
+            assertNotNull(image.getLinks());
          }
       }
    }
 
-   @Test
+   @Test(description = "GET /v${apiVersion}/{tenantId}/images/detail")
    public void testListImagesInDetail() throws Exception {
       for (String zoneId : novaContext.getApi().getConfiguredZones()) {
          ImageApi api = novaContext.getApi().getImageApiForZone(zoneId);
          Set<? extends Image> response = api.listImagesInDetail();
          assertNotNull(response);
-         assertTrue(response.size() >= 0);
+         assertFalse(response.isEmpty());
          for (Image image : response) {
-            Image newDetails = api.getImage(image.getId());
-            assertNotNull(newDetails);
-            assertEquals(newDetails.getId(), image.getId());
-            assertEquals(newDetails.getName(), image.getName());
-            assertEquals(newDetails.getLinks(), image.getLinks());
-            assertEquals(newDetails.getCreated(), image.getCreated());
-            assertEquals(newDetails.getMinDisk(), image.getMinDisk());
-            assertEquals(newDetails.getMinRam(), image.getMinRam());
-            assertEquals(newDetails.getProgress(), image.getProgress());
-            assertEquals(newDetails.getStatus(), image.getStatus());
-            assertEquals(newDetails.getServer(), image.getServer());
-            assertEquals(newDetails.getTenantId(), image.getTenantId());
-            assertEquals(newDetails.getUpdated(), image.getUpdated());
-            assertEquals(newDetails.getUserId(), image.getUserId());
+            assertNotNull(image.getId());
+            assertNotNull(image.getName());
+            assertNotNull(image.getLinks());
+            assertNotNull(image.getCreated());
+            assertTrue(image.getMinDisk() > 0);
+            assertTrue(image.getMinRam() > 0);
+            assertTrue(image.getProgress() >= 0 && image.getProgress() <= 100);
+            assertNotNull(image.getStatus());
+            assertNotNull(image.getServer());
+            assertNotNull(image.getTenantId());
+            assertNotNull(image.getUpdated());
+            assertNotNull(image.getUserId());
+         }
+      }
+   }
+
+   @Test(description = "GET /v${apiVersion}/{tenantId}/images/{id}", dependsOnMethods = { "testListImagesInDetail" })
+   public void testGetImageById() throws Exception {
+      for (String zoneId : novaContext.getApi().getConfiguredZones()) {
+         ImageApi api = novaContext.getApi().getImageApiForZone(zoneId);
+         Set<? extends Image> response = api.listImagesInDetail();
+         for (Image image : response) {
+            Image details = api.getImage(image.getId());
+            assertNotNull(details);
+            assertEquals(details.getId(), image.getId());
+            assertEquals(details.getName(), image.getName());
+            assertEquals(details.getLinks(), image.getLinks());
+            assertEquals(details.getCreated(), image.getCreated());
+            assertEquals(details.getMinDisk(), image.getMinDisk());
+            assertEquals(details.getMinRam(), image.getMinRam());
+            assertEquals(details.getProgress(), image.getProgress());
+            assertEquals(details.getStatus(), image.getStatus());
+            assertEquals(details.getServer(), image.getServer());
+            assertEquals(details.getTenantId(), image.getTenantId());
+            assertEquals(details.getUpdated(), image.getUpdated());
+            assertEquals(details.getUserId(), image.getUserId());
          }
       }
    }

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/internal/BaseNovaApiLiveTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/internal/BaseNovaApiLiveTest.java
@@ -19,11 +19,12 @@
 package org.jclouds.openstack.nova.v2_0.internal;
 
 import java.util.Properties;
+import java.util.Set;
 
 import org.jclouds.compute.internal.BaseComputeServiceContextLiveTest;
 import org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties;
-import org.jclouds.openstack.nova.v2_0.NovaAsyncApi;
 import org.jclouds.openstack.nova.v2_0.NovaApi;
+import org.jclouds.openstack.nova.v2_0.NovaAsyncApi;
 import org.jclouds.openstack.nova.v2_0.config.NovaProperties;
 import org.jclouds.openstack.nova.v2_0.domain.Flavor;
 import org.jclouds.openstack.nova.v2_0.domain.Server;
@@ -54,13 +55,15 @@ public class BaseNovaApiLiveTest extends BaseComputeServiceContextLiveTest {
       provider = "openstack-nova";
    }
 
+   protected Set<String> zones;
    protected RestContext<NovaApi, NovaAsyncApi> novaContext;
 
-   @BeforeGroups(groups = { "integration", "live" })
+   @BeforeGroups(groups = { "integration", "live" }, alwaysRun = true)
    @Override
    public void setupContext() {
       super.setupContext();
       novaContext = view.unwrap();
+      zones = novaContext.getApi().getConfiguredZones();
    }
 
    @Override


### PR DESCRIPTION
Added description with the REST URI and dependencies to the basic OpenStack feature test annotations, and split tests into methods that explicitly test a single API call. See vcloud-director for  similar implementation of test annotations.
