### PR TITLE
Cleanup virtualbox api from unwanted runtime dependencies and improvements on OSGi metadata

### DIFF
--- a/labs/virtualbox/pom.xml
+++ b/labs/virtualbox/pom.xml
@@ -42,7 +42,12 @@
     <test.virtualbox.credential>CHANGE_ME</test.virtualbox.credential>
     <test.virtualbox.template>osFamily=UBUNTU,osVersionMatches=12.04.1,os64Bit=true,osArchMatches=amd64,loginUser=toor:password,authenticateSudo=true</test.virtualbox.template>
     <jclouds.osgi.export>org.jclouds.virtualbox*;version="${project.version}"</jclouds.osgi.export>
-    <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
+    <jclouds.osgi.import>
+      org.jclouds*;version="${project.version}",
+      org.eclipse.jetty*;version="[7.5,9)",
+      javax.servlet*;version="[2.5,3)",
+      *
+    </jclouds.osgi.import>
   </properties>
 
   <dependencies>
@@ -110,6 +115,7 @@
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <version>6.3.1</version>
+      <scope>test</scope>
       <exclusions>
         <exclusion>
           <artifactId>snakeyaml</artifactId>

--- a/labs/virtualbox/src/main/java/org/jclouds/virtualbox/functions/IMachineToNodeMetadata.java
+++ b/labs/virtualbox/src/main/java/org/jclouds/virtualbox/functions/IMachineToNodeMetadata.java
@@ -24,6 +24,7 @@ import static org.jclouds.virtualbox.config.VirtualBoxConstants.GUEST_OS_USER;
 import static org.jclouds.virtualbox.config.VirtualBoxConstants.VIRTUALBOX_NODE_NAME_SEPARATOR;
 import static org.jclouds.virtualbox.config.VirtualBoxConstants.VIRTUALBOX_NODE_PREFIX;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -40,7 +41,6 @@ import org.jclouds.domain.LoginCredentials;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.logging.Logger;
 import org.jclouds.virtualbox.util.NetworkUtils;
-import org.testng.collections.Lists;
 import org.virtualbox_4_1.IMachine;
 import org.virtualbox_4_1.INetworkAdapter;
 import org.virtualbox_4_1.MachineState;
