### PR TITLE
Remove commons-io dependency from sshj

### DIFF
--- a/drivers/sshj/pom.xml
+++ b/drivers/sshj/pom.xml
@@ -52,7 +52,7 @@
         <test.ssh.keyfile />
 
         <jclouds.osgi.export>org.jclouds.sshj*;version="${project.version}"</jclouds.osgi.export>
-        <jclouds.osgi.import>org.jclouds*;version="${project.version}",org.apache.commons.io.input;version="[1.4,3)",*</jclouds.osgi.import>
+        <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
     </properties>
 
     <dependencies>
@@ -92,11 +92,6 @@
             <groupId>net.schmizz</groupId>
             <artifactId>sshj</artifactId>
             <version>0.8.1</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.4</version>
         </dependency>
     </dependencies>
 

--- a/drivers/sshj/src/main/java/org/jclouds/sshj/SshjSshClient.java
+++ b/drivers/sshj/src/main/java/org/jclouds/sshj/SshjSshClient.java
@@ -31,6 +31,7 @@ import static org.jclouds.crypto.SshKeys.fingerprintPrivateKey;
 import static org.jclouds.crypto.SshKeys.sha1PrivateKey;
 
 import java.io.Closeable;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.ConnectException;
@@ -54,7 +55,6 @@ import net.schmizz.sshj.transport.TransportException;
 import net.schmizz.sshj.userauth.UserAuthException;
 import net.schmizz.sshj.xfer.InMemorySourceFile;
 
-import org.apache.commons.io.input.ProxyInputStream;
 import org.jclouds.compute.domain.ExecChannel;
 import org.jclouds.compute.domain.ExecResponse;
 import org.jclouds.domain.LoginCredentials;
@@ -86,7 +86,7 @@ import com.google.inject.Inject;
 @SuppressWarnings("unchecked")
 public class SshjSshClient implements SshClient {
 
-   private final class CloseFtpChannelOnCloseInputStream extends ProxyInputStream {
+   private final class CloseFtpChannelOnCloseInputStream extends FilterInputStream {
 
       private final SFTPClient sftp;
 


### PR DESCRIPTION
FilterInputStream suffices since we only override close.
