### PR TITLE
Throw TimeoutException from awaitCompletion

### DIFF
--- a/blobstore/src/main/java/org/jclouds/blobstore/strategy/internal/DeleteAllKeysInList.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/strategy/internal/DeleteAllKeysInList.java
@@ -18,6 +18,7 @@
  */
 package org.jclouds.blobstore.strategy.internal;
 
+import static com.google.common.base.Throwables.propagate;
 import static org.jclouds.blobstore.options.ListContainerOptions.Builder.recursive;
 import static org.jclouds.concurrent.FutureIterables.awaitCompletion;
 
@@ -25,6 +26,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
 
 import javax.annotation.Resource;
 import javax.inject.Named;
@@ -42,7 +44,6 @@ import org.jclouds.blobstore.strategy.ClearListStrategy;
 import org.jclouds.http.handlers.BackoffLimitedRetryHandler;
 import org.jclouds.logging.Logger;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.Futures;
 import com.google.inject.Inject;
@@ -103,7 +104,7 @@ public class DeleteAllKeysInList implements ClearListStrategy, ClearContainerStr
          } catch (ExecutionException ee) {
             ++numErrors;
             if (numErrors == maxErrors) {
-               throw Throwables.propagate(ee.getCause());
+               throw propagate(ee.getCause());
             }
             retryHandler.imposeBackoffExponentialDelay(numErrors, message);
             continue;
@@ -153,7 +154,16 @@ public class DeleteAllKeysInList implements ClearListStrategy, ClearContainerStr
             }
          }
 
-         exceptions = awaitCompletion(responses, userExecutor, maxTime, logger, message);
+         try {
+            exceptions = awaitCompletion(responses, userExecutor, maxTime, logger, message);
+         } catch (TimeoutException te) {
+            ++numErrors;
+            if (numErrors == maxErrors) {
+               throw propagate(te);
+            }
+            retryHandler.imposeBackoffExponentialDelay(numErrors, message);
+            continue;
+         }
          if (!exceptions.isEmpty()) {
             ++numErrors;
             retryHandler.imposeBackoffExponentialDelay(numErrors, message);

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobIntegrationTest.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.GZIPInputStream;
 
@@ -119,7 +120,7 @@ public class BaseBlobIntegrationTest extends BaseBlobStoreIntegrationTest {
     * http://groups.google.com/group/jclouds/browse_thread/thread/4a7c8d58530b287f
     */
    @Test(groups = { "integration", "live" })
-   public void testPutFileParallel() throws InterruptedException, IOException {
+   public void testPutFileParallel() throws InterruptedException, IOException, TimeoutException {
 
       File payloadFile = File.createTempFile("testPutFileParallel", "png");
       Files.copy(InputSuppliers.of(getClass().getResource("/testimg.png").openStream()), payloadFile);
@@ -166,7 +167,7 @@ public class BaseBlobIntegrationTest extends BaseBlobStoreIntegrationTest {
    }
 
    @Test(groups = { "integration", "live" })
-   public void testBigFileGets() throws InterruptedException, IOException {
+   public void testBigFileGets() throws InterruptedException, IOException, TimeoutException {
       final String expectedContentDisposition = "attachment; filename=constit.txt";
       final String container = getContainerName();
       try {

--- a/core/src/test/java/org/jclouds/concurrent/FutureIterablesPerformanceTest.java
+++ b/core/src/test/java/org/jclouds/concurrent/FutureIterablesPerformanceTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
 
 import org.jclouds.logging.Logger;
 import org.testng.annotations.Test;
@@ -61,8 +62,8 @@ public class FutureIterablesPerformanceTest {
    }
 
    @Test(enabled = false)
-   public void testAwaitCompletionUsingSameThreadExecutorDoesntSerializeFutures() throws InterruptedException,
-            ExecutionException {
+   public void testAwaitCompletionUsingSameThreadExecutorDoesntSerializeFutures()
+            throws InterruptedException, ExecutionException, TimeoutException {
       long expectedMax = IO_DURATION;
       long expectedMin = IO_DURATION;
       long expectedOverhead = COUNT + FUDGE;

--- a/drivers/gae/src/test/java/org/jclouds/gae/AsyncGaeHttpCommandExecutorServiceIntegrationTest.java
+++ b/drivers/gae/src/test/java/org/jclouds/gae/AsyncGaeHttpCommandExecutorServiceIntegrationTest.java
@@ -76,7 +76,7 @@ public class AsyncGaeHttpCommandExecutorServiceIntegrationTest extends BaseHttpC
    }
 
    @Test(enabled = false)
-   public void testPerformanceVsNothing() {
+   public void testPerformanceVsNothing() throws TimeoutException {
       setupApiProxy();
       int count = 5;
       final URI fetch = URI.create("http://www.google.com");
@@ -159,7 +159,8 @@ public class AsyncGaeHttpCommandExecutorServiceIntegrationTest extends BaseHttpC
 
    }
 
-   private Results getTest(int count, String who, Supplier<ListenableFuture<?>> getSupplier, Consumer consumer) {
+   private Results getTest(int count, String who, Supplier<ListenableFuture<?>> getSupplier, Consumer consumer)
+         throws TimeoutException {
       Results results = new Results();
       results.count = count;
       results.who = who;


### PR DESCRIPTION
This is a common error that callers should interpret correctly.  For
DeleteAllKeysInList, we integrate into its retry and backoff logic,
and for other callers, we continue to propagate RuntimeException.
