### PR TITLE
Use Resources.toString where possible

### DIFF
--- a/antcontrib/src/test/java/org/jclouds/tools/ant/taskdefs/sshjava/SSHJavaTest.java
+++ b/antcontrib/src/test/java/org/jclouds/tools/ant/taskdefs/sshjava/SSHJavaTest.java
@@ -39,7 +39,6 @@ import org.testng.annotations.Test;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import com.google.common.io.CharStreams;
 import com.google.common.io.Files;
 import com.google.common.io.Resources;
 
@@ -65,9 +64,8 @@ public class SSHJavaTest {
                .getCommandLine()), new File("build", "init.sh"), Charsets.UTF_8);
       task.remotedir=new File(task.remotebase, task.id);
       task.replaceAllTokensIn(new File("build"));
-      assertEquals(Files.toString(new File("build", "init.sh"), Charsets.UTF_8), CharStreams
-               .toString(Resources.newReaderSupplier(Resources.getResource("init.sh"),
-                        Charsets.UTF_8)));
+      assertEquals(Files.toString(new File("build", "init.sh"), Charsets.UTF_8),
+               Resources.toString(Resources.getResource("init.sh"), Charsets.UTF_8));
    }
 
    private Java populateTask(Java task) {

--- a/labs/virtualbox/src/test/java/org/jclouds/virtualbox/domain/ExportIpAddressForVMNamedTest.java
+++ b/labs/virtualbox/src/test/java/org/jclouds/virtualbox/domain/ExportIpAddressForVMNamedTest.java
@@ -30,7 +30,6 @@ import org.jclouds.scriptbuilder.domain.ShellToken;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Charsets;
-import com.google.common.io.CharStreams;
 import com.google.common.io.Resources;
 
 /**
@@ -44,7 +43,7 @@ public class ExportIpAddressForVMNamedTest {
 	.addStatement(interpret("echo {varl}FOUND_IP_ADDRESS{varr}{lf}"));
    	
    public void testUNIX() throws IOException {  	
-      assertEquals(exportIpAddressForVMNamedBuilder.render(OsFamily.UNIX), CharStreams.toString(Resources.newReaderSupplier(Resources
-               .getResource("test_export_ip_address_from_vm_named." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8)));
+      assertEquals(exportIpAddressForVMNamedBuilder.render(OsFamily.UNIX), Resources.toString(Resources.getResource(
+               "test_export_ip_address_from_vm_named." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8));
    }
 }

--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/functionloader/BasicFunctionLoader.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/functionloader/BasicFunctionLoader.java
@@ -19,7 +19,6 @@
 package org.jclouds.scriptbuilder.functionloader;
 
 import com.google.common.base.Charsets;
-import com.google.common.io.CharStreams;
 import com.google.common.io.Resources;
 import org.jclouds.scriptbuilder.domain.OsFamily;
 import org.jclouds.scriptbuilder.domain.ShellToken;
@@ -46,9 +45,9 @@ public enum BasicFunctionLoader implements FunctionLoader {
    @Override
    public String loadFunction(String function, OsFamily family) throws FunctionNotFoundException {
       try {
-         return CharStreams.toString(Resources.newReaderSupplier(ClassLoadingUtils.loadResource(
+         return Resources.toString(ClassLoadingUtils.loadResource(
                   BasicFunctionLoader.class, String.format("/functions/%s.%s", function, ShellToken.SH.to(family))),
-                  Charsets.UTF_8));
+                  Charsets.UTF_8);
       } catch (IOException e) {
          throw new FunctionNotFoundException(function, family, e);
       }

--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/functionloader/osgi/BundleFunctionLoader.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/functionloader/osgi/BundleFunctionLoader.java
@@ -32,7 +32,6 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 
 import com.google.common.base.Charsets;
-import com.google.common.io.CharStreams;
 import com.google.common.io.Resources;
 
 /**
@@ -93,8 +92,8 @@ public class BundleFunctionLoader implements FunctionLoader {
    @Override
    public String loadFunction(String function, OsFamily family) throws FunctionNotFoundException {
       try {
-         return CharStreams.toString(Resources.newReaderSupplier(bundleContext.getBundle().getResource(
-                  String.format("/functions/%s.%s", function, ShellToken.SH.to(family))), Charsets.UTF_8));
+         return Resources.toString(bundleContext.getBundle().getResource(
+                  String.format("/functions/%s.%s", function, ShellToken.SH.to(family))), Charsets.UTF_8);
       } catch (IOException e) {
          throw new FunctionNotFoundException(function, family, e);
       }

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/EnvBuilderTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/EnvBuilderTest.java
@@ -29,7 +29,6 @@ import org.testng.annotations.Test;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.CharStreams;
 import com.google.common.io.Resources;
 
 /**
@@ -44,16 +43,16 @@ public class EnvBuilderTest {
 
    @Test
    public void testBuildSimpleWindows() throws MalformedURLException, IOException {
-      assertEquals(testScriptBuilder.build(OsFamily.WINDOWS), CharStreams.toString(Resources
-               .newReaderSupplier(Resources.getResource("test_env."
-                        + ShellToken.SH.to(OsFamily.WINDOWS)), Charsets.UTF_8)));
+      assertEquals(testScriptBuilder.build(OsFamily.WINDOWS),
+              Resources.toString(Resources.getResource("test_env."
+                        + ShellToken.SH.to(OsFamily.WINDOWS)), Charsets.UTF_8));
    }
 
    @Test
    public void testBuildSimpleUNIX() throws MalformedURLException, IOException {
-      assertEquals(testScriptBuilder.build(OsFamily.UNIX), CharStreams.toString(Resources
-               .newReaderSupplier(Resources.getResource("test_env."
-                        + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8)));
+      assertEquals(testScriptBuilder.build(OsFamily.UNIX),
+               Resources.toString(Resources.getResource("test_env."
+                        + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8));
    }
 
    @Test

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/InitBuilderTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/InitBuilderTest.java
@@ -34,7 +34,6 @@ import org.testng.annotations.Test;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.CharStreams;
 import com.google.common.io.Resources;
 
 /**
@@ -59,8 +58,7 @@ public class InitBuilderTest {
    public void testBuildSimpleUNIX() throws MalformedURLException, IOException {
       assertEquals(
             testInitBuilder.render(OsFamily.UNIX),
-            CharStreams.toString(Resources.newReaderSupplier(
-                  Resources.getResource("test_init." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8)));
+            Resources.toString(Resources.getResource("test_init." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8));
    }
 
    @Test
@@ -93,7 +91,6 @@ public class InitBuilderTest {
                               "du -sk {varl}EBS_MOUNT_POINT{varr}", "echo size of source",
                               "du -sk {varl}IMAGE_DIR{varr}", "rm -rf {varl}IMAGE_DIR{varr}/*",
                               "umount {varl}EBS_MOUNT_POINT{varr}", "echo ----COMPLETE----"))).render(OsFamily.UNIX),
-            CharStreams.toString(Resources.newReaderSupplier(
-                  Resources.getResource("test_ebs." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8)));
+            Resources.toString(Resources.getResource("test_ebs." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8));
    }
 }

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/InitScriptTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/InitScriptTest.java
@@ -34,7 +34,6 @@ import org.testng.annotations.Test;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.CharStreams;
 import com.google.common.io.Resources;
 
 /**
@@ -54,15 +53,13 @@ public class InitScriptTest {
    public void testBuildSimpleWindows() throws MalformedURLException, IOException {
       assertEquals(
             testInitScript.render(OsFamily.WINDOWS),
-            CharStreams.toString(Resources.newReaderSupplier(
-                  Resources.getResource("test_init." + ShellToken.SH.to(OsFamily.WINDOWS)), Charsets.UTF_8)));
+            Resources.toString(Resources.getResource("test_init." + ShellToken.SH.to(OsFamily.WINDOWS)), Charsets.UTF_8));
    }
 
    public void testBuildSimpleUNIX() throws MalformedURLException, IOException {
       assertEquals(
             testInitScript.render(OsFamily.UNIX),
-            CharStreams.toString(Resources.newReaderSupplier(
-                  Resources.getResource("test_init." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8)));
+            Resources.toString(Resources.getResource("test_init." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8));
    }
 
    public void testBuildEBS() throws MalformedURLException, IOException {
@@ -87,8 +84,7 @@ public class InitScriptTest {
                               "du -sk {varl}EBS_MOUNT_POINT{varr}", "echo size of source",
                               "du -sk {varl}IMAGE_DIR{varr}", "rm -rf {varl}IMAGE_DIR{varr}/*",
                               "umount {varl}EBS_MOUNT_POINT{varr}", "echo ----COMPLETE----")).build().render(OsFamily.UNIX),
-            CharStreams.toString(Resources.newReaderSupplier(
-                  Resources.getResource("test_ebs." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8)));
+            Resources.toString(Resources.getResource("test_ebs." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8));
    }
 
    InitScript testCallInRun = InitScript.builder().name("testcall").init(exec("echo hello"))
@@ -98,8 +94,7 @@ public class InitScriptTest {
    public void testCallInRunUNIX() throws MalformedURLException, IOException {
       assertEquals(
             testCallInRun.render(OsFamily.UNIX),
-            CharStreams.toString(Resources.newReaderSupplier(
-                  Resources.getResource("test_init_script." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8)));
+            Resources.toString(Resources.getResource("test_init_script." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8));
    }
 
 }

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/ScriptBuilderTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/ScriptBuilderTest.java
@@ -43,7 +43,6 @@ import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.CharStreams;
 import com.google.common.io.Resources;
 
 /**
@@ -72,16 +71,14 @@ public class ScriptBuilderTest {
    public void testBuildSimpleWindows() throws MalformedURLException, IOException {
       assertEquals(
             testScriptBuilder.render(OsFamily.WINDOWS),
-            CharStreams.toString(Resources.newReaderSupplier(
-                  Resources.getResource("test_script." + ShellToken.SH.to(OsFamily.WINDOWS)), Charsets.UTF_8)));
+            Resources.toString(Resources.getResource("test_script." + ShellToken.SH.to(OsFamily.WINDOWS)), Charsets.UTF_8));
    }
 
    @Test
    public void testBuildSimpleUNIX() throws MalformedURLException, IOException {
       assertEquals(
             testScriptBuilder.render(OsFamily.UNIX),
-            CharStreams.toString(Resources.newReaderSupplier(
-                  Resources.getResource("test_script." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8)));
+            Resources.toString(Resources.getResource("test_script." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8));
    }
 
    ScriptBuilder findPidBuilder = new ScriptBuilder().addStatement(findPid("{args}")).addStatement(
@@ -91,32 +88,29 @@ public class ScriptBuilderTest {
    public void testFindPidWindows() throws MalformedURLException, IOException {
       assertEquals(
             findPidBuilder.render(OsFamily.WINDOWS),
-            CharStreams.toString(Resources.newReaderSupplier(
-                  Resources.getResource("test_find_pid." + ShellToken.SH.to(OsFamily.WINDOWS)), Charsets.UTF_8)));
+            Resources.toString(Resources.getResource("test_find_pid." + ShellToken.SH.to(OsFamily.WINDOWS)), Charsets.UTF_8));
    }
 
    @Test
    public void testFindPidUNIX() throws MalformedURLException, IOException {
       assertEquals(
             findPidBuilder.render(OsFamily.UNIX),
-            CharStreams.toString(Resources.newReaderSupplier(
-                  Resources.getResource("test_find_pid." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8)));
+            Resources.toString(Resources.getResource("test_find_pid." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8));
    }
 
    ScriptBuilder seekAndDestroyBuilder = new ScriptBuilder().addStatement(findPid("{args}")).addStatement(kill());
 
    @Test
    public void testSeekAndDestroyWindows() throws MalformedURLException, IOException {
-      assertEquals(seekAndDestroyBuilder.render(OsFamily.WINDOWS), CharStreams.toString(Resources.newReaderSupplier(
-            Resources.getResource("test_seek_and_destroy." + ShellToken.SH.to(OsFamily.WINDOWS)), Charsets.UTF_8)));
+      assertEquals(seekAndDestroyBuilder.render(OsFamily.WINDOWS), Resources.toString(
+            Resources.getResource("test_seek_and_destroy." + ShellToken.SH.to(OsFamily.WINDOWS)), Charsets.UTF_8));
    }
 
    @Test
    public void testSeekAndDestroyUNIX() throws MalformedURLException, IOException {
       assertEquals(
             seekAndDestroyBuilder.render(OsFamily.UNIX),
-            CharStreams.toString(Resources.newReaderSupplier(
-                  Resources.getResource("test_seek_and_destroy." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8)));
+            Resources.toString(Resources.getResource("test_seek_and_destroy." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8));
    }
 
    @Test

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/domain/AppendFileTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/domain/AppendFileTest.java
@@ -27,7 +27,6 @@ import org.testng.annotations.Test;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
-import com.google.common.io.CharStreams;
 import com.google.common.io.Resources;
 
 /**
@@ -39,13 +38,13 @@ public class AppendFileTest {
             "log_location STDOUT", String.format("chef_server_url \"%s\"", "http://localhost:4000")));
 
    public void testUNIX() throws IOException {
-      assertEquals(statement.render(OsFamily.UNIX), CharStreams.toString(Resources.newReaderSupplier(Resources
-               .getResource("client_rb_append." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8)));
+      assertEquals(statement.render(OsFamily.UNIX), Resources.toString(Resources
+               .getResource("client_rb_append." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8));
    }
 
    public void testWINDOWS() throws IOException {
-      assertEquals(statement.render(OsFamily.WINDOWS), CharStreams.toString(Resources.newReaderSupplier(Resources
-               .getResource("client_rb_append." + ShellToken.SH.to(OsFamily.WINDOWS)), Charsets.UTF_8)));
+      assertEquals(statement.render(OsFamily.WINDOWS), Resources.toString(Resources
+               .getResource("client_rb_append." + ShellToken.SH.to(OsFamily.WINDOWS)), Charsets.UTF_8));
    }
 
 }

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/domain/CreateOrOverwriteFileTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/domain/CreateOrOverwriteFileTest.java
@@ -27,7 +27,6 @@ import org.testng.annotations.Test;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
-import com.google.common.io.CharStreams;
 import com.google.common.io.Resources;
 
 /**
@@ -39,13 +38,13 @@ public class CreateOrOverwriteFileTest {
             "log_location STDOUT", String.format("chef_server_url \"%s\"", "http://localhost:4000")));
 
    public void testUNIX() throws IOException {
-      assertEquals(statement.render(OsFamily.UNIX), CharStreams.toString(Resources.newReaderSupplier(Resources
-               .getResource("client_rb_overwrite." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8)));
+      assertEquals(statement.render(OsFamily.UNIX), Resources.toString(Resources
+               .getResource("client_rb_overwrite." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8));
    }
 
    public void testWINDOWS() throws IOException {
-      assertEquals(statement.render(OsFamily.WINDOWS), CharStreams.toString(Resources.newReaderSupplier(Resources
-               .getResource("client_rb_overwrite." + ShellToken.SH.to(OsFamily.WINDOWS)), Charsets.UTF_8)));
+      assertEquals(statement.render(OsFamily.WINDOWS), Resources.toString(Resources
+               .getResource("client_rb_overwrite." + ShellToken.SH.to(OsFamily.WINDOWS)), Charsets.UTF_8));
    }
 
 }

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/domain/CreateRunScriptTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/domain/CreateRunScriptTest.java
@@ -29,7 +29,6 @@ import org.testng.annotations.Test;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
-import com.google.common.io.CharStreams;
 import com.google.common.io.Resources;
 
 /**
@@ -49,8 +48,8 @@ public class CreateRunScriptTest {
                               exec("echo {varl}JAVA_HOME{varr}{fs}bin{fs}java -DinstanceName={varl}INSTANCE_NAME{varr} myServer.Main")));
 
    public void testUNIX() throws IOException {
-      assertEquals(statement.render(OsFamily.UNIX), CharStreams.toString(Resources.newReaderSupplier(Resources
-               .getResource("test_runrun." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8)));
+      assertEquals(statement.render(OsFamily.UNIX), Resources.toString(Resources
+               .getResource("test_runrun." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8));
    }
 
    @Test(expectedExceptions = UnsupportedOperationException.class)

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/git/InstallGitTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/git/InstallGitTest.java
@@ -29,7 +29,6 @@ import org.jclouds.scriptbuilder.statements.git.InstallGit;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Charsets;
-import com.google.common.io.CharStreams;
 import com.google.common.io.Resources;
 
 /**
@@ -44,9 +43,7 @@ public class InstallGitTest {
 
    public void testInstallGitUNIXInScriptBuilderSourcesSetupPublicCurl() throws IOException {
       assertEquals(InitScript.builder().name("install_git").run(new InstallGit()).build().render(OsFamily.UNIX),
-               CharStreams.toString(Resources.newReaderSupplier(
-                        Resources.getResource("test_install_git_scriptbuilder." + ShellToken.SH.to(OsFamily.UNIX)),
-                        Charsets.UTF_8)));
+               Resources.toString(Resources.getResource("test_install_git_scriptbuilder." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8));
    }
 
 }

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/java/InstallJDKTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/java/InstallJDKTest.java
@@ -30,7 +30,6 @@ import org.jclouds.scriptbuilder.domain.Statement;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Charsets;
-import com.google.common.io.CharStreams;
 import com.google.common.io.Resources;
 
 /**
@@ -47,9 +46,7 @@ public class InstallJDKTest {
 
    public void testInstallJDKUNIXInScriptBuilderSourcesSetupPublicCurl() throws IOException {
       assertEquals(InitScript.builder().name("install_jdk").run(InstallJDK.fromOpenJDK()).build().render(OsFamily.UNIX),
-            CharStreams.toString(Resources.newReaderSupplier(
-                  Resources.getResource("test_install_jdk_scriptbuilder." + ShellToken.SH.to(OsFamily.UNIX)),
-                  Charsets.UTF_8)));
+            Resources.toString(Resources.getResource("test_install_jdk_scriptbuilder." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8));
    }
 
    public void testInstallJDKUNIXWithURL() throws IOException {

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/login/AdminAccessTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/login/AdminAccessTest.java
@@ -27,7 +27,6 @@ import org.jclouds.scriptbuilder.domain.OsFamily;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Charsets;
-import com.google.common.io.CharStreams;
 import com.google.common.io.Resources;
 
 /**
@@ -40,8 +39,7 @@ public class AdminAccessTest {
       TestConfiguration.INSTANCE.reset();
       try {
          assertEquals(AdminAccess.standard().init(TestConfiguration.INSTANCE).render(OsFamily.UNIX),
-               CharStreams.toString(Resources.newReaderSupplier(Resources.getResource("test_adminaccess_standard.sh"),
-                     Charsets.UTF_8)));
+               Resources.toString(Resources.getResource("test_adminaccess_standard.sh"), Charsets.UTF_8));
       } finally {
          TestConfiguration.INSTANCE.reset();
       }
@@ -55,8 +53,7 @@ public class AdminAccessTest {
                      .adminPublicKey("fooPublicKey").adminUsername("foo")
                      .adminHome("/over/ridden/foo").build()
                      .init(TestConfiguration.INSTANCE).render(OsFamily.UNIX), 
-                     CharStreams.toString(Resources.newReaderSupplier(
-                     Resources.getResource("test_adminaccess_params.sh"), Charsets.UTF_8)));
+                     Resources.toString(Resources.getResource("test_adminaccess_params.sh"), Charsets.UTF_8));
 
       } finally {
          TestConfiguration.INSTANCE.reset();
@@ -71,8 +68,7 @@ public class AdminAccessTest {
                      .adminPublicKey("fooPublicKey").adminUsername("foo").adminFullName("JClouds Foo")
                      .adminHome("/over/ridden/foo").build()
                      .init(TestConfiguration.INSTANCE).render(OsFamily.UNIX),
-               CharStreams.toString(Resources.newReaderSupplier(
-                     Resources.getResource("test_adminaccess_params_and_fullname.sh"), Charsets.UTF_8)));
+               Resources.toString(Resources.getResource("test_adminaccess_params_and_fullname.sh"), Charsets.UTF_8));
 
       } finally {
          TestConfiguration.INSTANCE.reset();
@@ -86,8 +82,8 @@ public class AdminAccessTest {
          assertEquals(
                AdminAccess.builder().grantSudoToAdminUser(false).authorizeAdminPublicKey(true)
                      .installAdminPrivateKey(true).lockSsh(false).resetLoginPassword(false).build()
-                     .init(TestConfiguration.INSTANCE).render(OsFamily.UNIX), CharStreams.toString(Resources
-                     .newReaderSupplier(Resources.getResource("test_adminaccess_plainuser.sh"), Charsets.UTF_8)));
+                     .init(TestConfiguration.INSTANCE).render(OsFamily.UNIX),
+                     Resources.toString(Resources.getResource("test_adminaccess_plainuser.sh"), Charsets.UTF_8));
       } finally {
          TestConfiguration.INSTANCE.reset();
       }


### PR DESCRIPTION
Replaces calls to
CharStreams.toString(Resources.newReaderSupplier(...)).
