### PR TITLE
Update parsing of Status in CloudStack Template

### DIFF
--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/domain/Template.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/domain/Template.java
@@ -652,6 +652,14 @@ public class Template implements Comparable<Template> {
    }
 
    /**
+    * Retrieve the status of the template.
+    *
+    * <p>Note that in CloudStack 2.2.x through to at least 3.0.4, the possible status values are
+    * not well defined by CloudStack. CloudStack returns a plain-text English string for UI
+    * display, which jclouds attempts to parse into an enumeration, but the mapping is incomplete.
+    * This method should be reliable for the common cases, but it is possible (particularly for
+    * error statuses) that this method will return UNRECOGNIZED.</p>
+    *
     * @return status of the template
     */
    @Nullable


### PR DESCRIPTION
The CloudStack Template status field is generally presented as human
readable text. This commit extends the enum fromValue() to understand
the known status strings in CloudStack 3.0.4.
