### PR TITLE
Remove X-Auth-Token from HP temporary signing

### DIFF
--- a/providers/hpcloud-objectstorage/src/test/java/org/jclouds/hpcloud/objectstorage/blobstore/HPCloudObjectStorageBlobSignerExpectTest.java
+++ b/providers/hpcloud-objectstorage/src/test/java/org/jclouds/hpcloud/objectstorage/blobstore/HPCloudObjectStorageBlobSignerExpectTest.java
@@ -61,7 +61,7 @@ public class HPCloudObjectStorageBlobSignerExpectTest extends BaseBlobSignerExpe
    protected HttpRequest getBlobWithTime() {
       return HttpRequest.builder().method("GET")
             .endpoint("https://objects.jclouds.org/v1.0/40806637803162/container/name?temp_url_sig=40806637803162%3Aidentity%3Ada88bc31122f0d0806b1c7bf71cd3af5c5d5b94c&temp_url_expires=123456792")
-            .addHeader("X-Auth-Token", "Auth_4f173437e4b013bee56d1007").build();
+            .build();
    }
 
    @Override
@@ -82,7 +82,7 @@ public class HPCloudObjectStorageBlobSignerExpectTest extends BaseBlobSignerExpe
    protected HttpRequest putBlobWithTime() {
       return HttpRequest.builder().method("PUT")
             .endpoint("https://objects.jclouds.org/v1.0/40806637803162/container/name?temp_url_sig=40806637803162%3Aidentity%3Ac90269245ab0a316d5ea5e654d4c2a975fb4bf77&temp_url_expires=123456792")
-            .addHeader("X-Auth-Token", "Auth_4f173437e4b013bee56d1007").build();
+            .build();
    }
 
    @Override


### PR DESCRIPTION
HP Cloud does not use X-Auth-Token for temporary signed URLs and
leaking this allows clients arbitrary privileges until token timeout.