@@ -108,8 +108,8 @@ public class IMachineToNodeMetadata implements Function<IMachine, NodeMetadata> 
    }
    
    private NodeMetadataBuilder getIpAddresses(IMachine vm, NodeMetadataBuilder nodeMetadataBuilder) {
-      List<String> publicIpAddresses = Lists.newArrayList();
-      List<String> privateIpAddresses = Lists.newArrayList();
+      List<String> publicIpAddresses = new ArrayList<String>();
+      List<String> privateIpAddresses = new ArrayList<String>();
       for(long slot = 0; slot < 4; slot ++) {
          INetworkAdapter adapter = vm.getNetworkAdapter(slot);
          if(adapter != null) {

--- a/labs/virtualbox/src/main/java/org/jclouds/virtualbox/functions/MastersLoadingCache.java
+++ b/labs/virtualbox/src/main/java/org/jclouds/virtualbox/functions/MastersLoadingCache.java
@@ -34,6 +34,7 @@ import static org.jclouds.virtualbox.util.MachineUtils.machineNotFoundException;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -70,7 +71,6 @@ import org.jclouds.virtualbox.domain.YamlImage;
 import org.jclouds.virtualbox.functions.admin.PreseedCfgServer;
 import org.jclouds.virtualbox.predicates.RetryIfSocketNotYetOpen;
 import org.jclouds.virtualbox.util.NetworkUtils;
-import org.testng.collections.Lists;
 import org.virtualbox_4_1.CleanupMode;
 import org.virtualbox_4_1.IMachine;
 import org.virtualbox_4_1.NetworkAttachmentType;
@@ -293,7 +293,7 @@ public class MastersLoadingCache extends AbstractLoadingCache<Image, Master> {
          throw new RuntimeException("could not connect to virtualbox");
       }
       File file = new File(isosDir, fileName);
-      List<Statement> statements = Lists.newArrayList();
+      List<Statement> statements = new ArrayList<Statement>();
       statements.add(Statements.saveHttpResponseTo(URI.create(httpUrl),
             isosDir, fileName));
       StatementList statementList = new StatementList(statements);

--- a/labs/virtualbox/src/main/java/org/jclouds/virtualbox/functions/admin/StartVBoxIfNotAlreadyRunning.java
+++ b/labs/virtualbox/src/main/java/org/jclouds/virtualbox/functions/admin/StartVBoxIfNotAlreadyRunning.java
@@ -24,6 +24,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static org.jclouds.compute.options.RunScriptOptions.Builder.runAsRoot;
 
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.PostConstruct;
@@ -46,7 +47,6 @@ import org.jclouds.virtualbox.predicates.RetryIfSocketNotYetOpen;
 import org.virtualbox_4_1.SessionState;
 import org.virtualbox_4_1.VirtualBoxManager;
 
-import com.beust.jcommander.internal.Lists;
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;
 import com.google.common.net.HostAndPort;
@@ -120,7 +120,7 @@ public class StartVBoxIfNotAlreadyRunning implements Supplier<VirtualBoxManager>
 
    private void cleanUpHost(URI provider, NodeMetadata hostNodeMetadata) {
       // kill previously started vboxwebsrv (possibly dirty session)
-      List<Statement> statements = Lists.newArrayList();
+      List<Statement> statements = new ArrayList<Statement>();
       statements.add(Statements.findPid("vboxwebsrv"));
       statements.add(Statements.kill());
       StatementList statementList = new StatementList(statements);

--- a/labs/virtualbox/src/main/java/org/jclouds/virtualbox/statements/EnableNetworkInterface.java
+++ b/labs/virtualbox/src/main/java/org/jclouds/virtualbox/statements/EnableNetworkInterface.java
@@ -22,13 +22,13 @@ package org.jclouds.virtualbox.statements;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.jclouds.scriptbuilder.domain.Statements.exec;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.jclouds.scriptbuilder.domain.OsFamily;
 import org.jclouds.scriptbuilder.domain.Statement;
 import org.jclouds.scriptbuilder.domain.StatementList;
 import org.jclouds.virtualbox.domain.NetworkInterfaceCard;
-import org.testng.collections.Lists;
 
 /**
  * Up the network interface chosen
@@ -63,7 +63,7 @@ public class EnableNetworkInterface implements Statement {
    }
 
    private List<Statement> getStatements(String iface) {
-      List<Statement> statements = Lists.newArrayList();
+      List<Statement> statements = new ArrayList<Statement>();
       statements.add(exec(String.format("echo auto %s >> /etc/network/interfaces", iface))); //
       statements.add(exec(String.format("echo iface %s inet dhcp >> /etc/network/interfaces", iface))); //
       statements.add(exec("/etc/init.d/networking restart"));

--- a/labs/virtualbox/src/main/java/org/jclouds/virtualbox/statements/InstallGuestAdditions.java
+++ b/labs/virtualbox/src/main/java/org/jclouds/virtualbox/statements/InstallGuestAdditions.java
@@ -25,6 +25,7 @@ import static org.jclouds.scriptbuilder.domain.Statements.exec;
 import static org.jclouds.scriptbuilder.domain.Statements.saveHttpResponseTo;
 
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.Resource;
@@ -38,7 +39,6 @@ import org.jclouds.scriptbuilder.domain.StatementList;
 import org.jclouds.virtualbox.domain.IsoImage;
 import org.jclouds.virtualbox.domain.StorageController;
 import org.jclouds.virtualbox.domain.VmSpec;
-import org.testng.collections.Lists;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
@@ -62,7 +62,7 @@ public class InstallGuestAdditions implements Statement {
    }
 
    private List<Statement> getStatements(VmSpec vmSpecification, String vboxVersion) {
-      List<Statement> statements = Lists.newArrayList();
+      List<Statement> statements = new ArrayList<Statement>();
       statements.add(call("installModuleAssistantIfNeeded"));
       String mountPoint = "/mnt";
       if (Iterables.tryFind(vmSpecification.getControllers(), new Predicate<StorageController>() {


### PR DESCRIPTION
The vritualbox api has compile/runtime dependency on packages from testng and jcommander, just for the purpose of creating array lists.

Since this can be avoid, its bet to so that we decrease the size of runtime dependencies.

Also, I think that we could widen the version ranges for the eclispe and servlet in the OSGi metadata. 
