### PR TITLE
Clarify the HP Cloud credential type

### DIFF
--- a/providers/hpcloud-compute/pom.xml
+++ b/providers/hpcloud-compute/pom.xml
@@ -37,6 +37,11 @@
     <test.hpcloud-compute.endpoint>https://region-a.geo-1.identity.hpcloudsvc.com:35357/v2.0/</test.hpcloud-compute.endpoint>
     <test.hpcloud-compute.api-version>1.1</test.hpcloud-compute.api-version>
     <test.hpcloud-compute.build-version></test.hpcloud-compute.build-version>
+    <!--
+        Identity must be tenantName:userName.  Note that the following
+        credentials are the HP Cloud username and password, not the access
+        key id and secret key.
+    -->
     <test.hpcloud-compute.identity>FIXME_IDENTITY</test.hpcloud-compute.identity>
     <test.hpcloud-compute.credential>FIXME_CREDENTIAL</test.hpcloud-compute.credential>
     <test.hpcloud-compute.template></test.hpcloud-compute.template>

--- a/providers/hpcloud-objectstorage/pom.xml
+++ b/providers/hpcloud-objectstorage/pom.xml
@@ -37,6 +37,11 @@
         <test.hpcloud-objectstorage.endpoint>https://region-a.geo-1.identity.hpcloudsvc.com:35357/v2.0/</test.hpcloud-objectstorage.endpoint>
         <test.hpcloud-objectstorage.api-version>1.0</test.hpcloud-objectstorage.api-version>
         <test.hpcloud-objectstorage.build-version></test.hpcloud-objectstorage.build-version>
+        <!--
+            Identity must be tenantName:userName.  Note that the following
+            credentials are the HP Cloud username and password, not the access
+            key id and secret key.
+        -->
         <test.hpcloud-objectstorage.identity>FIXME_IDENTITY</test.hpcloud-objectstorage.identity>
         <test.hpcloud-objectstorage.credential>FIXME_CREDENTIAL</test.hpcloud-objectstorage.credential>
 


### PR DESCRIPTION
While users can override this by setting
KeystoneProperties.CREDENTIAL_TYPE to
CredentialTypes.API_ACCESS_KEY_CREDENTIALS, unit tests expect
CredentialTypes.PASSWORD_CREDENTIALS.
