### PR TITLE
Version upgrades

### DIFF
--- a/apis/atmos/pom.xml
+++ b/apis/atmos/pom.xml
@@ -67,7 +67,6 @@
     <dependency>
        <groupId>log4j</groupId>
        <artifactId>log4j</artifactId>
-       <version>1.2.16</version>
        <scope>test</scope>
     </dependency>
     <dependency>

--- a/apis/byon/pom.xml
+++ b/apis/byon/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.10</version>
+      <version>1.11</version>
     </dependency>
   </dependencies>
 

--- a/apis/cloudfiles/pom.xml
+++ b/apis/cloudfiles/pom.xml
@@ -91,7 +91,6 @@
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>1.2.16</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/apis/cloudstack/pom.xml
+++ b/apis/cloudstack/pom.xml
@@ -106,7 +106,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/apis/cloudwatch/pom.xml
+++ b/apis/cloudwatch/pom.xml
@@ -67,7 +67,6 @@
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>1.2.16</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/apis/openstack-keystone/pom.xml
+++ b/apis/openstack-keystone/pom.xml
@@ -73,7 +73,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/apis/openstack-nova/pom.xml
+++ b/apis/openstack-nova/pom.xml
@@ -101,7 +101,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/apis/rackspace-cloudidentity/pom.xml
+++ b/apis/rackspace-cloudidentity/pom.xml
@@ -80,7 +80,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/apis/s3/pom.xml
+++ b/apis/s3/pom.xml
@@ -85,7 +85,6 @@
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>1.2.16</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/apis/swift/pom.xml
+++ b/apis/swift/pom.xml
@@ -108,7 +108,6 @@
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>1.2.16</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/apis/walrus/pom.xml
+++ b/apis/walrus/pom.xml
@@ -81,7 +81,6 @@
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>1.2.16</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/archetypes/compute-service-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/compute-service-archetype/src/main/resources/archetype-resources/pom.xml
@@ -94,7 +94,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/archetypes/rest-client-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/rest-client-archetype/src/main/resources/archetype-resources/pom.xml
@@ -85,7 +85,6 @@ $symbol_dollar = '$' )
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>    
   </dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>org.99soft.guice</groupId>
             <artifactId>rocoto</artifactId>
-            <version>6.1</version>
+            <version>6.2</version>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>
@@ -100,12 +100,12 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.2</version>
+            <version>2.2.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>13.0</version>
+            <version>13.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>

--- a/demos/pom.xml
+++ b/demos/pom.xml
@@ -48,7 +48,6 @@
         <dependency>
            <groupId>log4j</groupId>
            <artifactId>log4j</artifactId>
-           <version>1.2.16</version>
            <scope>test</scope>
         </dependency>
         <dependency>

--- a/drivers/apachehc/pom.xml
+++ b/drivers/apachehc/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.1.3</version>
+            <version>4.2.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/drivers/jsch/pom.xml
+++ b/drivers/jsch/pom.xml
@@ -81,7 +81,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/drivers/log4j/pom.xml
+++ b/drivers/log4j/pom.xml
@@ -65,7 +65,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/drivers/netty/pom.xml
+++ b/drivers/netty/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty</artifactId>
-            <version>3.3.1.Final</version>
+            <version>3.5.9.Final</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/drivers/slf4j/pom.xml
+++ b/drivers/slf4j/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.6.4</version>
+            <version>1.7.2</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/drivers/sshj/pom.xml
+++ b/drivers/sshj/pom.xml
@@ -74,7 +74,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/labs/abiquo/pom.xml
+++ b/labs/abiquo/pom.xml
@@ -126,13 +126,11 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/labs/aws-elb/pom.xml
+++ b/labs/aws-elb/pom.xml
@@ -107,7 +107,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/labs/aws-rds/pom.xml
+++ b/labs/aws-rds/pom.xml
@@ -74,7 +74,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/labs/azure-management/pom.xml
+++ b/labs/azure-management/pom.xml
@@ -89,7 +89,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/labs/cdmi/pom.xml
+++ b/labs/cdmi/pom.xml
@@ -80,7 +80,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/labs/elb/pom.xml
+++ b/labs/elb/pom.xml
@@ -105,7 +105,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/labs/fgcp-au/pom.xml
+++ b/labs/fgcp-au/pom.xml
@@ -113,13 +113,11 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>6.0.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymockclassextension</artifactId>
-            <version>2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/labs/fgcp-de/pom.xml
+++ b/labs/fgcp-de/pom.xml
@@ -113,13 +113,11 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>6.0.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymockclassextension</artifactId>
-            <version>2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/labs/fgcp/pom.xml
+++ b/labs/fgcp/pom.xml
@@ -114,19 +114,16 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>6.0.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymockclassextension</artifactId>
-            <version>2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.0.0</version>
         </dependency>
 
     </dependencies>

