### PR TITLE
Improved setupPublicCurl script

### DIFF
--- a/compute/src/test/resources/initscript_with_java.sh
+++ b/compute/src/test/resources/initscript_with_java.sh
@@ -89,14 +89,16 @@ alias yum-install="yum --quiet --nogpgcheck -y install"
 
 function ensure_cmd_or_install_package_apt(){
   local cmd=$1
-  local pkg=$2
+  shift
+  local pkg=$*
   
   hash $cmd 2>/dev/null || ( apt-get-update && apt-get-install $pkg )
 }
 
 function ensure_cmd_or_install_package_yum(){
   local cmd=$1
-  local pkg=$2
+  shift
+  local pkg=$*
   hash $cmd 2>/dev/null || yum-install $pkg
 }
 

--- a/compute/src/test/resources/initscript_with_jetty.sh
+++ b/compute/src/test/resources/initscript_with_jetty.sh
@@ -89,14 +89,16 @@ alias yum-install="yum --quiet --nogpgcheck -y install"
 
 function ensure_cmd_or_install_package_apt(){
   local cmd=$1
-  local pkg=$2
+  shift
+  local pkg=$*
   
   hash $cmd 2>/dev/null || ( apt-get-update && apt-get-install $pkg )
 }
 
 function ensure_cmd_or_install_package_yum(){
   local cmd=$1
-  local pkg=$2
+  shift
+  local pkg=$*
   hash $cmd 2>/dev/null || yum-install $pkg
 }
 

--- a/compute/src/test/resources/runscript.sh
+++ b/compute/src/test/resources/runscript.sh
@@ -89,14 +89,16 @@ alias yum-install="yum --quiet --nogpgcheck -y install"
 
 function ensure_cmd_or_install_package_apt(){
   local cmd=$1
-  local pkg=$2
+  shift
+  local pkg=$*
   
   hash $cmd 2>/dev/null || ( apt-get-update && apt-get-install $pkg )
 }
 
 function ensure_cmd_or_install_package_yum(){
   local cmd=$1
-  local pkg=$2
+  shift
+  local pkg=$*
   hash $cmd 2>/dev/null || yum-install $pkg
 }
 

--- a/scriptbuilder/src/main/resources/functions/setupPublicCurl.sh
+++ b/scriptbuilder/src/main/resources/functions/setupPublicCurl.sh
@@ -4,14 +4,16 @@ alias yum-install="yum --quiet --nogpgcheck -y install"
 
 function ensure_cmd_or_install_package_apt(){
   local cmd=$1
-  local pkg=$2
+  shift
+  local pkg=$*
   
   hash $cmd 2>/dev/null || ( apt-get-update && apt-get-install $pkg )
 }
 
 function ensure_cmd_or_install_package_yum(){
   local cmd=$1
-  local pkg=$2
+  shift
+  local pkg=$*
   hash $cmd 2>/dev/null || yum-install $pkg
 }
 

--- a/scriptbuilder/src/test/resources/test_install_git_scriptbuilder.sh
+++ b/scriptbuilder/src/test/resources/test_install_git_scriptbuilder.sh
@@ -89,14 +89,16 @@ alias yum-install="yum --quiet --nogpgcheck -y install"
 
 function ensure_cmd_or_install_package_apt(){
   local cmd=$1
-  local pkg=$2
+  shift
+  local pkg=$*
   
   hash $cmd 2>/dev/null || ( apt-get-update && apt-get-install $pkg )
 }
 
 function ensure_cmd_or_install_package_yum(){
   local cmd=$1
-  local pkg=$2
+  shift
+  local pkg=$*
   hash $cmd 2>/dev/null || yum-install $pkg
 }
 

--- a/scriptbuilder/src/test/resources/test_install_jdk_scriptbuilder.sh
+++ b/scriptbuilder/src/test/resources/test_install_jdk_scriptbuilder.sh
@@ -89,14 +89,16 @@ alias yum-install="yum --quiet --nogpgcheck -y install"
 
 function ensure_cmd_or_install_package_apt(){
   local cmd=$1
-  local pkg=$2
+  shift
+  local pkg=$*
   
   hash $cmd 2>/dev/null || ( apt-get-update && apt-get-install $pkg )
 }
 
 function ensure_cmd_or_install_package_yum(){
   local cmd=$1
-  local pkg=$2
+  shift
+  local pkg=$*
   hash $cmd 2>/dev/null || yum-install $pkg
 }
 


### PR DESCRIPTION
With this changes, apt and yum helper functions can be used to install
many packages at once as follows:

```
ensure_cmd_or_install_package_apt git git-core build-essentials <...>
```
