### PR TITLE
Change Nova CreateVolumeOptions field names to match the documentation

### DIFF
--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/options/CreateVolumeOptions.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/options/CreateVolumeOptions.java
@@ -58,15 +58,15 @@ public class CreateVolumeOptions implements MapBinder {
       Map<String, Object> image = Maps.newHashMap();
       image.putAll(postParams);
       if (name != null)
-         image.put("display_name", name);
+         image.put("displayName", name);
       if (description != null)
-         image.put("display_description", description);
+         image.put("displayDescription", description);
       if (volumeType != null)
-         image.put("volume_type", volumeType);
+         image.put("volumeType", volumeType);
       if (availabilityZone != null)
-         image.put("availability_zone", availabilityZone);
+         image.put("availabilityZone", availabilityZone);
       if (snapshotId != null)
-         image.put("snapshot_id", snapshotId);
+         image.put("snapshotId", snapshotId);
       if (!metadata.isEmpty())
          image.put("metadata", metadata);
       return jsonBinder.bindToRequest(request, ImmutableMap.of("volume", image));

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/extensions/VolumeApiExpectTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/extensions/VolumeApiExpectTest.java
@@ -112,7 +112,7 @@ public class VolumeApiExpectTest extends BaseNovaApiExpectTest {
             responseWithKeystoneAccess, extensionsOfNovaRequest, extensionsOfNovaResponse,
             authenticatedGET().endpoint(endpoint)
                   .method("POST")
-                  .payload(payloadFromStringWithContentType("{\"volume\":{\"display_name\":\"jclouds-test-volume\",\"display_description\":\"description of test volume\",\"size\":1}}", MediaType.APPLICATION_JSON))
+                  .payload(payloadFromStringWithContentType("{\"volume\":{\"displayName\":\"jclouds-test-volume\",\"displayDescription\":\"description of test volume\",\"size\":1}}", MediaType.APPLICATION_JSON))
                   .build(),
             HttpResponse.builder().statusCode(200).payload(payloadFromResource("/volume_details.json")).build()
       ).getVolumeExtensionForZone("az-1.region-a.geo-1").get();
@@ -130,7 +130,7 @@ public class VolumeApiExpectTest extends BaseNovaApiExpectTest {
             authenticatedGET().endpoint(endpoint)
                .endpoint(endpoint)
                .method("POST")
-               .payload(payloadFromStringWithContentType("{\"volume\":{\"display_name\":\"jclouds-test-volume\",\"display_description\":\"description of test volume\",\"size\":1}}", MediaType.APPLICATION_JSON))
+               .payload(payloadFromStringWithContentType("{\"volume\":{\"displayName\":\"jclouds-test-volume\",\"displayDescription\":\"description of test volume\",\"size\":1}}", MediaType.APPLICATION_JSON))
                .build(),
             HttpResponse.builder().statusCode(404).payload(payloadFromResource("/volume_details.json")).build()
       ).getVolumeExtensionForZone("az-1.region-a.geo-1").get();


### PR DESCRIPTION
 These were originally _lower_underscore_ formatted names, but should be rewritten as _lowerCamel_ format to match the rest of the API and the documentation for the extension. The _Cinder_ volume service from OpenStack Folsom uses _lower_underscore_, and we will need to deal with using both types of mae when this is implemeted.
