### PR TITLE
Fix deleteAndVerifyContainerGone return value

### DIFF
--- a/apis/s3/src/main/java/org/jclouds/s3/util/S3Utils.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/util/S3Utils.java
@@ -62,7 +62,7 @@ public class S3Utils {
     */
    public static boolean deleteAndVerifyContainerGone(S3Client sync, String container) {
       sync.deleteBucketIfEmpty(container);
-      return sync.bucketExists(container);
+      return !sync.bucketExists(container);
    }
    
    private static final Predicate<Annotation> ANNOTATIONTYPE_BUCKET = new Predicate<Annotation>() {


### PR DESCRIPTION
Return true if the container does not exist -- this matches the
behavior of Atmos and Swift.  This allows deleteAndEnsurePathGone to
terminate correctly with S3.
