### PR TITLE
Use the TimeUnit parameter in async monitor

### DIFF
--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/internal/BaseMonitoringService.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/internal/BaseMonitoringService.java
@@ -176,8 +176,7 @@ public class BaseMonitoringService implements MonitoringService {
     * Performs the periodical monitoring tasks.
     * 
     * @author Ignasi Barrera
-    * @param <T>
-    *           The type of the object being monitored.
+    * @param <T> The type of the object being monitored.
     */
    @VisibleForTesting
    class AsyncMonitor<T> implements Runnable {
@@ -205,10 +204,13 @@ public class BaseMonitoringService implements MonitoringService {
       /**
        * Starts the monitoring job with the given timeout.
        * 
-       * @param maxWait
-       *           The timeout.
+       * @param maxWait The timeout.
+       * @param timeUnit The timeunit used in the maxWait parameter.
        */
       public void startMonitoring(final Long maxWait, TimeUnit timeUnit) {
+         if (maxWait != null) {
+            checkNotNull(timeUnit, "timeUnit must not be null when using timeouts");
+         }
          future = scheduler.scheduleWithFixedDelay(this, 0L, pollingDelay, TimeUnit.MILLISECONDS);
          timeout = maxWait == null ? null : System.currentTimeMillis() + timeUnit.toMillis(maxWait);
          logger.debug("started monitor job for %s with %s timeout", monitoredObject,


### PR DESCRIPTION
The TimeUnit parameter of the monitoring functions was not properly populated and the timeout was always considered in milliseconds.

This commit fixes this, calculating the timeout based on the given TimeUnit.
