### PR TITLE
Avoid Futures.getUnchecked in DeleteAllKeysInList

### DIFF
--- a/blobstore/src/main/java/org/jclouds/blobstore/strategy/internal/DeleteAllKeysInList.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/strategy/internal/DeleteAllKeysInList.java
@@ -22,6 +22,7 @@ import static org.jclouds.blobstore.options.ListContainerOptions.Builder.recursi
 import static org.jclouds.concurrent.FutureIterables.awaitCompletion;
 
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
@@ -95,8 +96,11 @@ public class DeleteAllKeysInList implements ClearListStrategy, ClearContainerStr
       for (int i = 0; i < maxErrors; ) {
          // fetch partial directory listing
          try {
-            listing = Futures.getUnchecked(connection.list(containerName, options));
-         } catch (RuntimeException ee) {
+            listing = connection.list(containerName, options).get();
+         } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            break;
+         } catch (ExecutionException ee) {
             ++i;
             if (i == maxErrors) {
                throw Throwables.propagate(ee.getCause());


### PR DESCRIPTION
This masks InterruptedException.  We should rework the logic in
execute to unwind the stack on errors; currently we only return from
the leaf method.