--- a/labs/greenqloud-storage/pom.xml
+++ b/labs/greenqloud-storage/pom.xml
@@ -82,7 +82,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/labs/iam/pom.xml
+++ b/labs/iam/pom.xml
@@ -67,7 +67,6 @@
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>1.2.16</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/labs/jenkins/pom.xml
+++ b/labs/jenkins/pom.xml
@@ -70,7 +70,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/labs/joyent-cloudapi/pom.xml
+++ b/labs/joyent-cloudapi/pom.xml
@@ -82,7 +82,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/labs/joyentcloud/pom.xml
+++ b/labs/joyentcloud/pom.xml
@@ -89,7 +89,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/labs/nodepool/pom.xml
+++ b/labs/nodepool/pom.xml
@@ -106,7 +106,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/labs/openstack-glance/pom.xml
+++ b/labs/openstack-glance/pom.xml
@@ -85,7 +85,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/labs/openstack-quantum/pom.xml
+++ b/labs/openstack-quantum/pom.xml
@@ -84,7 +84,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/labs/openstack-swift/pom.xml
+++ b/labs/openstack-swift/pom.xml
@@ -94,7 +94,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/labs/rds/pom.xml
+++ b/labs/rds/pom.xml
@@ -66,7 +66,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/labs/smartos-ssh/pom.xml
+++ b/labs/smartos-ssh/pom.xml
@@ -81,7 +81,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/labs/vcloud-director/pom.xml
+++ b/labs/vcloud-director/pom.xml
@@ -107,7 +107,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/labs/virtualbox/pom.xml
+++ b/labs/virtualbox/pom.xml
@@ -108,13 +108,11 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>6.3.1</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/loadbalancer/pom.xml
+++ b/loadbalancer/pom.xml
@@ -83,7 +83,6 @@
         <dependency>
            <groupId>log4j</groupId>
            <artifactId>log4j</artifactId>
-           <version>1.2.16</version>
            <scope>test</scope>
         </dependency>
     </dependencies>

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -206,7 +206,7 @@
             <dependency>
                 <groupId>com.jcraft</groupId>
                 <artifactId>jsch</artifactId>
-                <version>0.1.48</version>
+                <version>0.1.49</version>
             </dependency>
             <dependency>
                 <groupId>org.clojure</groupId>
@@ -231,17 +231,17 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-security</artifactId>
-                <version>8.1.1.v20120215</version>
+                <version>8.1.7.v20120910</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-server</artifactId>
-                <version>8.1.1.v20120215</version>
+                <version>8.1.7.v20120910</version>
             </dependency>
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>6.5.2</version>
+                <version>6.8</version>
                 <exclusions>
                     <exclusion>
                         <groupId>junit</groupId>
@@ -253,6 +253,21 @@
                 <groupId>xmlunit</groupId>
                 <artifactId>xmlunit</artifactId>
                 <version>1.3</version>
