### PR TITLE
Miscellaneous Checkstyle fixes

### DIFF
--- a/blobstore/src/main/java/org/jclouds/blobstore/InputStreamMap.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/InputStreamMap.java
@@ -53,7 +53,7 @@ public interface InputStreamMap extends ListableMap<String, InputStream> {
 
    void putAllStrings(Map<? extends String, ? extends String> map);
 
-   void putAllBytes(Map<? extends String, ? extends byte[]> map);
+   void putAllBytes(Map<? extends String, byte[]> map);
 
    void putAllFiles(Map<? extends String, ? extends File> map);
 

--- a/blobstore/src/main/java/org/jclouds/blobstore/internal/InputStreamMapImpl.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/internal/InputStreamMapImpl.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Provider;
 
-import org.jclouds.blobstore.BlobMap;
 import org.jclouds.blobstore.BlobStore;
 import org.jclouds.blobstore.InputStreamMap;
 import org.jclouds.blobstore.domain.Blob;
@@ -109,7 +108,7 @@ public class InputStreamMapImpl extends BaseBlobMap<InputStream> implements Inpu
    }
 
    @Override
-   public void putAllBytes(Map<? extends String, ? extends byte[]> map) {
+   public void putAllBytes(Map<? extends String, byte[]> map) {
       putAllInternal(map);
    }
 


### PR DESCRIPTION
Nothing can extend a byte[] and remove a previous hidden unused import.
