### PR TITLE
Remove unneeded UnsupportedEncodingExceptions

### DIFF
--- a/core/src/main/java/org/jclouds/crypto/CryptoStreams.java
+++ b/core/src/main/java/org/jclouds/crypto/CryptoStreams.java
@@ -24,7 +24,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -342,16 +341,12 @@ public class CryptoStreams {
          int currentPos = 0;
 
          public boolean processBytes(byte[] buf, int off, int len) {
-            try {
-               if (currentPos == 0 && new String(Arrays.copyOfRange(buf, off, 2), "ASCII").equals("0x")) {
-                  off += 2;
-               }
-               byte[] decoded = hex(new String(Arrays.copyOfRange(buf, off, len), "ASCII"));
-               out.write(decoded, 0, decoded.length);
-               currentPos += len;
-            } catch (UnsupportedEncodingException e) {
-               throw new IllegalStateException("ASCII must be supported");
+            if (currentPos == 0 && new String(Arrays.copyOfRange(buf, off, 2), Charsets.US_ASCII).equals("0x")) {
+               off += 2;
             }
+            byte[] decoded = hex(new String(Arrays.copyOfRange(buf, off, len), Charsets.US_ASCII));
+            out.write(decoded, 0, decoded.length);
+            currentPos += len;
             return true;
          }
 

--- a/core/src/test/java/org/jclouds/http/filters/BasicAuthenticationTest.java
+++ b/core/src/test/java/org/jclouds/http/filters/BasicAuthenticationTest.java
@@ -20,7 +20,6 @@ package org.jclouds.http.filters;
 
 import static org.testng.Assert.assertEquals;
 
-import java.io.UnsupportedEncodingException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 
@@ -40,7 +39,7 @@ public class BasicAuthenticationTest {
    private static final String USER = "Aladdin";
    private static final String PASSWORD = "open sesame";
 
-   public void testAuth() throws UnsupportedEncodingException, NoSuchAlgorithmException, CertificateException {
+   public void testAuth() throws NoSuchAlgorithmException, CertificateException {
       BasicAuthentication filter = new BasicAuthentication(USER, PASSWORD, new JCECrypto(null));
       HttpRequest request = HttpRequest.builder().method("GET").endpoint("http://localhost").build();
       request = filter.filter(request);

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/http/filters/AbiquoAuthentication.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/http/filters/AbiquoAuthentication.java
@@ -22,8 +22,6 @@ package org.jclouds.abiquo.http.filters;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.jclouds.abiquo.config.AbiquoProperties.CREDENTIAL_IS_TOKEN;
 
-import java.io.UnsupportedEncodingException;
-
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -37,6 +35,7 @@ import org.jclouds.rest.annotations.Credential;
 import org.jclouds.rest.annotations.Identity;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Charsets;
 
 /**
  * Authenticates using Basic Authentication or a generated token from previous API sessions.
@@ -68,28 +67,19 @@ public class AbiquoAuthentication implements HttpRequestFilter
     @Override
     public HttpRequest filter(final HttpRequest request) throws HttpException
     {
-        try
-        {
-            String header =
-                credentialIsToken ? tokenAuth(credential) : basicAuth(identity, credential);
-            return request
-                .toBuilder()
-                .replaceHeader(credentialIsToken ? HttpHeaders.COOKIE : HttpHeaders.AUTHORIZATION,
-                    header).build();
-        }
-        catch (UnsupportedEncodingException ex)
-        {
-            throw new HttpException(ex);
-        }
+        String header = credentialIsToken ? tokenAuth(credential) : basicAuth(identity, credential);
+        return request
+            .toBuilder()
+            .replaceHeader(credentialIsToken ? HttpHeaders.COOKIE : HttpHeaders.AUTHORIZATION,
+                header).build();
     }
 
     @VisibleForTesting
     static String basicAuth(final String user, final String password)
-        throws UnsupportedEncodingException
     {
         return "Basic "
             + CryptoStreams.base64(String.format("%s:%s", checkNotNull(user, "user"),
-                checkNotNull(password, "password")).getBytes("UTF-8"));
+                checkNotNull(password, "password")).getBytes(Charsets.UTF_8));
     }
 
     @VisibleForTesting

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/http/filters/AbiquoAuthenticationLiveApiTest.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/http/filters/AbiquoAuthenticationLiveApiTest.java
@@ -27,7 +27,6 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Properties;
@@ -142,7 +141,7 @@ public class AbiquoAuthenticationLiveApiTest
         fail("Token authentication should have failed");
     }
 
-    private String getAuthtenticationToken() throws UnsupportedEncodingException
+    private String getAuthtenticationToken()
     {
         String token = null;
 

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/http/filters/AbiquoAuthenticationTest.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/http/filters/AbiquoAuthenticationTest.java
@@ -22,7 +22,6 @@ package org.jclouds.abiquo.http.filters;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
@@ -41,8 +40,7 @@ import org.testng.annotations.Test;
 public class AbiquoAuthenticationTest
 {
 
-    public void testBasicAuthentication() throws UnsupportedEncodingException,
-        NoSuchAlgorithmException, CertificateException
+    public void testBasicAuthentication() throws NoSuchAlgorithmException, CertificateException
     {
         HttpRequest request =
             HttpRequest.builder().method("GET").endpoint(URI.create("http://foo")).build();
@@ -60,8 +58,7 @@ public class AbiquoAuthenticationTest
     }
 
     @Test(expectedExceptions = NullPointerException.class)
-    public void testBasicAuthenticationWithoutIdentity() throws UnsupportedEncodingException,
-        NoSuchAlgorithmException, CertificateException
+    public void testBasicAuthenticationWithoutIdentity() throws NoSuchAlgorithmException, CertificateException
     {
         HttpRequest request =
             HttpRequest.builder().method("GET").endpoint(URI.create("http://foo")).build();
@@ -71,8 +68,7 @@ public class AbiquoAuthenticationTest
     }
 
     @Test(expectedExceptions = NullPointerException.class)
-    public void testBasicAuthenticationWithoutCredential() throws UnsupportedEncodingException,
-        NoSuchAlgorithmException, CertificateException
+    public void testBasicAuthenticationWithoutCredential() throws NoSuchAlgorithmException, CertificateException
     {
         HttpRequest request =
             HttpRequest.builder().method("GET").endpoint(URI.create("http://foo")).build();
@@ -81,8 +77,7 @@ public class AbiquoAuthenticationTest
         filter.filter(request);
     }
 
-    public void testTokenAuthentication() throws UnsupportedEncodingException,
-        NoSuchAlgorithmException, CertificateException
+    public void testTokenAuthentication() throws NoSuchAlgorithmException, CertificateException
     {
         HttpRequest request =
             HttpRequest.builder().method("GET").endpoint(URI.create("http://foo")).build();

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/filters/RequestAuthenticator.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/filters/RequestAuthenticator.java
@@ -20,7 +20,6 @@ package org.jclouds.fujitsu.fgcp.filters;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.io.UnsupportedEncodingException;
 import java.security.InvalidKeyException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -57,6 +56,7 @@ import org.jclouds.rest.annotations.ApiVersion;
 import org.jclouds.rest.annotations.Credential;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Charsets;
 import com.google.common.collect.Multimap;
 
 /**
@@ -223,14 +223,8 @@ public class RequestAuthenticator implements HttpRequestFilter, RequestSigner {
 
       String signatureData = String.format("%s&%s&%s&%s", timezone, expires,
             signatureVersion, signatureMethod);
-      try {
-         String accessKeyId = Base64.encodeBytes(signatureData.getBytes("UTF-8"));
-         return accessKeyId.replace("\n", "\r\n");
-//         return CryptoStreams.base64(signatureData.getBytes("UTF-8")).;
-      } catch (UnsupportedEncodingException e) {
-         throw new RuntimeException(e); // should never happen as
-                                 // signatureData contains only ASCII
-      }
+      String accessKeyId = Base64.encodeBytes(signatureData.getBytes(Charsets.UTF_8));
+      return accessKeyId.replace("\n", "\r\n");
    }
 
    @Override

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/binders/BindUserOrgAndPasswordAsBasicAuthorizationHeader.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/binders/BindUserOrgAndPasswordAsBasicAuthorizationHeader.java
@@ -20,7 +20,6 @@ package org.jclouds.vcloud.director.v1_5.binders;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.io.UnsupportedEncodingException;
 import java.util.Map;
 
 import javax.inject.Singleton;
@@ -30,6 +29,7 @@ import org.jclouds.crypto.CryptoStreams;
 import org.jclouds.http.HttpRequest;
 import org.jclouds.rest.MapBinder;
 
+import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 
 /**
@@ -45,15 +45,11 @@ public class BindUserOrgAndPasswordAsBasicAuthorizationHeader implements MapBind
    @SuppressWarnings("unchecked")
    @Override
    public <R extends HttpRequest> R bindToRequest(R request, Map<String, Object> postParams) {
-      try {
-         String header = "Basic "
-                  + CryptoStreams.base64(String.format("%s@%s:%s", checkNotNull(postParams.get("user"), "user"),
-                           checkNotNull(postParams.get("org"), "org"),
-                           checkNotNull(postParams.get("password"), "password")).getBytes("UTF-8"));
-         return (R) request.toBuilder().replaceHeader(HttpHeaders.AUTHORIZATION, header).build();
-      } catch (UnsupportedEncodingException e) {
-         throw Throwables.propagate(e);
-      }
+      String header = "Basic "
+               + CryptoStreams.base64(String.format("%s@%s:%s", checkNotNull(postParams.get("user"), "user"),
+                        checkNotNull(postParams.get("org"), "org"),
+                        checkNotNull(postParams.get("password"), "password")).getBytes(Charsets.UTF_8));
+      return (R) request.toBuilder().replaceHeader(HttpHeaders.AUTHORIZATION, header).build();
    }
 
    @Override


### PR DESCRIPTION
Enabled by use of Charsets.  Remaining calls due to URLEncoder.encode
and decode.