+            </dependency>
+            <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>1.2.17</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.0.7</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>1.0.7</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/providers/aws-sqs/pom.xml
+++ b/providers/aws-sqs/pom.xml
@@ -74,7 +74,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/providers/cloudfiles-uk/pom.xml
+++ b/providers/cloudfiles-uk/pom.xml
@@ -89,7 +89,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/providers/cloudfiles-us/pom.xml
+++ b/providers/cloudfiles-us/pom.xml
@@ -90,7 +90,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/providers/cloudonestorage/pom.xml
+++ b/providers/cloudonestorage/pom.xml
@@ -81,7 +81,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/providers/eucalyptus-partnercloud-s3/pom.xml
+++ b/providers/eucalyptus-partnercloud-s3/pom.xml
@@ -92,7 +92,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/providers/gogrid/pom.xml
+++ b/providers/gogrid/pom.xml
@@ -84,7 +84,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/providers/hpcloud-compute/pom.xml
+++ b/providers/hpcloud-compute/pom.xml
@@ -103,7 +103,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/providers/hpcloud-objectstorage/pom.xml
+++ b/providers/hpcloud-objectstorage/pom.xml
@@ -97,7 +97,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/providers/ninefold-storage/pom.xml
+++ b/providers/ninefold-storage/pom.xml
@@ -81,7 +81,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/providers/rackspace-cloudservers-uk/pom.xml
+++ b/providers/rackspace-cloudservers-uk/pom.xml
@@ -110,7 +110,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/providers/rackspace-cloudservers-us/pom.xml
+++ b/providers/rackspace-cloudservers-us/pom.xml
@@ -110,7 +110,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/providers/rimuhosting/pom.xml
+++ b/providers/rimuhosting/pom.xml
@@ -82,7 +82,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/providers/synaptic-storage/pom.xml
+++ b/providers/synaptic-storage/pom.xml
@@ -81,7 +81,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/providers/trystack-nova/pom.xml
+++ b/providers/trystack-nova/pom.xml
@@ -98,7 +98,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/sandbox-apis/libvirt/pom.xml
+++ b/sandbox-apis/libvirt/pom.xml
@@ -90,7 +90,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/sandbox-apis/nirvanix/pom.xml
+++ b/sandbox-apis/nirvanix/pom.xml
@@ -82,7 +82,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/sandbox-apis/pcs/pom.xml
+++ b/sandbox-apis/pcs/pom.xml
@@ -82,7 +82,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/sandbox-apis/scality-rs2/pom.xml
+++ b/sandbox-apis/scality-rs2/pom.xml
@@ -82,7 +82,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sandbox-providers/aws-simpledb/pom.xml
+++ b/sandbox-providers/aws-simpledb/pom.xml
@@ -74,7 +74,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sandbox-providers/azurequeue/pom.xml
+++ b/sandbox-providers/azurequeue/pom.xml
@@ -67,7 +67,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sandbox-providers/boxdotnet/pom.xml
+++ b/sandbox-providers/boxdotnet/pom.xml
@@ -73,7 +73,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/sandbox-providers/googlestorage/pom.xml
+++ b/sandbox-providers/googlestorage/pom.xml
@@ -82,7 +82,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sandbox-providers/hosteurope-storage/pom.xml
+++ b/sandbox-providers/hosteurope-storage/pom.xml
@@ -89,7 +89,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sandbox-providers/scaleup-storage/pom.xml
+++ b/sandbox-providers/scaleup-storage/pom.xml
@@ -89,7 +89,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sandbox-providers/tiscali-storage/pom.xml
+++ b/sandbox-providers/tiscali-storage/pom.xml
@@ -89,7 +89,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sandbox-providers/twitter/pom.xml
+++ b/sandbox-providers/twitter/pom.xml
@@ -74,7 +74,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/skeletons/standalone-compute/pom.xml
+++ b/skeletons/standalone-compute/pom.xml
@@ -67,7 +67,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
I came across this really cool tool: `mvn versions:display-dependency-updates`

This pull request upgrades various things:
- gson from 2.2 to 2.2.2
- guava from 13.0 to 13.0.1
- rocoto from 6.1 to 6.2
- log4j from 1.2.16 to 1.2.17
- log back from 1.0.0 to 1.0.7
- httpclient from 4.1.3 to 4.2.2
- netty from 3.3.1 to 3.5.9
- slf4j from 1.6.4 to 1.7.2
- testing from various to 6.8
- jetty from 8.1.1 to 8.1.7
- snakeyaml from 1.10 to 1.11

I've also cleaned up the poms to include in the version of log4j and logback in project/pom.xml's dependencyManagement, so we don't repeat it in dozens of other files.

A few things I have not touched, even though there are more recent versions:
- clojure
- osgi
- org.virtualbox, vboxjws
- com.google.appengine:appengine-api-1.0-sdk ............ 1.6.5 -> 1.7.3
- org.apache.wink:wink-common ....... 1.1-incubating -> 1.2.1-incubating
- jersey: not upgrading to 1.14 (because of StringIndexOutOfBoundsException - http://java.net/jira/browse/JERSEY-1423, which makes some tests fail)
