### PR TITLE
Cancel Futures in clearContainer

### DIFF
--- a/blobstore/src/main/java/org/jclouds/blobstore/strategy/internal/DeleteAllKeysInList.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/strategy/internal/DeleteAllKeysInList.java
@@ -92,12 +92,14 @@ public class DeleteAllKeysInList implements ClearListStrategy, ClearContainerStr
       if (options.isRecursive())
          message = message + " recursively";
       Map<StorageMetadata, Exception> exceptions = Maps.newHashMap();
-      PageSet<? extends StorageMetadata> listing;
       int maxErrors = 3; // TODO parameterize
       for (int numErrors = 0; numErrors < maxErrors; ) {
          // fetch partial directory listing
+         PageSet<? extends StorageMetadata> listing;
+         Future<PageSet<? extends StorageMetadata>> listFuture =
+               connection.list(containerName, options);
          try {
-            listing = connection.list(containerName, options).get();
+            listing = listFuture.get();
          } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             break;
@@ -108,6 +110,8 @@ public class DeleteAllKeysInList implements ClearListStrategy, ClearContainerStr
             }
             retryHandler.imposeBackoffExponentialDelay(numErrors, message);
             continue;
+         } finally {
+            listFuture.cancel(true);
          }
 
          // recurse on subdirectories
@@ -163,7 +167,12 @@ public class DeleteAllKeysInList implements ClearListStrategy, ClearContainerStr
             }
             retryHandler.imposeBackoffExponentialDelay(numErrors, message);
             continue;
+         } finally {
+            for (Future<?> future : responses.values()) {
+               future.cancel(true);
+            }
          }
+
          if (!exceptions.isEmpty()) {
             ++numErrors;
             retryHandler.imposeBackoffExponentialDelay(numErrors, message);


### PR DESCRIPTION
This prevents Futures from hanging around on exceptional code paths like
interrupts and timeouts.
