### PR TITLE
Remove InputSuppliers.of(byte[])

### DIFF
--- a/core/src/main/java/org/jclouds/http/HttpUtils.java
+++ b/core/src/main/java/org/jclouds/http/HttpUtils.java
@@ -50,7 +50,6 @@ import javax.inject.Singleton;
 import org.jclouds.Constants;
 import org.jclouds.crypto.CryptoStreams;
 import org.jclouds.io.ContentMetadata;
-import org.jclouds.io.InputSuppliers;
 import org.jclouds.io.MutableContentMetadata;
 import org.jclouds.io.Payload;
 import org.jclouds.io.PayloadEnclosing;
@@ -304,17 +303,9 @@ public class HttpUtils {
          if (message.getPayload().getContentMetadata().getContentLength() != null)
             logger.debug("%s %s: %s", prefix, CONTENT_LENGTH, message.getPayload().getContentMetadata()
                   .getContentLength());
-         if (message.getPayload().getContentMetadata().getContentMD5() != null)
-            try {
-               logger.debug(
-                     "%s %s: %s",
-                     prefix,
-                     "Content-MD5",
-                     CryptoStreams.base64Encode(InputSuppliers.of(message.getPayload().getContentMetadata()
-                           .getContentMD5())));
-            } catch (IOException e) {
-               logger.warn(e, " error getting md5 for %s", message);
-            }
+         byte[] md5 = message.getPayload().getContentMetadata().getContentMD5();
+         if (md5 != null)
+            logger.debug("%s %s: %s", prefix, "Content-MD5", CryptoStreams.base64(md5));
          if (message.getPayload().getContentMetadata().getContentDisposition() != null)
             logger.debug("%s %s: %s", prefix, "Content-Disposition", message.getPayload().getContentMetadata()
                   .getContentDisposition());

--- a/core/src/main/java/org/jclouds/io/InputSuppliers.java
+++ b/core/src/main/java/org/jclouds/io/InputSuppliers.java
@@ -82,11 +82,8 @@ public class InputSuppliers {
       };
    }
 
-   public static InputSupplier<? extends InputStream> of(byte[] in) {
-      return ByteStreams.newInputStreamSupplier(checkNotNull(in, "in"));
-   }
-
    public static InputSupplier<? extends InputStream> of(String in) {
-      return of(checkNotNull(in, "in").getBytes(Charsets.UTF_8));
+      byte[] bytes = checkNotNull(in, "in").getBytes(Charsets.UTF_8);
+      return ByteStreams.newInputStreamSupplier(bytes);
    }
 }

--- a/core/src/test/java/org/jclouds/http/BaseHttpCommandExecutorServiceIntegrationTest.java
+++ b/core/src/test/java/org/jclouds/http/BaseHttpCommandExecutorServiceIntegrationTest.java
@@ -195,7 +195,7 @@ public abstract class BaseHttpCommandExecutorServiceIntegrationTest extends Base
          payload.getContentMetadata().setContentMD5(digest);
          Multimap<String, String> headers = client.postPayloadAndReturnHeaders("", payload);
          assertEquals(headers.get("x-Content-MD5"),
-               Collections.singleton(CryptoStreams.base64Encode(InputSuppliers.of(digest))));
+               Collections.singleton(CryptoStreams.base64(digest)));
          payload.release();
       } finally {
          if (os != null)

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/handlers/VCloudDirectorErrorHandler.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/handlers/VCloudDirectorErrorHandler.java
@@ -20,6 +20,7 @@ package org.jclouds.vcloud.director.v1_5.handlers;
 
 import static org.jclouds.http.HttpUtils.closeClientButKeepContentStream;
 
+import java.io.ByteArrayInputStream;
 import javax.inject.Singleton;
 import javax.xml.bind.JAXB;
 
@@ -27,7 +28,6 @@ import org.jclouds.http.HttpCommand;
 import org.jclouds.http.HttpErrorHandler;
 import org.jclouds.http.HttpResponse;
 import org.jclouds.http.HttpResponseException;
-import org.jclouds.io.InputSuppliers;
 import org.jclouds.rest.AuthorizationException;
 import org.jclouds.rest.ResourceNotFoundException;
 import org.jclouds.vcloud.director.v1_5.VCloudDirectorException;
@@ -58,7 +58,7 @@ public class VCloudDirectorErrorHandler implements HttpErrorHandler {
       // Try to create a VCloudDirectorException from XML payload, if it exists
       if (response.getPayload() != null && response.getPayload().getContentMetadata().getContentType().startsWith(VCloudDirectorMediaType.ERROR)) {
 	      try {
-	         Error error = JAXB.unmarshal(InputSuppliers.of(data).getInput(), Error.class);
+	         Error error = JAXB.unmarshal(new ByteArrayInputStream(data), Error.class);
 	         exception = new VCloudDirectorException(error);
 	         message = error.getMessage();
 	      } catch (Exception e) {


### PR DESCRIPTION
Callers rarely want this functionality and should call
ByteStreams.newInputStreamSupplier when they do.
