### PR TITLE
Implement Comparable in GoGrid ErrorResponse

### DIFF
--- a/providers/gogrid/src/main/java/org/jclouds/gogrid/domain/internal/ErrorResponse.java
+++ b/providers/gogrid/src/main/java/org/jclouds/gogrid/domain/internal/ErrorResponse.java
@@ -24,13 +24,14 @@ import java.beans.ConstructorProperties;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
+import com.google.common.collect.ComparisonChain;
 
 /**
  * Class ErrorResponse
  *
  * @author Oleksiy Yarmula
  */
-public class ErrorResponse {
+public class ErrorResponse implements Comparable<ErrorResponse> {
 
    public static Builder<?> builder() {
       return new ConcreteBuilder();
@@ -111,6 +112,14 @@ public class ErrorResponse {
       ErrorResponse that = ErrorResponse.class.cast(obj);
       return Objects.equal(this.message, that.message)
             && Objects.equal(this.errorCode, that.errorCode);
+   }
+
+   @Override
+   public int compareTo(ErrorResponse that) {
+      return ComparisonChain.start()
+            .compare(errorCode, that.errorCode)
+            .compare(message, that.message)
+            .result();
    }
 
    protected ToStringHelper string() {


### PR DESCRIPTION
Gson collects errors in a TreeMap which requires a well-behaved
Comparable method.  This addresses a Java 7 GoGrid failure seen in
GridServerClientExpectTest.testGetServerCredentialsWhenNotFoundThrowsResourceNotFoundExceptionWithNiceMessage:

java.lang.ClassCastException: org.jclouds.gogrid.domain.internal.ErrorResponse cannot be cast to java.lang.Comparable
