### PR TITLE
Pass through the property test.openstack-nova.image-id

### DIFF
--- a/apis/openstack-nova/pom.xml
+++ b/apis/openstack-nova/pom.xml
@@ -129,6 +129,7 @@
                     <test.openstack-nova.identity>${test.openstack-nova.identity}</test.openstack-nova.identity>
                     <test.openstack-nova.credential>${test.openstack-nova.credential}</test.openstack-nova.credential>
                     <test.openstack-nova.template>${test.openstack-nova.template}</test.openstack-nova.template>
+                    <test.openstack-nova.image-id>${test.openstack-nova.image-id}</test.openstack-nova.image-id>
                     <test.jclouds.openstack-nova.auto-allocate-floating-ips>${test.jclouds.openstack-nova.auto-allocate-floating-ips}</test.jclouds.openstack-nova.auto-allocate-floating-ips>
                     <test.jclouds.keystone.credential-type>${test.jclouds.keystone.credential-type}</test.jclouds.keystone.credential-type>
                   </systemPropertyVariables>


### PR DESCRIPTION
Change to the openstack-nova pom.xml so that when -Dtest.openstack-nova.image-id is given on the maven command line when running OpenStack live tests, this is passed through.
