### PR TITLE
Enforce use of Collection helpers via Checkstyle

### DIFF
--- a/apis/atmos/src/main/java/org/jclouds/atmos/filters/SignRequest.java
+++ b/apis/atmos/src/main/java/org/jclouds/atmos/filters/SignRequest.java
@@ -23,7 +23,6 @@ import static org.jclouds.util.Patterns.NEWLINE_PATTERN;
 import static org.jclouds.util.Patterns.TWO_SPACE_PATTERN;
 
 import java.util.Set;
-import java.util.TreeSet;
 
 import javax.annotation.Resource;
 import javax.inject.Inject;
@@ -52,6 +51,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
 
 /**
  * Signs the EMC Atmos Online Storage request.
@@ -141,7 +141,7 @@ public class SignRequest implements HttpRequestFilter {
 
    private void appendCanonicalizedHeaders(HttpRequest request, StringBuilder toSign) {
       // TreeSet == Sort the headers alphabetically.
-      Set<String> headers = new TreeSet<String>(request.getHeaders().keySet());
+      Set<String> headers = Sets.newTreeSet(request.getHeaders().keySet());
       for (String header : headers) {
          if (header.startsWith("x-emc-") && !header.equals(AtmosHeaders.SIGNATURE)) {
             // Convert all header names to lowercase.

--- a/apis/byon/src/main/java/org/jclouds/byon/Node.java
+++ b/apis/byon/src/main/java/org/jclouds/byon/Node.java
@@ -19,7 +19,6 @@
 package org.jclouds.byon;
 
 import java.net.URI;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -27,6 +26,7 @@ import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
 /**
  * 
@@ -245,7 +245,7 @@ public class Node {
    }
    
    public Set<String> getTags() {
-      Set<String> tagSet = new HashSet<String>();
+      Set<String> tagSet = Sets.newHashSet();
       for (String tag : tags)
          tagSet.add(tag);
       return tagSet;

--- a/apis/cloudloadbalancers/src/test/java/org/jclouds/cloudloadbalancers/features/NodeClientLiveTest.java
+++ b/apis/cloudloadbalancers/src/test/java/org/jclouds/cloudloadbalancers/features/NodeClientLiveTest.java
@@ -22,7 +22,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -30,6 +29,7 @@ import java.util.Map.Entry;
 import java.util.logging.Logger;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 
 import org.jclouds.cloudloadbalancers.domain.LoadBalancer;
 import org.jclouds.cloudloadbalancers.domain.LoadBalancerRequest;
@@ -49,7 +49,7 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "live", singleThreaded = true, testName = "NodeClientLiveTest")
 public class NodeClientLiveTest extends BaseCloudLoadBalancersClientLiveTest {
-   private Map<LoadBalancer, Set<Node>> nodes = new HashMap<LoadBalancer, Set<Node>>();
+   private Map<LoadBalancer, Set<Node>> nodes = Maps.newHashMap();
 
    @Test(groups = "live")
    public void testCreateLoadBalancers() {

--- a/apis/cloudsigma/src/main/java/org/jclouds/cloudsigma/options/CloneDriveOptions.java
+++ b/apis/cloudsigma/src/main/java/org/jclouds/cloudsigma/options/CloneDriveOptions.java
@@ -68,7 +68,7 @@ public class CloneDriveOptions {
       Set<String> currentTags = (currentTagsString == null) ? new HashSet<String>() :
          Sets.newLinkedHashSet(Splitter.on(' ').split(currentTagsString));
 
-      Set<String> newTags = new LinkedHashSet<String>();
+      Set<String> newTags = Sets.newLinkedHashSet();
       for (String tag : tags)
           newTags.add(tag);
       

--- a/apis/filesystem/src/test/java/org/jclouds/filesystem/FilesystemAsyncBlobStoreTest.java
+++ b/apis/filesystem/src/test/java/org/jclouds/filesystem/FilesystemAsyncBlobStoreTest.java
@@ -31,7 +31,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Properties;
 import java.util.Set;
@@ -64,6 +63,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Charsets;
+import com.google.common.collect.Sets;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Closeables;
 import com.google.common.io.Files;
@@ -136,7 +136,7 @@ public class FilesystemAsyncBlobStoreTest {
      */
     public void testList_Root() throws IOException {
         PageSet<? extends StorageMetadata> containersRetrieved;
-        Set<String> containersCreated = new HashSet<String>();
+        Set<String> containersCreated = Sets.newHashSet();
 
         // Testing list with no containers
         containersRetrieved = blobStore.list();
@@ -144,7 +144,7 @@ public class FilesystemAsyncBlobStoreTest {
 
         // Testing list with some containers
         String[] containerNames = new String[]{"34343", "aaaa", "bbbbb"};
-        containersCreated = new HashSet<String>();
+        containersCreated = Sets.newHashSet();
         for (String containerName : containerNames) {
             blobStore.createContainerInLocation(null, containerName);
             containersCreated.add(containerName);
@@ -839,7 +839,7 @@ public class FilesystemAsyncBlobStoreTest {
         }
 
         // copies values
-        Set<String> expectedBlobKeysCopy = new HashSet<String>();
+        Set<String> expectedBlobKeysCopy = Sets.newHashSet();
         for (String value : expectedBlobKeys) {
             expectedBlobKeysCopy.add(value);
         }

--- a/apis/filesystem/src/test/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImplTest.java
+++ b/apis/filesystem/src/test/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImplTest.java
@@ -27,8 +27,6 @@ import static org.testng.Assert.fail;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -49,6 +47,8 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;
 import com.google.common.io.InputSupplier;
@@ -305,7 +305,7 @@ public class FilesystemStorageStrategyImplTest {
       storageStrategy.createContainer(CONTAINER_NAME + "2");
       storageStrategy.createContainer(CONTAINER_NAME + "3");
 
-      List<String> containers = new ArrayList<String>();
+      List<String> containers = Lists.newArrayList();
       resultList = storageStrategy.getAllContainerNames();
       Iterator<String> containersIterator = resultList.iterator();
       while (containersIterator.hasNext()) {
@@ -465,7 +465,7 @@ public class FilesystemStorageStrategyImplTest {
                TestUtils.createRandomBlobKey("346" + FS + "g3sx2" + FS + "removeBlob-", ".jpg"),
                TestUtils.createRandomBlobKey("346" + FS + "g3sx2" + FS + "removeBlob-", ".jpg") });
 
-      Set<String> remainingBlobKeys = new HashSet<String>();
+      Set<String> remainingBlobKeys = Sets.newHashSet();
       for (String key : blobKeys) {
          remainingBlobKeys.add(key);
       }
@@ -507,7 +507,7 @@ public class FilesystemStorageStrategyImplTest {
                TestUtils.createRandomBlobKey("563" + FS + "g3sx2" + FS + "removeBlob-", ".jpg") });
       storageStrategy.getBlobKeysInsideContainer(CONTAINER_NAME);
 
-      List<String> retrievedBlobKeys = new ArrayList<String>();
+      List<String> retrievedBlobKeys = Lists.newArrayList();
       resultList = storageStrategy.getBlobKeysInsideContainer(CONTAINER_NAME);
       Iterator<String> containersIterator = resultList.iterator();
       while (containersIterator.hasNext()) {

--- a/apis/filesystem/src/test/java/org/jclouds/filesystem/utils/TestUtils.java
+++ b/apis/filesystem/src/test/java/org/jclouds/filesystem/utils/TestUtils.java
@@ -24,7 +24,6 @@ import static org.testng.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
@@ -32,6 +31,7 @@ import org.jclouds.filesystem.util.Utils;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
+import com.google.common.collect.Sets;
 import com.google.common.io.Files;
 
 /**
@@ -85,7 +85,7 @@ public class TestUtils {
      * @throws IOException
      */
    public static Set<String> createBlobsInContainer(String containerName, String... blobNames) throws IOException {
-        Set<String> blobNamesCreatedInContainer = new HashSet<String>();
+        Set<String> blobNamesCreatedInContainer = Sets.newHashSet();
         for (String blobName : blobNames) {
             createBlobAsFile(containerName, blobName, getImageForBlobPayload());
             blobNamesCreatedInContainer.add(blobName);

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/AccessControlList.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/AccessControlList.java
@@ -19,17 +19,17 @@
 package org.jclouds.s3.domain;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.TreeSet;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 /**
  * An Access Control List (ACL) describes the access control settings for a bucket or object in S3.
@@ -46,7 +46,7 @@ import com.google.common.collect.Collections2;
 public class AccessControlList {
 
    private CanonicalUser owner;
-   private final List<Grant> grants = new ArrayList<Grant>();
+   private final List<Grant> grants = Lists.newArrayList();
 
    public void setOwner(CanonicalUser owner) {
       this.owner = owner;
@@ -67,7 +67,7 @@ public class AccessControlList {
     * @return an unmodifiable set of grantees who have been assigned permissions in this ACL.
     */
    public Set<Grantee> getGrantees() {
-      Set<Grantee> grantees = new TreeSet<Grantee>();
+      Set<Grantee> grantees = Sets.newTreeSet();
       for (Grant grant : getGrants()) {
          grantees.add(grant.getGrantee());
       }

--- a/apis/swift/src/test/java/org/jclouds/openstack/swift/functions/ParseContainerListFromJsonResponseTest.java
+++ b/apis/swift/src/test/java/org/jclouds/openstack/swift/functions/ParseContainerListFromJsonResponseTest.java
@@ -21,7 +21,6 @@ package org.jclouds.openstack.swift.functions;
 import static org.testng.Assert.assertEquals;
 
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -33,6 +32,7 @@ import org.jclouds.util.Strings2;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Key;
@@ -51,7 +51,7 @@ public class ParseContainerListFromJsonResponseTest {
    public void testApplyInputStream() {
       InputStream is = Strings2
                .toInputStream("[ {\"name\":\"test_container_1\",\"count\":2,\"bytes\":78}, {\"name\":\"test_container_2\",\"count\":1,\"bytes\":17} ]   ");
-      Map<String, String> meta = new HashMap<String, String>();
+      Map<String, String> meta = Maps.newHashMap();
 
       List<ContainerMetadata> expects = ImmutableList.of(ContainerMetadata.builder().name("test_container_1").count( 2).bytes(78).metadata(meta).build(),
                ContainerMetadata.builder().name("test_container_2").count(1).bytes(17).metadata(meta).build());

--- a/blobstore/src/main/java/org/jclouds/blobstore/options/GetOptions.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/options/GetOptions.java
@@ -21,9 +21,10 @@ package org.jclouds.blobstore.options;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+
+import com.google.common.collect.Lists;
 
 /**
  * Contains options supported for HTTP GET operations. <h2>
@@ -46,7 +47,7 @@ public class GetOptions {
 
    public static final GetOptions NONE = new GetOptions();
 
-   private final List<String> ranges = new ArrayList<String>();
+   private final List<String> ranges = Lists.newArrayList();
    private Date ifModifiedSince;
    private Date ifUnmodifiedSince;
    private String ifMatch;

--- a/blobstore/src/test/java/org/jclouds/blobstore/BlobStoresTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/BlobStoresTest.java
@@ -21,7 +21,6 @@ package org.jclouds.blobstore;
 import static org.easymock.EasyMock.createMock;
 import static org.testng.Assert.assertEquals;
 
-import java.util.HashSet;
 import java.util.Set;
 
 import org.easymock.EasyMock;
@@ -37,6 +36,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
 
 @Test(singleThreaded = true, testName = "BlobStoresTest")
 public class BlobStoresTest {
@@ -95,7 +95,7 @@ public class BlobStoresTest {
       try {
          blobStore = context.getBlobStore();
          blobStore.createContainerInLocation(null, containerName);
-         Set<String> expectedNames = new HashSet<String>();
+         Set<String> expectedNames = Sets.newHashSet();
          for (int i = 0; i < NUM_BLOBS; i++) {
             String blobName = "myname" + i;
             blobStore.putBlob(containerName, blobStore.blobBuilder(blobName).payload("payload" + i).build());

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseInputStreamMapIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseInputStreamMapIntegrationTest.java
@@ -25,7 +25,6 @@ import static org.testng.Assert.assertEquals;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -39,6 +38,7 @@ import org.jclouds.blobstore.options.ListContainerOptions;
 import org.jclouds.util.Strings2;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
 /**
@@ -80,7 +80,7 @@ public abstract class BaseInputStreamMapIntegrationTest extends BaseMapIntegrati
             keySet.add(i + "");
          }
 
-         Map<String, String> newMap = new HashMap<String, String>();
+         Map<String, String> newMap = Maps.newHashMap();
          for (String key : keySet) {
             newMap.put(key, key);
          }

--- a/common/aws/src/main/java/org/jclouds/aws/domain/AWSError.java
+++ b/common/aws/src/main/java/org/jclouds/aws/domain/AWSError.java
@@ -18,8 +18,9 @@
  */
 package org.jclouds.aws.domain;
 
-import java.util.HashMap;
 import java.util.Map;
+
+import com.google.common.collect.Maps;
 
 /**
  * When an Amazon S3 request is in error, the client receives an error response.
@@ -35,7 +36,7 @@ public class AWSError {
    private String message;
    private String requestId;
    private String requestToken;
-   private Map<String, String> details = new HashMap<String, String>();
+   private Map<String, String> details = Maps.newHashMap();
    private String stringSigned;
    private String signature;
 

--- a/common/azure/src/main/java/org/jclouds/azure/storage/filters/SharedKeyLiteAuthentication.java
+++ b/common/azure/src/main/java/org/jclouds/azure/storage/filters/SharedKeyLiteAuthentication.java
@@ -22,7 +22,6 @@ import static org.jclouds.util.Patterns.NEWLINE_PATTERN;
 
 import java.util.Collection;
 import java.util.Set;
-import java.util.TreeSet;
 
 import javax.annotation.Resource;
 import javax.inject.Inject;
@@ -52,6 +51,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
 
 /**
  * Signs the Azure Storage request.
@@ -153,7 +153,8 @@ public class SharedKeyLiteAuthentication implements HttpRequestFilter {
    }
 
    private void appendCanonicalizedHeaders(HttpRequest request, StringBuilder toSign) {
-      Set<String> headers = new TreeSet<String>(request.getHeaders().keySet());
+      // TreeSet == Sort the headers alphabetically.
+      Set<String> headers = Sets.newTreeSet(request.getHeaders().keySet());
       for (String header : headers) {
          if (header.startsWith("x-ms-")) {
             toSign.append(header.toLowerCase()).append(":");

--- a/compute/src/test/java/org/jclouds/compute/internal/BaseComputeServiceLiveTest.java
+++ b/compute/src/test/java/org/jclouds/compute/internal/BaseComputeServiceLiveTest.java
@@ -46,7 +46,6 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -103,6 +102,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -420,8 +420,8 @@ public abstract class BaseComputeServiceLiveTest extends BaseComputeServiceConte
    @Test(enabled = true, dependsOnMethods = "testCompareSizes")
    public void testConcurrentUseOfComputeServiceToCreateNodes() throws Exception {
       final long timeoutMs = 20 * 60 * 1000;
-      List<String> groups = new ArrayList<String>();
-      List<ListenableFuture<NodeMetadata>> futures = new ArrayList<ListenableFuture<NodeMetadata>>();
+      List<String> groups = Lists.newArrayList();
+      List<ListenableFuture<NodeMetadata>> futures = Lists.newArrayList();
       ListeningExecutorService executor = MoreExecutors.listeningDecorator(context.utils().userExecutor());
 
       try {

--- a/core/src/main/java/org/jclouds/ContextBuilder.java
+++ b/core/src/main/java/org/jclouds/ContextBuilder.java
@@ -33,7 +33,6 @@ import static com.google.common.collect.Lists.newArrayList;
 import static org.jclouds.Constants.*;
 import static org.jclouds.util.Throwables2.propagateAuthorizationOrOriginalException;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -79,6 +78,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.ImmutableMultimap.Builder;
 import com.google.common.reflect.TypeToken;
@@ -157,7 +157,7 @@ public class ContextBuilder {
    protected String apiVersion;
    protected String buildVersion;
    protected Optional<Properties> overrides = Optional.absent();
-   protected List<Module> modules = new ArrayList<Module>(3);
+   protected List<Module> modules = Lists.newArrayListWithCapacity(3);
 
    @Override
    public String toString() {

--- a/core/src/main/java/org/jclouds/apis/ApiRegistry.java
+++ b/core/src/main/java/org/jclouds/apis/ApiRegistry.java
@@ -18,15 +18,16 @@
  */
 package org.jclouds.apis;
 
-import java.util.HashSet;
 import java.util.Set;
+
+import com.google.common.collect.Sets;
 
 /**
  * A registry for holding {@link org.jclouds.apis.ApiMetadata}.
  */
 public class ApiRegistry {
 
-  private static final Set<ApiMetadata> apis = new HashSet<ApiMetadata>();
+  private static final Set<ApiMetadata> apis = Sets.newHashSet();
 
   public static void registerApi(ApiMetadata api) {
     apis.add(api);

--- a/core/src/main/java/org/jclouds/http/options/GetOptions.java
+++ b/core/src/main/java/org/jclouds/http/options/GetOptions.java
@@ -21,7 +21,6 @@ package org.jclouds.http.options;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -31,6 +30,7 @@ import org.jclouds.date.DateService;
 import org.jclouds.date.internal.SimpleDateFormatDateService;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 
 /**
@@ -53,7 +53,7 @@ import com.google.common.collect.Multimap;
 public class GetOptions extends BaseHttpRequestOptions {
    private static final DateService dateService = new SimpleDateFormatDateService();
    public static final GetOptions NONE = new GetOptions();
-   private final List<String> ranges = new ArrayList<String>();
+   private final List<String> ranges = Lists.newArrayList();
 
    @Override
    public Multimap<String, String> buildRequestHeaders() {

--- a/core/src/main/java/org/jclouds/json/internal/DeserializationConstructorAndReflectiveTypeAdapterFactory.java
+++ b/core/src/main/java/org/jclouds/json/internal/DeserializationConstructorAndReflectiveTypeAdapterFactory.java
@@ -25,11 +25,11 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.jclouds.json.internal.NamingStrategies.ConstructorFieldNamingStrategy;
 
+import com.google.common.collect.Maps;
 import com.google.gson.FieldNamingStrategy;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
@@ -248,7 +248,7 @@ public final class DeserializationConstructorAndReflectiveTypeAdapterFactory imp
 
    @SuppressWarnings("unchecked")
    private Map<String, ParameterReader> getParameterReaders(Gson context, TypeToken<?> declaring, Constructor<?> constructor) {
-      Map<String, ParameterReader> result = new LinkedHashMap<String, ParameterReader>();
+      Map<String, ParameterReader> result = Maps.newLinkedHashMap();
 
       for (int index = 0; index < constructor.getGenericParameterTypes().length; index++) {
          Type parameterType = getTypeOfConstructorParameter(declaring, constructor, index);

--- a/core/src/main/java/org/jclouds/lifecycle/BaseLifeCycle.java
+++ b/core/src/main/java/org/jclouds/lifecycle/BaseLifeCycle.java
@@ -18,7 +18,6 @@
  */
 package org.jclouds.lifecycle;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -27,6 +26,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.annotation.Resource;
+
+import com.google.common.collect.Lists;
 
 import org.jclouds.logging.Logger;
 
@@ -47,7 +48,7 @@ public abstract class BaseLifeCycle implements Runnable, LifeCycle {
 
    public BaseLifeCycle(ExecutorService executor, LifeCycle... dependencies) {
       this.executorService = executor;
-      this.dependencies = new ArrayList<LifeCycle>();
+      this.dependencies = Lists.newArrayList();
       this.dependencies.addAll(Arrays.asList(dependencies));
       this.statusLock = new Object();
       this.status = Status.INACTIVE;

--- a/core/src/main/java/org/jclouds/lifecycle/config/LifeCycleModule.java
+++ b/core/src/main/java/org/jclouds/lifecycle/config/LifeCycleModule.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -39,6 +38,7 @@ import org.jclouds.concurrent.MoreExecutors;
 import org.jclouds.lifecycle.Closer;
 
 import com.google.common.base.Throwables;
+import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ExecutionList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
@@ -103,7 +103,7 @@ public class LifeCycleModule extends AbstractModule {
    protected void bindPostInjectionInvoke(final Closer closer, final ExecutionList list) {
       bindListener(any(), new TypeListener() {
          public <I> void hear(TypeLiteral<I> injectableType, TypeEncounter<I> encounter) {
-            Set<Method> methods = new HashSet<Method>();
+            Set<Method> methods = Sets.newHashSet();
             Class<? super I> type = injectableType.getRawType();
             while (type != null) {
                methods.addAll(Arrays.asList(type.getDeclaredMethods()));

--- a/core/src/main/java/org/jclouds/logging/config/BindLoggersAnnotatedWithResource.java
+++ b/core/src/main/java/org/jclouds/logging/config/BindLoggersAnnotatedWithResource.java
@@ -23,7 +23,6 @@ import static com.google.common.collect.Sets.filter;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 
 import javax.annotation.Resource;
@@ -35,6 +34,7 @@ import org.jclouds.logging.Logger.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
+import com.google.common.collect.Sets;
 import com.google.inject.ProvisionException;
 import com.google.inject.TypeLiteral;
 import com.google.inject.spi.InjectionListener;
@@ -129,7 +129,7 @@ public class BindLoggersAnnotatedWithResource implements TypeListener {
 
     @VisibleForTesting
     Set<Field> getLoggerFieldsAnnotatedWithResource(Class<?> declaredType) {
-        Set<Field> fields = new HashSet<Field>();
+        Set<Field> fields = Sets.newHashSet();
         Class<?> type = declaredType;
         while (type != null) {
             fields.addAll(Arrays.asList(type.getDeclaredFields()));

--- a/core/src/main/java/org/jclouds/providers/ProviderRegistry.java
+++ b/core/src/main/java/org/jclouds/providers/ProviderRegistry.java
@@ -18,15 +18,16 @@
  */
 package org.jclouds.providers;
 
-import java.util.HashSet;
 import java.util.Set;
+
+import com.google.common.collect.Sets;
 
 /**
  * A registry for holding {@link org.jclouds.providers.ProviderMetadata}.
  */
 public class ProviderRegistry {
 
-  private static final Set<ProviderMetadata> providers = new HashSet<ProviderMetadata>();
+  private static final Set<ProviderMetadata> providers = Sets.newHashSet();
 
   public static void registerProvider(ProviderMetadata provider) {
     providers.add(provider);

--- a/core/src/main/java/org/jclouds/util/InputStreamChain.java
+++ b/core/src/main/java/org/jclouds/util/InputStreamChain.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.LinkedList;
 
+import com.google.common.collect.Lists;
+
 /**
  * {@link InputStream} implementation that allows chaining of various streams for seamless
  * sequential reading
@@ -34,7 +36,7 @@ public class InputStreamChain extends InputStream {
    /**
     * Input stream chain
     */
-   private final LinkedList<InputStream> streams = new LinkedList<InputStream>();
+   private final LinkedList<InputStream> streams = Lists.newLinkedList();
 
    /**
     * Currently active stream

--- a/core/src/test/java/org/jclouds/ContextBuilderTest.java
+++ b/core/src/test/java/org/jclouds/ContextBuilderTest.java
@@ -21,7 +21,6 @@ package org.jclouds;
 import static org.testng.Assert.assertEquals;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
@@ -47,6 +46,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.inject.AbstractModule;
 import com.google.inject.Binder;
 import com.google.inject.Key;
@@ -130,7 +130,7 @@ public class ContextBuilderTest {
    
    @Test
    public void testAddHttpModuleIfNotPresent() {
-      List<Module> modules = new ArrayList<Module>();
+      List<Module> modules = Lists.newArrayList();
       HttpModule module = new HttpModule();
       modules.add(module);
       ContextBuilder.addHttpModuleIfNeededAndNotPresent(modules);
@@ -140,7 +140,7 @@ public class ContextBuilderTest {
 
    @Test
    public void testAddLoggingModuleIfNotPresent() {
-      List<Module> modules = new ArrayList<Module>();
+      List<Module> modules = Lists.newArrayList();
       LoggingModule module = new NullLoggingModule();
       modules.add(module);
       ContextBuilder.addLoggingModuleIfNotPresent(modules);
@@ -150,7 +150,7 @@ public class ContextBuilderTest {
    
    @Test
    public void testAddEventBusModuleIfNotPresent() {
-      List<Module> modules = new ArrayList<Module>();
+      List<Module> modules = Lists.newArrayList();
       EventBusModule module = new EventBusModule();
       modules.add(module);
       ContextBuilder.addEventBusIfNotPresent(modules);
@@ -160,7 +160,7 @@ public class ContextBuilderTest {
 
    @Test
    public void testAddExecutorServiceModuleIfNotPresent() {
-      List<Module> modules = new ArrayList<Module>();
+      List<Module> modules = Lists.newArrayList();
       ExecutorServiceModule module = new ExecutorServiceModule();
       modules.add(module);
       ContextBuilder.addExecutorServiceIfNotPresent(modules);
@@ -170,7 +170,7 @@ public class ContextBuilderTest {
 
    @Test
    public void testAddCredentialStoreModuleIfNotPresent() {
-      List<Module> modules = new ArrayList<Module>();
+      List<Module> modules = Lists.newArrayList();
       CredentialStoreModule module = new CredentialStoreModule();
       modules.add(module);
       ContextBuilder.addCredentialStoreIfNotPresent(modules);
@@ -180,7 +180,7 @@ public class ContextBuilderTest {
 
    @Test
    public void testAddNone() {
-      List<Module> modules = new ArrayList<Module>();
+      List<Module> modules = Lists.newArrayList();
       LoggingModule loggingModule = new NullLoggingModule();
       modules.add(loggingModule);
       HttpModule httpModule = new HttpModule();
@@ -202,7 +202,7 @@ public class ContextBuilderTest {
 
    @Test
    public void testAddBothWhenDefault() {
-      List<Module> modules = new ArrayList<Module>();
+      List<Module> modules = Lists.newArrayList();
       ContextBuilder.addHttpModuleIfNeededAndNotPresent(modules);
       ContextBuilder.addLoggingModuleIfNotPresent(modules);
       assertEquals(modules.size(), 2);
@@ -212,7 +212,7 @@ public class ContextBuilderTest {
 
    @Test
    public void testAddBothWhenLive() {
-      List<Module> modules = new ArrayList<Module>();
+      List<Module> modules = Lists.newArrayList();
       ContextBuilder.addHttpModuleIfNeededAndNotPresent(modules);
       ContextBuilder.addLoggingModuleIfNotPresent(modules);
       assertEquals(modules.size(), 2);

--- a/core/src/test/java/org/jclouds/date/DateServiceTest.java
+++ b/core/src/test/java/org/jclouds/date/DateServiceTest.java
@@ -20,7 +20,6 @@ package org.jclouds.date;
 
 import static org.testng.Assert.assertEquals;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -28,6 +27,7 @@ import org.jclouds.PerformanceTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.Lists;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 
@@ -205,7 +205,7 @@ public class DateServiceTest extends PerformanceTest {
 
    @Test
    void testFormatIso8601DateCorrectnessInParallel() throws Throwable {
-      List<Runnable> tasks = new ArrayList<Runnable>(testData.length);
+      List<Runnable> tasks = Lists.newArrayListWithCapacity(testData.length);
       for (final TestData myData : testData) {
          tasks.add(new Runnable() {
             public void run() {
@@ -219,7 +219,7 @@ public class DateServiceTest extends PerformanceTest {
 
    @Test
    void testFormatIso8601DatePerformanceInParallel() throws Throwable {
-      List<Runnable> tasks = new ArrayList<Runnable>(testData.length);
+      List<Runnable> tasks = Lists.newArrayListWithCapacity(testData.length);
       for (final TestData myData : testData) {
          tasks.add(new Runnable() {
             public void run() {
@@ -238,7 +238,7 @@ public class DateServiceTest extends PerformanceTest {
 
    @Test
    void testParseIso8601DateCorrectnessInParallel() throws Throwable {
-      List<Runnable> tasks = new ArrayList<Runnable>(testData.length);
+      List<Runnable> tasks = Lists.newArrayListWithCapacity(testData.length);
       for (final TestData myData : testData) {
          tasks.add(new Runnable() {
             public void run() {
@@ -252,7 +252,7 @@ public class DateServiceTest extends PerformanceTest {
 
    @Test
    void testParseIso8601DatePerformanceInParallel() throws Throwable {
-      List<Runnable> tasks = new ArrayList<Runnable>(testData.length);
+      List<Runnable> tasks = Lists.newArrayListWithCapacity(testData.length);
       for (final TestData myData : testData) {
          tasks.add(new Runnable() {
             public void run() {

--- a/core/src/test/java/org/jclouds/json/GsonExperimentsTest.java
+++ b/core/src/test/java/org/jclouds/json/GsonExperimentsTest.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -34,6 +33,7 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
@@ -75,7 +75,7 @@ public class GsonExperimentsTest {
    @BeforeTest
    void setupSource() {
       gson = new Gson();
-      Collection<Object> collection = new ArrayList<Object>();
+      Collection<Object> collection = Lists.newArrayList();
       collection.add("hello");
       collection.add(5);
       collection.add(new Event("GREETINGS", "guest"));

--- a/core/src/test/java/org/jclouds/json/internal/DeserializationConstructorAndReflectiveTypeAdapterFactoryTest.java
+++ b/core/src/test/java/org/jclouds/json/internal/DeserializationConstructorAndReflectiveTypeAdapterFactoryTest.java
@@ -26,8 +26,6 @@ import static org.testng.Assert.fail;
 
 import java.beans.ConstructorProperties;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -41,6 +39,8 @@ import org.testng.annotations.Test;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.gson.FieldNamingStrategy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -188,8 +188,8 @@ public final class DeserializationConstructorAndReflectiveTypeAdapterFactoryTest
 
       @Inject
       GenericParamsCopiedIn(@Named("foo") List<String> foo, @Named("bar") Map<String, String> bar) {
-         this.foo = new ArrayList<String>(foo);
-         this.bar = new HashMap<String, String>(bar);
+         this.foo = Lists.newArrayList(foo);
+         this.bar = Maps.newHashMap(bar);
       }
 
    }
@@ -197,9 +197,9 @@ public final class DeserializationConstructorAndReflectiveTypeAdapterFactoryTest
    public void testGenericParamsCopiedIn() throws IOException {
       TypeAdapter<GenericParamsCopiedIn> adapter = parameterizedCtorFactory.create(gson, TypeToken
             .get(GenericParamsCopiedIn.class));
-      List<String> inputFoo = new ArrayList<String>();
+      List<String> inputFoo = Lists.newArrayList();
       inputFoo.add("one");
-      HashMap<String, String> inputBar = new HashMap<String, String>();
+      Map<String, String> inputBar = Maps.newHashMap();
       inputBar.put("2", "two");
 
       GenericParamsCopiedIn toTest = adapter.fromJson("{ \"foo\":[\"one\"], \"bar\":{ \"2\":\"two\"}}");

--- a/core/src/test/java/org/jclouds/predicates/RetryablePredicateTest.java
+++ b/core/src/test/java/org/jclouds/predicates/RetryablePredicateTest.java
@@ -20,7 +20,6 @@ package org.jclouds.predicates;
 
 import static org.testng.Assert.fail;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -35,6 +34,7 @@ import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
+import com.google.common.collect.Lists;
 
 /**
  * 
@@ -160,7 +160,7 @@ public class RetryablePredicateTest {
    }
    
    public static class RepeatedAttemptsPredicate implements Predicate<String> {
-      final List<Long> callTimes = new ArrayList<Long>();
+      final List<Long> callTimes = Lists.newArrayList();
       private final int succeedOnAttempt;
       private final Stopwatch stopwatch;
       private int count = 0;

--- a/drivers/gae/src/test/java/org/jclouds/gae/ConvertToJcloudsResponseTest.java
+++ b/drivers/gae/src/test/java/org/jclouds/gae/ConvertToJcloudsResponseTest.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.ws.rs.core.HttpHeaders;
@@ -47,6 +46,7 @@ import org.testng.annotations.Test;
 import com.google.appengine.api.urlfetch.HTTPHeader;
 import com.google.appengine.api.urlfetch.HTTPResponse;
 import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
 
 /**
  * 
@@ -85,7 +85,7 @@ public class ConvertToJcloudsResponseTest {
    void testConvertWithHeaders() throws IOException {
       HTTPResponse gaeResponse = createMock(HTTPResponse.class);
       expect(gaeResponse.getResponseCode()).andReturn(200);
-      List<HTTPHeader> headers = new ArrayList<HTTPHeader>();
+      List<HTTPHeader> headers = Lists.newArrayList();
       headers.add(new HTTPHeader(HttpHeaders.CONTENT_TYPE, "text/xml"));
       expect(gaeResponse.getHeaders()).andReturn(headers);
       expect(gaeResponse.getContent()).andReturn(null).atLeastOnce();
@@ -100,7 +100,7 @@ public class ConvertToJcloudsResponseTest {
    void testConvertWithContent() throws IOException {
       HTTPResponse gaeResponse = createMock(HTTPResponse.class);
       expect(gaeResponse.getResponseCode()).andReturn(200);
-      List<HTTPHeader> headers = new ArrayList<HTTPHeader>();
+      List<HTTPHeader> headers = Lists.newArrayList();
       headers.add(new HTTPHeader(HttpHeaders.CONTENT_TYPE, "text/xml"));
       expect(gaeResponse.getHeaders()).andReturn(headers);
       expect(gaeResponse.getContent()).andReturn("hello".getBytes()).atLeastOnce();

--- a/drivers/jsch/src/test/java/org/jclouds/ssh/jsch/JschSshClientLiveTest.java
+++ b/drivers/jsch/src/test/java/org/jclouds/ssh/jsch/JschSshClientLiveTest.java
@@ -30,7 +30,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.net.InetAddress;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
@@ -51,6 +50,7 @@ import org.testng.annotations.Test;
 import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.Lists;
 import com.google.common.io.Closeables;
 import com.google.common.io.Files;
 import com.google.common.net.HostAndPort;
@@ -236,7 +236,7 @@ public class JschSshClientLiveTest {
    public void testExecHostnameConcurrentlyWithSameSessions() throws Exception {
       final SshClient client = setupClient();
       ListeningExecutorService executor = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(10));
-      List<ListenableFuture<ExecResponse>> futures = new ArrayList<ListenableFuture<ExecResponse>>();
+      List<ListenableFuture<ExecResponse>> futures = Lists.newArrayList();
       try {
          for (int i = 0; i < 100; i++) {
             futures.add(executor.submit(new Callable<ExecResponse>() {

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/DomainWrapper.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/DomainWrapper.java
@@ -24,7 +24,6 @@ import static com.google.common.collect.Iterables.transform;
 
 import java.lang.reflect.Constructor;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.jclouds.abiquo.AbiquoApi;
@@ -199,7 +198,7 @@ public abstract class DomainWrapper<T extends SingleResourceTransportDto> {
     * @return The async task array.
     */
    protected AsyncTask[] getTasks(final AcceptedRequestDto<String> acceptedRequest) {
-      List<AsyncTask> tasks = new ArrayList<AsyncTask>();
+      List<AsyncTask> tasks = Lists.newArrayList();
 
       for (RESTLink link : acceptedRequest.getLinks()) {
          // This will return null on untrackable tasks

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/enterprise/User.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/enterprise/User.java
@@ -22,7 +22,6 @@ package org.jclouds.abiquo.domain.enterprise;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Iterables.filter;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
 
@@ -155,7 +154,7 @@ public class User extends DomainWrapper<UserDto> {
     *           List of virtual datacenters from the user's enterprise.
     */
    public void setPermittedVirtualDatacenters(final List<VirtualDatacenter> vdcs) {
-      List<Integer> ids = new ArrayList<Integer>();
+      List<Integer> ids = Lists.newArrayList();
 
       for (VirtualDatacenter vdc : vdcs) {
          checkNotNull(vdc.getId(), ValidationErrors.MISSING_REQUIRED_FIELD + " id in " + VirtualDatacenter.class);

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/EnterpriseResources.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/EnterpriseResources.java
@@ -21,7 +21,6 @@ package org.jclouds.abiquo.domain;
 
 import static org.jclouds.abiquo.domain.DomainUtils.link;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import com.abiquo.model.rest.RESTLink;
@@ -30,6 +29,7 @@ import com.abiquo.server.core.enterprise.DatacenterLimitsDto;
 import com.abiquo.server.core.enterprise.EnterpriseDto;
 import com.abiquo.server.core.enterprise.EnterprisePropertiesDto;
 import com.abiquo.server.core.enterprise.UserDto;
+import com.google.common.collect.Maps;
 
 /**
  * Enterprise domain utilities.
@@ -71,7 +71,7 @@ public class EnterpriseResources {
    public static EnterprisePropertiesDto enterprisePropertiesPut() {
       EnterprisePropertiesDto enterpriseProp = new EnterprisePropertiesDto();
       enterpriseProp.setId(1);
-      Map<String, String> props = new HashMap<String, String>();
+      Map<String, String> props = Maps.newHashMap();
       props.put("key", "value");
       enterpriseProp.setProperties(props);
       enterpriseProp.addLink(new RESTLink("edit", "http://localhost/api/admin/enterprises/1/properties"));

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/cloud/VirtualApplianceLiveApiTest.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/cloud/VirtualApplianceLiveApiTest.java
@@ -24,7 +24,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.jclouds.abiquo.internal.BaseAbiquoApiLiveApiTest;
@@ -32,6 +31,7 @@ import org.testng.annotations.Test;
 
 import com.abiquo.server.core.cloud.VirtualApplianceDto;
 import com.abiquo.server.core.cloud.VirtualApplianceState;
+import com.google.common.collect.Lists;
 
 /**
  * Live integration tests for the {@link VirtualAppliance} domain class.
@@ -69,7 +69,7 @@ public class VirtualApplianceLiveApiTest extends BaseAbiquoApiLiveApiTest {
    }
 
    public void testListVirtualMachinesReturnsAll() {
-      List<VirtualMachine> vms = new ArrayList<VirtualMachine>();
+      List<VirtualMachine> vms = Lists.newArrayList();
 
       // Pagination by default is set to 25 items per page, so create a few more
       // to verify that

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/config/CostCodeLiveApiTest.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/config/CostCodeLiveApiTest.java
@@ -26,10 +26,11 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.ws.rs.core.Response.Status;
+
+import com.google.common.collect.Lists;
 
 import org.jclouds.abiquo.domain.exception.AbiquoException;
 import org.jclouds.abiquo.internal.BaseAbiquoApiLiveApiTest;
@@ -99,7 +100,7 @@ public class CostCodeLiveApiTest extends BaseAbiquoApiLiveApiTest {
             .description("description").build();
 
       costcodeprice = new CostCodePrice(currency, new BigDecimal(100));
-      this.defaultPrices = new ArrayList<CostCodePrice>();
+      this.defaultPrices = Lists.newArrayList();
       defaultPrices.add(costcodeprice);
       costcode2.setDefaultPrices(defaultPrices);
       // When a cost code is created it is also created a costcodecurrency with

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/strategy/cloud/ListVirtualMachinesLiveApiTest.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/strategy/cloud/ListVirtualMachinesLiveApiTest.java
@@ -24,8 +24,9 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-import java.util.ArrayList;
 import java.util.List;
+
+import com.google.common.collect.Lists;
 
 import org.jclouds.abiquo.domain.cloud.VirtualMachine;
 import org.jclouds.abiquo.predicates.cloud.VirtualMachinePredicates;
@@ -69,7 +70,7 @@ public class ListVirtualMachinesLiveApiTest extends BaseAbiquoStrategyLiveApiTes
    }
 
    public void testExecuteWhenExceedsPagination() {
-      List<VirtualMachine> vms = new ArrayList<VirtualMachine>();
+      List<VirtualMachine> vms = Lists.newArrayList();
 
       // Pagination by default is set to 25 items per page, so create a few more
       // to verify that

--- a/labs/azure-management/src/main/java/org/jclouds/azure/management/domain/DeploymentParams.java
+++ b/labs/azure-management/src/main/java/org/jclouds/azure/management/domain/DeploymentParams.java
@@ -1,10 +1,10 @@
 package org.jclouds.azure.management.domain;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
+import com.google.common.collect.Lists;
 
 /**
  * 
@@ -34,7 +34,7 @@ public class DeploymentParams {
 		protected String storageAccount;
 		protected OSType osType;
 		protected RoleSize size = RoleSize.SMALL;
-		protected List<InputEndpoint> endpoints = new ArrayList<InputEndpoint>();
+		protected List<InputEndpoint> endpoints = Lists.newArrayList();
 
 		public Builder name(String name) {
 			this.name = name;

--- a/labs/azure-management/src/main/java/org/jclouds/azure/management/domain/hostedservice/CreateDeployment.java
+++ b/labs/azure-management/src/main/java/org/jclouds/azure/management/domain/hostedservice/CreateDeployment.java
@@ -1,11 +1,12 @@
 package org.jclouds.azure.management.domain.hostedservice;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.collect.Lists;
 
 @XmlRootElement(name = "CreateDeployment")
 public class CreateDeployment {
@@ -65,7 +66,7 @@ public class CreateDeployment {
 
    @XmlElementWrapper(name = "ExtendedProperties")
    @XmlElement(required = true, name = "ExtendedProperty")
-   private List<ExtendedProperty> extendedProperties = new ArrayList<ExtendedProperty>();
+   private List<ExtendedProperty> extendedProperties = Lists.newArrayList();
 
    public CreateDeployment() {
    }

--- a/labs/azure-management/src/main/java/org/jclouds/azure/management/domain/role/AbstractRole.java
+++ b/labs/azure-management/src/main/java/org/jclouds/azure/management/domain/role/AbstractRole.java
@@ -1,10 +1,11 @@
 package org.jclouds.azure.management.domain.role;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
+
+import com.google.common.collect.Lists;
 
 import org.jclouds.azure.management.domain.role.conf.ConfigurationSet;
 
@@ -32,7 +33,7 @@ public abstract class AbstractRole {
     */
    @XmlElementWrapper(name = "ConfigurationSets")
    @XmlElement(name = "ConfigurationSet")
-   private List<ConfigurationSet> configurationSets = new ArrayList<ConfigurationSet>(0);
+   private List<ConfigurationSet> configurationSets = Lists.newArrayListWithCapacity(0);
    
    /**
     * Specifies the name of an availability set to which to add the virtual machine. This value
@@ -45,7 +46,7 @@ public abstract class AbstractRole {
 
    @XmlElementWrapper(name = "DataVirtualHardDisks")
    @XmlElement(name = "DataVirtualHardDisk")
-   private List<DataVirtualHardDisk> dataVirtualHardDisks = new ArrayList<DataVirtualHardDisk>(0);
+   private List<DataVirtualHardDisk> dataVirtualHardDisks = Lists.newArrayListWithCapacity(0);
    
    @XmlElement(name = "OSVirtualHardDisk")
    private OSVirtualHardDisk osVirtualHardDisk;

--- a/labs/azure-management/src/main/java/org/jclouds/azure/management/domain/role/DNS.java
+++ b/labs/azure-management/src/main/java/org/jclouds/azure/management/domain/role/DNS.java
@@ -1,11 +1,12 @@
 package org.jclouds.azure.management.domain.role;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.collect.Lists;
 
 @XmlRootElement(name = "Dns")
 public class DNS {
@@ -14,7 +15,7 @@ public class DNS {
     */
    @XmlElementWrapper(required = true, name = "DnsServers")
    @XmlElement(name = "DnsServer")
-   private List<DNSServer> dnsServers = new ArrayList<DNSServer>();
+   private List<DNSServer> dnsServers = Lists.newArrayList();
 
    public DNS() {
       super();

--- a/labs/azure-management/src/main/java/org/jclouds/azure/management/domain/role/Deployment.java
+++ b/labs/azure-management/src/main/java/org/jclouds/azure/management/domain/role/Deployment.java
@@ -1,11 +1,12 @@
 package org.jclouds.azure.management.domain.role;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.collect.Lists;
 
 @XmlRootElement(name = "Deployment")
 public class Deployment {
@@ -37,7 +38,7 @@ public class Deployment {
 
    @XmlElementWrapper(required = true, name = "RoleList")
    @XmlElement(required = true, name = "Role")
-   private List<Role> roleList = new ArrayList<Role>();
+   private List<Role> roleList = Lists.newArrayList();
 
    /**
     * Specifies the name of an existing virtual network to which the deployment will belong.

--- a/labs/azure-management/src/main/java/org/jclouds/azure/management/domain/role/conf/ConfigurationSetAdapter.java
+++ b/labs/azure-management/src/main/java/org/jclouds/azure/management/domain/role/conf/ConfigurationSetAdapter.java
@@ -1,12 +1,13 @@
 package org.jclouds.azure.management.domain.role.conf;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+import com.google.common.collect.Lists;
 
 public class ConfigurationSetAdapter extends
          XmlAdapter<ConfigurationSetAdapter.AdaptedConfigurationSet, ConfigurationSet> {
@@ -119,15 +120,15 @@ public class ConfigurationSetAdapter extends
 
       @XmlElementWrapper(required = true, name = "StoredCertificateSettings")
       @XmlElement(name = "CertificateSetting")
-      public List<CertificateSetting> storedCertificateSettings = new ArrayList<CertificateSetting>();
+      public List<CertificateSetting> storedCertificateSettings = Lists.newArrayList();
 
       @XmlElementWrapper(name = "InputEndpoints")
       @XmlElement(name = "InputEndpoint")
-      public List<InputEndpoint> inputEndpoints = new ArrayList<InputEndpoint>(0);
+      public List<InputEndpoint> inputEndpoints = Lists.newArrayListWithCapacity(0);
 
       @XmlElementWrapper(name = "SubnetNames")
       @XmlElement(name = "SubnetName")
-      public List<String> subnetNames = new ArrayList<String>(0);
+      public List<String> subnetNames = Lists.newArrayListWithCapacity(0);
    }
 
 }

--- a/labs/azure-management/src/main/java/org/jclouds/azure/management/domain/role/conf/NetworkConfiguration.java
+++ b/labs/azure-management/src/main/java/org/jclouds/azure/management/domain/role/conf/NetworkConfiguration.java
@@ -1,7 +1,8 @@
 package org.jclouds.azure.management.domain.role.conf;
 
-import java.util.ArrayList;
 import java.util.List;
+
+import com.google.common.collect.Lists;
 
 //@XmlRootElement(name = "ConfigurationSet")
 public class NetworkConfiguration extends ConfigurationSet {
@@ -13,14 +14,14 @@ public class NetworkConfiguration extends ConfigurationSet {
     */
    // @XmlElementWrapper(name = "InputEndpoints")
    // @XmlElement(name = "InputEndpoint")
-   private List<InputEndpoint> inputEndpoints = new ArrayList<InputEndpoint>(0);
+   private List<InputEndpoint> inputEndpoints = Lists.newArrayListWithCapacity(0);
 
    /**
     * Specifies the name of a subnet to which the virtual machine belongs.
     */
    // @XmlElementWrapper(name = "SubnetNames")
    // @XmlElement(name = "SubnetName")
-   private List<String> subnetNames = new ArrayList<String>(0);
+   private List<String> subnetNames = Lists.newArrayListWithCapacity(0);
 
    public NetworkConfiguration() {
       setConfigurationSetType(ID);

--- a/labs/azure-management/src/main/java/org/jclouds/azure/management/domain/role/conf/SSH.java
+++ b/labs/azure-management/src/main/java/org/jclouds/azure/management/domain/role/conf/SSH.java
@@ -1,11 +1,12 @@
 package org.jclouds.azure.management.domain.role.conf;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.collect.Lists;
 
 @XmlRootElement(name = "SSH")
 public class SSH {
@@ -15,14 +16,14 @@ public class SSH {
     */
    @XmlElementWrapper(name = "PublicKeys")
    @XmlElement(name = "PublicKey")
-   private List<PublicKey> publicKeys = new ArrayList<PublicKey>(0);
+   private List<PublicKey> publicKeys = Lists.newArrayListWithCapacity(0);
 
    /**
     * Specifies the public key.
     */
    @XmlElementWrapper(name = "KeyPairs")
    @XmlElement(name = "KeyPair")
-   private List<KeyPair> keyPairs = new ArrayList<KeyPair>(0);
+   private List<KeyPair> keyPairs = Lists.newArrayListWithCapacity(0);
 
    public SSH() {
    }

--- a/labs/azure-management/src/main/java/org/jclouds/azure/management/domain/role/conf/WindowsProvisioningConfiguration.java
+++ b/labs/azure-management/src/main/java/org/jclouds/azure/management/domain/role/conf/WindowsProvisioningConfiguration.java
@@ -1,8 +1,9 @@
 package org.jclouds.azure.management.domain.role.conf;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
+
+import com.google.common.collect.Lists;
 
 //@XmlRootElement(name = "ConfigurationSet")
 public class WindowsProvisioningConfiguration extends ConfigurationSet {
@@ -50,7 +51,7 @@ public class WindowsProvisioningConfiguration extends ConfigurationSet {
     */
    // @XmlElementWrapper(required = true, name = "StoredCertificateSettings")
    // @XmlElement(name = "CertificateSetting")
-   private List<CertificateSetting> storedCertificateSettings = new ArrayList<CertificateSetting>();
+   private List<CertificateSetting> storedCertificateSettings = Lists.newArrayList();
 
    public WindowsProvisioningConfiguration() {
 

--- a/labs/azure-management/src/main/java/org/jclouds/azure/management/xml/DeploymentHandler.java
+++ b/labs/azure-management/src/main/java/org/jclouds/azure/management/xml/DeploymentHandler.java
@@ -22,8 +22,9 @@ import static org.jclouds.util.SaxUtils.currentOrNull;
 import static org.jclouds.util.SaxUtils.equalsOrSuffix;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.List;
+
+import com.google.common.collect.Lists;
 
 import org.jclouds.azure.management.domain.Deployment;
 import org.jclouds.azure.management.domain.DeploymentSlot;
@@ -42,7 +43,7 @@ import org.xml.sax.SAXException;
 public class DeploymentHandler extends
 		ParseSax.HandlerForGeneratedRequestWithResult<Deployment> {
 
-	private List<String> elements = new ArrayList<String>();
+	private List<String> elements = Lists.newArrayList();
 	protected StringBuilder currentText = new StringBuilder();
 	private Deployment.Builder builder = Deployment.builder();
 

--- a/labs/cdmi/src/main/java/org/jclouds/snia/cdmi/v1/domain/CDMIObject.java
+++ b/labs/cdmi/src/main/java/org/jclouds/snia/cdmi/v1/domain/CDMIObject.java
@@ -21,8 +21,6 @@ package org.jclouds.snia.cdmi.v1.domain;
 import static com.google.common.base.Objects.equal;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +31,7 @@ import org.jclouds.javax.annotation.Nullable;
 import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 /**
@@ -190,9 +189,9 @@ public class CDMIObject {
     * 
     */
    private void parseMetadata() {
-      userMetaDataIn = new HashMap<String, String>();
-      systemMetaDataIn = new HashMap<String, String>();
-      aclMetaDataIn = new ArrayList<Map<String, String>>();
+      userMetaDataIn = Maps.newHashMap();
+      systemMetaDataIn = Maps.newHashMap();
+      aclMetaDataIn = Lists.newArrayList();
       Iterator<String> keys = metadata.keySet().iterator();
       while (keys.hasNext()) {
          String key = keys.next();
@@ -203,7 +202,7 @@ public class CDMIObject {
                for (int i = 0; i < cdmi_acl_array.length; i++) {
                   if (!(cdmi_acl_array[i].startsWith("[") || cdmi_acl_array[i].startsWith("]") || cdmi_acl_array[i]
                            .startsWith(","))) {
-                     HashMap<String, String> aclMap = new HashMap<String, String>();
+                     Map<String, String> aclMap = Maps.newHashMap();
                      String[] cdmi_acl_member = cdmi_acl_array[i].split(",");
                      for (String s : cdmi_acl_member) {
                         String cdmi_acl_key = s.substring(0, s.indexOf(":"));

--- a/labs/cdmi/src/test/java/org/jclouds/snia/cdmi/v1/features/ContainerApiLiveTest.java
+++ b/labs/cdmi/src/test/java/org/jclouds/snia/cdmi/v1/features/ContainerApiLiveTest.java
@@ -21,11 +21,12 @@ package org.jclouds.snia.cdmi.v1.features;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
+
+import com.google.common.collect.Maps;
 
 import org.jclouds.domain.JsonBall;
 import org.jclouds.snia.cdmi.v1.ObjectTypes;
@@ -46,7 +47,7 @@ public class ContainerApiLiveTest extends BaseCDMIApiLiveTest {
    @Test
    public void testCreateContainer() throws Exception {
       String pContainerName = "MyContainer" + System.currentTimeMillis() + "/";
-      Map<String, String> pContainerMetaDataIn = new HashMap<String, String>();
+      Map<String, String> pContainerMetaDataIn = Maps.newHashMap();
       Iterator<String> keys;
       pContainerMetaDataIn.put("containerkey1", "value1");
       pContainerMetaDataIn.put("containerkey2", "value2");
@@ -134,7 +135,7 @@ public class ContainerApiLiveTest extends BaseCDMIApiLiveTest {
    @Test
    public void testGetContainer() throws Exception {
       String pContainerName = "MyContainer" + System.currentTimeMillis() + "/";
-      Map<String, String> pContainerMetaDataIn = new HashMap<String, String>();
+      Map<String, String> pContainerMetaDataIn = Maps.newHashMap();
       Iterator<String> keys;
       pContainerMetaDataIn.put("containerkey1", "value1");
       pContainerMetaDataIn.put("containerkey2", "value2");

--- a/labs/cdmi/src/test/java/org/jclouds/snia/cdmi/v1/features/DataApiLiveTest.java
+++ b/labs/cdmi/src/test/java/org/jclouds/snia/cdmi/v1/features/DataApiLiveTest.java
@@ -27,9 +27,7 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.logging.Logger;
 
@@ -42,6 +40,7 @@ import org.jclouds.snia.cdmi.v1.queryparams.DataObjectQueryParams;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Charsets;
+import com.google.common.collect.Maps;
 import com.google.common.io.CharStreams;
 import com.google.common.io.Files;
 
@@ -69,8 +68,8 @@ public class DataApiLiveTest extends BaseCDMIApiLiveTest {
       DataObject dataObject;
       Iterator<String> keys;
       Map<String, String> dataObjectMetaDataOut;
-      Map<String, String> pContainerMetaDataIn = new HashMap<String, String>();
-      Map<String, String> pDataObjectMetaDataIn = new LinkedHashMap<String, String>();
+      Map<String, String> pContainerMetaDataIn = Maps.newHashMap();
+      Map<String, String> pDataObjectMetaDataIn = Maps.newLinkedHashMap();
       pDataObjectMetaDataIn.put("dataObjectkey1", "value1");
       pDataObjectMetaDataIn.put("dataObjectkey2", "value2");
       pDataObjectMetaDataIn.put("dataObjectkey3", "value3");
@@ -487,8 +486,8 @@ public class DataApiLiveTest extends BaseCDMIApiLiveTest {
       DataObject dataObject;
       Iterator<String> keys;
       Map<String, String> dataObjectMetaDataOut;
-      Map<String, String> pContainerMetaDataIn = new HashMap<String, String>();
-      Map<String, String> pDataObjectMetaDataIn = new LinkedHashMap<String, String>();
+      Map<String, String> pContainerMetaDataIn = Maps.newHashMap();
+      Map<String, String> pDataObjectMetaDataIn = Maps.newLinkedHashMap();
       pDataObjectMetaDataIn.put("dataObjectkey1", "value1");
       pDataObjectMetaDataIn.put("dataObjectkey2", "value2");
       pDataObjectMetaDataIn.put("dataObjectkey3", "value3");

--- a/labs/cdmi/src/test/java/org/jclouds/snia/cdmi/v1/features/DataNonCDMIContentTypeApiLiveTest.java
+++ b/labs/cdmi/src/test/java/org/jclouds/snia/cdmi/v1/features/DataNonCDMIContentTypeApiLiveTest.java
@@ -26,8 +26,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.logging.Logger;
 
@@ -46,6 +44,7 @@ import org.jclouds.util.Strings2;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Charsets;
+import com.google.common.collect.Maps;
 import com.google.common.io.CharStreams;
 import com.google.common.io.Files;
 import com.google.common.net.MediaType;
@@ -68,8 +67,8 @@ public class DataNonCDMIContentTypeApiLiveTest extends BaseCDMIApiLiveTest {
       Files.touch(tmpFileIn);
       byte[] bytes;
       DataObject dataObject;
-      Map<String, String> pContainerMetaDataIn = new HashMap<String, String>();
-      Map<String, String> pDataObjectMetaDataIn = new LinkedHashMap<String, String>();
+      Map<String, String> pContainerMetaDataIn = Maps.newHashMap();
+      Map<String, String> pDataObjectMetaDataIn = Maps.newLinkedHashMap();
       pDataObjectMetaDataIn.put("dataObjectkey1", "value1");
       pDataObjectMetaDataIn.put("dataObjectkey2", "value2");
       pDataObjectMetaDataIn.put("dataObjectkey3", "value3");

--- a/labs/dmtf/src/main/java/org/jclouds/dmtf/cim/CimReference.java
+++ b/labs/dmtf/src/main/java/org/jclouds/dmtf/cim/CimReference.java
@@ -20,8 +20,6 @@ package org.jclouds.dmtf.cim;
 
 import static org.jclouds.dmtf.DMTFConstants.CIM_NS;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -29,6 +27,9 @@ import javax.xml.bind.annotation.XmlAnyAttribute;
 import javax.xml.bind.annotation.XmlAnyElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 /**
  * Java class for cimReference complex type.
@@ -43,7 +44,7 @@ public class CimReference {
     @XmlAnyElement(lax = true)
     protected List<Object> any;
     @XmlAnyAttribute
-    private Map<QName, String> otherAttributes = new HashMap<QName, String>();
+    private Map<QName, String> otherAttributes = Maps.newHashMap();
 
     /**
      * Gets the value of the any property.
@@ -70,7 +71,7 @@ public class CimReference {
      */
     public List<Object> getAny() {
         if (any == null) {
-            any = new ArrayList<Object>();
+            any = Lists.newArrayList();
         }
         return this.any;
     }

--- a/labs/dmtf/src/main/java/org/jclouds/dmtf/ovf/Item.java
+++ b/labs/dmtf/src/main/java/org/jclouds/dmtf/ovf/Item.java
@@ -20,7 +20,6 @@ package org.jclouds.dmtf.ovf;
 
 import static com.google.common.base.Objects.equal;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import javax.xml.bind.annotation.XmlAnyAttribute;
@@ -31,6 +30,7 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
 
 import com.google.common.base.Objects;
+import com.google.common.collect.Maps;
 
 /**
  * Java class for anonymous complex type.
@@ -78,7 +78,7 @@ public class Item {
     @XmlAttribute
     protected String stopAction;
     @XmlAnyAttribute
-    private Map<QName, String> otherAttributes = new HashMap<QName, String>();
+    private Map<QName, String> otherAttributes = Maps.newHashMap();
 
     /**
      * Gets the value of the id property.

--- a/labs/dmtf/src/main/java/org/jclouds/dmtf/ovf/environment/Property.java
+++ b/labs/dmtf/src/main/java/org/jclouds/dmtf/ovf/environment/Property.java
@@ -20,8 +20,9 @@ package org.jclouds.dmtf.ovf.environment;
 
 import static org.jclouds.dmtf.DMTFConstants.OVF_ENV_NS;
 
-import java.util.HashMap;
 import java.util.Map;
+
+import com.google.common.collect.Maps;
 
 import javax.xml.bind.annotation.XmlAnyAttribute;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -39,7 +40,7 @@ public class Property {
     @XmlAttribute(namespace = OVF_ENV_NS, required = true)
     protected String value;
     @XmlAnyAttribute
-    private Map<QName, String> otherAttributes = new HashMap<QName, String>();
+    private Map<QName, String> otherAttributes = Maps.newHashMap();
 
     /**
      * Gets the value of the key property.

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/compute/functions/VServerMetadataToNodeMetadata.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/compute/functions/VServerMetadataToNodeMetadata.java
@@ -20,7 +20,6 @@ package org.jclouds.fujitsu.fgcp.compute.functions;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -53,6 +52,7 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 
 /**
  * @author Dies Koper
@@ -228,7 +228,7 @@ public class VServerMetadataToNodeMetadata implements
 
             VServerWithVNICs server = (VServerWithVNICs) from.getServer();
             builder.location(parseLocation(server));
-            List<String> ips = new ArrayList<String>();
+            List<String> ips = Lists.newArrayList();
             if (server.getVnics() != null && server.getVnics().iterator().next().getPrivateIp() != null) {
                ips.add(server.getVnics().iterator().next().getPrivateIp());
             }

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/compute/strategy/FGCPComputeServiceAdapter.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/compute/strategy/FGCPComputeServiceAdapter.java
@@ -20,7 +20,6 @@ package org.jclouds.fujitsu.fgcp.compute.strategy;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -57,6 +56,7 @@ import org.jclouds.predicates.RetryablePredicate;
 import com.google.common.base.Predicate;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -172,7 +172,7 @@ public class FGCPComputeServiceAdapter implements
       Builder builder = VServerMetadata.builder();
       builder.id(id);
 
-      List<ListenableFuture<?>> futures = new ArrayList<ListenableFuture<?>>();
+      List<ListenableFuture<?>> futures = Lists.newArrayList();
 
       futures.add(asyncApi.getVirtualServerApi().getDetails(id));
       futures.add(asyncApi.getVirtualServerApi().getStatus(id));
@@ -216,7 +216,7 @@ public class FGCPComputeServiceAdapter implements
             .<VServerMetadata> builder();
 
       Set<VSystem> systems = api.getVirtualDCApi().listVirtualSystems();
-      List<ListenableFuture<VSystemWithDetails>> futures = new ArrayList<ListenableFuture<VSystemWithDetails>>();
+      List<ListenableFuture<VSystemWithDetails>> futures = Lists.newArrayList();
       for (VSystem system : systems) {
 
          futures.add(asyncApi.getVirtualSystemApi().getDetails(

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/Direction.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/Direction.java
@@ -18,11 +18,11 @@
  */
 package org.jclouds.fujitsu.fgcp.domain;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * Grouping of firewall rules pertaining to a particular direction in network
@@ -34,7 +34,7 @@ import com.google.common.collect.ImmutableSet;
 public class Direction {
    private String from;
    private String to;
-   private Set<Policy> policies = new LinkedHashSet<Policy>();
+   private Set<Policy> policies = Sets.newLinkedHashSet();
    private Acceptable acceptable;
    private Prefix prefix;
    private int maxPolicyNum;

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/DiskImage.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/DiskImage.java
@@ -18,7 +18,6 @@
  */
 package org.jclouds.fujitsu.fgcp.domain;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -27,6 +26,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * Represents a disk image with pre-installed OS and/or software.
@@ -59,7 +59,7 @@ public class DiskImage {
 
    @XmlElementWrapper(name = "softwares")
    @XmlElement(name = "software")
-   private Set<Software> software = new LinkedHashSet<Software>();
+   private Set<Software> software = Sets.newLinkedHashSet();
 
    public String getId() {
       return id;

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/ErrorStatistics.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/ErrorStatistics.java
@@ -18,12 +18,12 @@
  */
 package org.jclouds.fujitsu.fgcp.domain;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * Holds statistics of errors reported by a load balancer (SLB).
@@ -33,7 +33,7 @@ import com.google.common.collect.ImmutableSet;
 @XmlRootElement(name = "errorstatistics")
 public class ErrorStatistics {
    private Period period;
-   private Set<Group> groups = new LinkedHashSet<Group>();
+   private Set<Group> groups = Sets.newLinkedHashSet();
 
    /**
     * @return the period

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/Firewall.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/Firewall.java
@@ -18,12 +18,12 @@
  */
 package org.jclouds.fujitsu.fgcp.domain;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * Represents a firewall (FW).
@@ -33,7 +33,7 @@ import com.google.common.collect.ImmutableSet;
 @XmlRootElement(name = "fw")
 public class Firewall {
    private NAT nat;
-   private Set<Direction> directions = new LinkedHashSet<Direction>();
+   private Set<Direction> directions = Sets.newLinkedHashSet();
    private String log;
    private String status;
    private String category;

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/Group.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/Group.java
@@ -18,13 +18,13 @@
  */
 package org.jclouds.fujitsu.fgcp.domain;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlEnumValue;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * Describes attributes of a software load balancer's (SLB) configuration.
@@ -62,7 +62,7 @@ public class Group {
 
    private RecoveryAction recoveryAction;
 
-   private Set<Target> targets = new LinkedHashSet<Target>();
+   private Set<Target> targets = Sets.newLinkedHashSet();
 
    private String validity;
 

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/Image.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/Image.java
@@ -18,7 +18,6 @@
  */
 package org.jclouds.fujitsu.fgcp.domain;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -26,6 +25,7 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * Holds information on the system disk image of a virtual server, including the
@@ -50,7 +50,7 @@ public class Image {
 
    @XmlElementWrapper(name = "softwares")
    @XmlElement(name = "software")
-   private Set<Software> software = new LinkedHashSet<Software>();
+   private Set<Software> software = Sets.newLinkedHashSet();
 
    public String getId() {
       return id;

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/LoadStatistics.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/LoadStatistics.java
@@ -18,13 +18,13 @@
  */
 package org.jclouds.fujitsu.fgcp.domain;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * Holds statistics of the load on a load balancer (SLB).
@@ -33,7 +33,7 @@ import com.google.common.collect.ImmutableSet;
  */
 @XmlRootElement(name = "loadstatistics")
 public class LoadStatistics {
-   private Set<Group> groups = new LinkedHashSet<Group>();
+   private Set<Group> groups = Sets.newLinkedHashSet();
 
    /**
     * @return the groups

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/NAT.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/NAT.java
@@ -18,11 +18,11 @@
  */
 package org.jclouds.fujitsu.fgcp.domain;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * Holds the network address translation rules of a firewall.
@@ -30,7 +30,7 @@ import com.google.common.collect.ImmutableSet;
  * @author Dies Koper
  */
 public class NAT {
-   private Set<Rule> rules = new LinkedHashSet<Rule>();
+   private Set<Rule> rules = Sets.newLinkedHashSet();
 
    /**
     * @return the rules

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/SLB.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/SLB.java
@@ -18,12 +18,12 @@
  */
 package org.jclouds.fujitsu.fgcp.domain;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * Represents a software load balancer.
@@ -34,9 +34,9 @@ import com.google.common.collect.ImmutableSet;
 public class SLB extends BuiltinServer {
    private String ipAddress;
 
-   private Set<IntermediateCACert> ccacerts = new LinkedHashSet<IntermediateCACert>();
+   private Set<IntermediateCACert> ccacerts = Sets.newLinkedHashSet();
 
-   private Set<ServerCert> servercerts = new LinkedHashSet<ServerCert>();
+   private Set<ServerCert> servercerts = Sets.newLinkedHashSet();
 
    private Set<Group> groups;
 

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/UsageInfo.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/UsageInfo.java
@@ -18,7 +18,6 @@
  */
 package org.jclouds.fujitsu.fgcp.domain;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -27,6 +26,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * Describes the usage by a virtual system.
@@ -42,7 +42,7 @@ public class UsageInfo {
 
    @XmlElementWrapper(name = "products")
    @XmlElement(name = "product")
-   private Set<Product> products = new LinkedHashSet<Product>();
+   private Set<Product> products = Sets.newLinkedHashSet();
 
    /**
     * @return the systemId

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/VServerWithDetails.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/VServerWithDetails.java
@@ -18,7 +18,6 @@
  */
 package org.jclouds.fujitsu.fgcp.domain;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -27,6 +26,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * Represents a virtual server with virtual storage and NICs.
@@ -37,7 +37,7 @@ import com.google.common.collect.ImmutableSet;
 public class VServerWithDetails extends VServerWithVNICs {
    @XmlElementWrapper(name = "vdisks")
    @XmlElement(name = "vdisk")
-   protected Set<VDisk> vdisks = new LinkedHashSet<VDisk>();
+   protected Set<VDisk> vdisks = Sets.newLinkedHashSet();
    protected Image image;
 
    public Set<VDisk> getVdisks() {

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/VServerWithVNICs.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/VServerWithVNICs.java
@@ -1,6 +1,5 @@
 package org.jclouds.fujitsu.fgcp.domain;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -8,12 +7,13 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 public class VServerWithVNICs extends VServer {
 
    @XmlElementWrapper(name = "vnics")
    @XmlElement(name = "vnic")
-   protected Set<VNIC> vnics = new LinkedHashSet<VNIC>();
+   protected Set<VNIC> vnics = Sets.newLinkedHashSet();
 
    public Set<VNIC> getVnics() {
       return vnics == null ? ImmutableSet.<VNIC> of() : ImmutableSet

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/VSystemDescriptor.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/VSystemDescriptor.java
@@ -18,7 +18,6 @@
  */
 package org.jclouds.fujitsu.fgcp.domain;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -26,6 +25,7 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * Describes a virtual system template.
@@ -50,7 +50,7 @@ public class VSystemDescriptor {
 
    @XmlElementWrapper(name = "vservers")
    @XmlElement(name = "vserver")
-   private Set<VServerWithDetails> servers = new LinkedHashSet<VServerWithDetails>();
+   private Set<VServerWithDetails> servers = Sets.newLinkedHashSet();
 
    /**
     * @return the id

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/VSystemWithDetails.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/domain/VSystemWithDetails.java
@@ -18,7 +18,6 @@
  */
 package org.jclouds.fujitsu.fgcp.domain;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -27,6 +26,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * Represents a virtual system with servers, additional storage, public IP
@@ -38,16 +38,16 @@ import com.google.common.collect.ImmutableSet;
 public class VSystemWithDetails extends VSystem {
    @XmlElementWrapper(name = "vservers")
    @XmlElement(name = "vserver")
-   private Set<VServerWithVNICs> servers = new LinkedHashSet<VServerWithVNICs>();
+   private Set<VServerWithVNICs> servers = Sets.newLinkedHashSet();
    @XmlElementWrapper(name = "vdisks")
    @XmlElement(name = "vdisk")
-   private Set<VDisk> disks = new LinkedHashSet<VDisk>();
+   private Set<VDisk> disks = Sets.newLinkedHashSet();
    @XmlElementWrapper(name = "publicips")
    @XmlElement(name = "publicip")
-   private Set<PublicIP> publicips = new LinkedHashSet<PublicIP>();
+   private Set<PublicIP> publicips = Sets.newLinkedHashSet();
    @XmlElementWrapper(name = "vnets")
    @XmlElement(name = "vnet")
-   private Set<VNet> networks = new LinkedHashSet<VNet>();
+   private Set<VNet> networks = Sets.newLinkedHashSet();
 
    public Set<VServerWithVNICs> getServers() {
       return servers == null ? ImmutableSet.<VServerWithVNICs> of() : ImmutableSet

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/location/SystemAndNetworkSegmentToLocationSupplier.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/location/SystemAndNetworkSegmentToLocationSupplier.java
@@ -20,7 +20,6 @@ package org.jclouds.fujitsu.fgcp.location;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -42,6 +41,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -83,7 +83,7 @@ public class SystemAndNetworkSegmentToLocationSupplier implements
    public Set<Location> get() {
       Builder<Location> locations = ImmutableSet.builder();
       try {
-         List<ListenableFuture<VSystemWithDetails>> futures = new ArrayList<ListenableFuture<VSystemWithDetails>>();
+         List<ListenableFuture<VSystemWithDetails>> futures = Lists.newArrayList();
          for (VSystem system : api.getVirtualDCApi().listVirtualSystems()
                .get()) {
 

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/xml/internal/GetAddressRangeResponse.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/xml/internal/GetAddressRangeResponse.java
@@ -19,7 +19,6 @@
 package org.jclouds.fujitsu.fgcp.xml.internal;
 
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -29,6 +28,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import org.jclouds.fujitsu.fgcp.domain.AddressRange;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * Wrapper for GetAddressRangeResponse.
@@ -40,7 +40,7 @@ public class GetAddressRangeResponse extends
       SetWithStatusResponse<AddressRange> {
    @XmlElementWrapper(name = "addressranges")
    @XmlElement(name = "addressrange")
-   private Set<AddressRange> ranges = new LinkedHashSet<AddressRange>();
+   private Set<AddressRange> ranges = Sets.newLinkedHashSet();
 
    @Override
    protected Set<AddressRange> delegate() {

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/xml/internal/GetEventLogResponse.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/xml/internal/GetEventLogResponse.java
@@ -19,7 +19,6 @@
 package org.jclouds.fujitsu.fgcp.xml.internal;
 
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -29,6 +28,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import org.jclouds.fujitsu.fgcp.domain.EventLog;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * Wrapper for GetEventLogResponse.
@@ -39,7 +39,7 @@ import com.google.common.collect.ImmutableSet;
 public class GetEventLogResponse extends SetWithStatusResponse<EventLog> {
    @XmlElementWrapper(name = "eventlogs")
    @XmlElement(name = "eventlog")
-   private Set<EventLog> logs = new LinkedHashSet<EventLog>();
+   private Set<EventLog> logs = Sets.newLinkedHashSet();
 
    @Override
    protected Set<EventLog> delegate() {

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/xml/internal/GetPerformanceInformationResponse.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/xml/internal/GetPerformanceInformationResponse.java
@@ -19,7 +19,6 @@
 package org.jclouds.fujitsu.fgcp.xml.internal;
 
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -29,6 +28,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import org.jclouds.fujitsu.fgcp.domain.PerformanceInfo;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * Wrapper for GetPerformanceInformationResponse.
@@ -40,7 +40,7 @@ public class GetPerformanceInformationResponse extends
       SetWithStatusResponse<PerformanceInfo> {
    @XmlElementWrapper(name = "performanceinfos")
    @XmlElement(name = "performanceinfo")
-   private Set<PerformanceInfo> stats = new LinkedHashSet<PerformanceInfo>();
+   private Set<PerformanceInfo> stats = Sets.newLinkedHashSet();
 
    @Override
    protected Set<PerformanceInfo> delegate() {

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/xml/internal/ListDiskImageResponse.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/xml/internal/ListDiskImageResponse.java
@@ -19,7 +19,6 @@
 package org.jclouds.fujitsu.fgcp.xml.internal;
 
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -29,6 +28,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import org.jclouds.fujitsu.fgcp.domain.DiskImage;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * Wrapper for ListDiskImageResponse.
@@ -39,7 +39,7 @@ import com.google.common.collect.ImmutableSet;
 public class ListDiskImageResponse extends SetWithStatusResponse<DiskImage> {
    @XmlElementWrapper(name = "diskimages")
    @XmlElement(name = "diskimage")
-   private Set<DiskImage> diskImages = new LinkedHashSet<DiskImage>();
+   private Set<DiskImage> diskImages = Sets.newLinkedHashSet();
 
    @Override
    protected Set<DiskImage> delegate() {

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/xml/internal/ListEFMBackupResponse.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/xml/internal/ListEFMBackupResponse.java
@@ -19,7 +19,6 @@
 package org.jclouds.fujitsu.fgcp.xml.internal;
 
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -29,6 +28,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import org.jclouds.fujitsu.fgcp.domain.BuiltinServerBackup;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * Wrapper for ListEFMBackupResponse.
@@ -40,7 +40,7 @@ public class ListEFMBackupResponse extends
       SetWithStatusResponse<BuiltinServerBackup> {
    @XmlElementWrapper(name = "backups")
    @XmlElement(name = "backup")
-   private Set<BuiltinServerBackup> backup = new LinkedHashSet<BuiltinServerBackup>();
+   private Set<BuiltinServerBackup> backup = Sets.newLinkedHashSet();
 
    @Override
    protected Set<BuiltinServerBackup> delegate() {

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/xml/internal/ListEFMResponse.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/xml/internal/ListEFMResponse.java
@@ -19,7 +19,6 @@
 package org.jclouds.fujitsu.fgcp.xml.internal;
 
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -29,6 +28,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import org.jclouds.fujitsu.fgcp.domain.BuiltinServer;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * Wrapper for ListEFMResponse.
@@ -39,7 +39,7 @@ import com.google.common.collect.ImmutableSet;
 public class ListEFMResponse extends SetWithStatusResponse<BuiltinServer> {
    @XmlElementWrapper(name = "efms")
    @XmlElement(name = "efm")
-   private Set<BuiltinServer> efm = new LinkedHashSet<BuiltinServer>();
+   private Set<BuiltinServer> efm = Sets.newLinkedHashSet();
 
    @Override
    protected Set<BuiltinServer> delegate() {

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/xml/internal/ListVDiskResponse.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/xml/internal/ListVDiskResponse.java
@@ -19,7 +19,6 @@
 package org.jclouds.fujitsu.fgcp.xml.internal;
 
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -29,6 +28,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import org.jclouds.fujitsu.fgcp.domain.VDisk;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * Wrapper for ListVDiskResponse.
@@ -39,7 +39,7 @@ import com.google.common.collect.ImmutableSet;
 public class ListVDiskResponse extends SetWithStatusResponse<VDisk> {
    @XmlElementWrapper(name = "vdisks")
    @XmlElement(name = "vdisk")
-   private Set<VDisk> disks = new LinkedHashSet<VDisk>();
+   private Set<VDisk> disks = Sets.newLinkedHashSet();
 
    @Override
    protected Set<VDisk> delegate() {

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/xml/internal/ListVSYSResponse.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/xml/internal/ListVSYSResponse.java
@@ -19,7 +19,6 @@
 package org.jclouds.fujitsu.fgcp.xml.internal;
 
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -29,6 +28,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import org.jclouds.fujitsu.fgcp.domain.VSystem;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * Wrapper for ListVSYSResponse.
@@ -39,7 +39,7 @@ import com.google.common.collect.ImmutableSet;
 public class ListVSYSResponse extends SetWithStatusResponse<VSystem> {
    @XmlElementWrapper(name = "vsyss")
    @XmlElement(name = "vsys")
-   private Set<VSystem> systems = new LinkedHashSet<VSystem>();
+   private Set<VSystem> systems = Sets.newLinkedHashSet();
 
    @Override
    protected Set<VSystem> delegate() {

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/xml/internal/ListVServerResponse.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/xml/internal/ListVServerResponse.java
@@ -19,7 +19,6 @@
 package org.jclouds.fujitsu.fgcp.xml.internal;
 
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -29,6 +28,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import org.jclouds.fujitsu.fgcp.domain.VServer;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * Wrapper for ListVServerResponse.
@@ -39,7 +39,7 @@ import com.google.common.collect.ImmutableSet;
 public class ListVServerResponse extends SetWithStatusResponse<VServer> {
    @XmlElementWrapper(name = "vservers")
    @XmlElement(name = "vserver")
-   private Set<VServer> servers = new LinkedHashSet<VServer>();
+   private Set<VServer> servers = Sets.newLinkedHashSet();
 
    @Override
    protected Set<VServer> delegate() {

--- a/labs/nodepool/src/main/java/org/jclouds/nodepool/internal/NodeMetadataStoreCache.java
+++ b/labs/nodepool/src/main/java/org/jclouds/nodepool/internal/NodeMetadataStoreCache.java
@@ -18,7 +18,6 @@
  */
 package org.jclouds.nodepool.internal;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -31,11 +30,12 @@ import org.jclouds.compute.options.TemplateOptions;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
 
 @Singleton
 public class NodeMetadataStoreCache implements NodeMetadataStore {
 
-   private Map<String, NodeMetadata> frontendMetadataCache = new HashMap<String, NodeMetadata>();
+   private Map<String, NodeMetadata> frontendMetadataCache = Maps.newHashMap();
    private NodeMetadataStore backend;
 
    @Inject

--- a/labs/smartos-ssh/src/main/java/org/jclouds/smartos/compute/strategy/SmartOSComputeServiceAdapter.java
+++ b/labs/smartos-ssh/src/main/java/org/jclouds/smartos/compute/strategy/SmartOSComputeServiceAdapter.java
@@ -20,7 +20,6 @@ package org.jclouds.smartos.compute.strategy;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
@@ -39,6 +38,7 @@ import org.jclouds.smartos.compute.domain.VmSpecification;
 
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 /**
@@ -56,7 +56,7 @@ public class SmartOSComputeServiceAdapter implements ComputeServiceAdapter<VM, V
    public SmartOSComputeServiceAdapter(SmartOSHostController host) {
       this.host = checkNotNull(host, "host");
 
-      Collection<VmSpecification> specifications = new ArrayList<VmSpecification>();
+      Collection<VmSpecification> specifications = Lists.newArrayList();
 
        specifications.add(VmSpecification.builder().alias("Standard Joyent VM, 1Gb RAM / 2Gb SWAP").ram(1024).maxSwap(2048)
                .nic(VmNIC.builder().simpleDHCPNic().build()).build());

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/params/RecomposeVAppParams.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/domain/params/RecomposeVAppParams.java
@@ -20,7 +20,6 @@ package org.jclouds.vcloud.director.v1_5.domain.params;
 
 import static com.google.common.base.Objects.equal;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -32,6 +31,7 @@ import org.jclouds.vcloud.director.v1_5.domain.Vm;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
+import com.google.common.collect.Lists;
 
 /**
  * Represents vApp re-composition parameters.
@@ -117,7 +117,7 @@ public class RecomposeVAppParams extends ComposeVAppParams {
     */
    public List<Vm> getCreateItem() {
       if (createItem == null) {
-         createItem = new ArrayList<Vm>();
+         createItem = Lists.newArrayList();
       }
       return this.createItem;
    }
@@ -127,7 +127,7 @@ public class RecomposeVAppParams extends ComposeVAppParams {
     */
    public List<Reference> getDeleteItem() {
       if (removeItem == null) {
-         removeItem = new ArrayList<Reference>();
+         removeItem = Lists.newArrayList();
       }
       return this.removeItem;
    }

--- a/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/QueryApiLiveTest.java
+++ b/labs/vcloud-director/src/test/java/org/jclouds/vcloud/director/v1_5/features/QueryApiLiveTest.java
@@ -26,7 +26,6 @@ import static org.testng.Assert.assertTrue;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -50,6 +49,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
 
 /**
  * Tests live behavior of {@link QueryApi}.
@@ -230,7 +230,7 @@ public class QueryApiLiveTest extends BaseVCloudDirectorApiLiveTest {
    }
 
    private Set<URI> toHrefs(QueryResultRecords queryResult) {
-      Set<URI> hrefs = new LinkedHashSet<URI>();
+      Set<URI> hrefs = Sets.newLinkedHashSet();
       for (QueryResultRecordType record : queryResult.getRecords()) {
          hrefs.add(record.getHref());
       }
@@ -238,7 +238,7 @@ public class QueryApiLiveTest extends BaseVCloudDirectorApiLiveTest {
    }
 
    private Set<URI> toHrefs(Iterable<? extends Resource> resources) {
-      Set<URI> hrefs = new LinkedHashSet<URI>();
+      Set<URI> hrefs = Sets.newLinkedHashSet();
       for (Resource resource : resources) {
          hrefs.add(resource.getHref());
       }

--- a/labs/virtualbox/src/main/java/org/jclouds/virtualbox/compute/extensions/VirtualBoxImageExtension.java
+++ b/labs/virtualbox/src/main/java/org/jclouds/virtualbox/compute/extensions/VirtualBoxImageExtension.java
@@ -25,7 +25,6 @@ import static org.jclouds.virtualbox.config.VirtualBoxConstants.VIRTUALBOX_DEFAU
 import static org.jclouds.virtualbox.config.VirtualBoxConstants.VIRTUALBOX_IMAGE_PREFIX;
 import static org.jclouds.virtualbox.config.VirtualBoxConstants.VIRTUALBOX_WORKINGDIR;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.Resource;
@@ -60,6 +59,7 @@ import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -122,7 +122,7 @@ public class VirtualBoxImageExtension implements ImageExtension {
       IMachine clonedMachine = manager.get().getVBox()
                .createMachine(settingsFile, template.getName(), source.getOSTypeId(), template.getName(), true);
 
-      List<CloneOptions> options = new ArrayList<CloneOptions>();
+      List<CloneOptions> options = Lists.newArrayList();
       if (isLinkedClone)
          options.add(CloneOptions.Link);
 

--- a/labs/virtualbox/src/main/java/org/jclouds/virtualbox/domain/NetworkSpec.java
+++ b/labs/virtualbox/src/main/java/org/jclouds/virtualbox/domain/NetworkSpec.java
@@ -20,12 +20,11 @@ package org.jclouds.virtualbox.domain;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
-
+import com.google.common.collect.Lists;
 
 /**
  * Describes the network configuration for a VirtualBox machine.
@@ -44,7 +43,7 @@ public class NetworkSpec {
 
    public static class Builder {
 
-      private List<NetworkInterfaceCard> networkInterfaceCards = new ArrayList<NetworkInterfaceCard>();
+      private List<NetworkInterfaceCard> networkInterfaceCards = Lists.newArrayList();
 
       public Builder addNIC(NetworkInterfaceCard networkInterfaceCard) {
          this.networkInterfaceCards.add(networkInterfaceCard);

--- a/labs/virtualbox/src/main/java/org/jclouds/virtualbox/domain/StorageController.java
+++ b/labs/virtualbox/src/main/java/org/jclouds/virtualbox/domain/StorageController.java
@@ -21,7 +21,6 @@ package org.jclouds.virtualbox.domain;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Iterables.filter;
 
-import java.util.HashSet;
 import java.util.Set;
 
 import org.jclouds.javax.annotation.Nullable;
@@ -31,6 +30,7 @@ import org.virtualbox_4_1.StorageBus;
 import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
 
 /**
  * Represents a storage controller in a VirtualBox VM.
@@ -117,8 +117,8 @@ public class StorageController {
 
       private String name;
       private StorageBus bus;
-      private Set<HardDisk> hardDisks = new HashSet<HardDisk>();
-      private Set<IsoImage> dvds = new HashSet<IsoImage>();
+      private Set<HardDisk> hardDisks = Sets.newHashSet();
+      private Set<IsoImage> dvds = Sets.newHashSet();
 
       public Builder name(String name) {
          this.name = name;

--- a/labs/virtualbox/src/main/java/org/jclouds/virtualbox/domain/VmSpec.java
+++ b/labs/virtualbox/src/main/java/org/jclouds/virtualbox/domain/VmSpec.java
@@ -22,12 +22,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 import org.virtualbox_4_1.CleanupMode;
 
 import com.google.common.base.Objects;
+import com.google.common.collect.Sets;
 
 /**
  * A description of a Virtual Machine in VirtualBox.
@@ -60,7 +60,7 @@ public class VmSpec {
 
    public static class Builder {
 
-      private Set<StorageController> controllers = new HashSet<StorageController>();
+      private Set<StorageController> controllers = Sets.newHashSet();
 
       private String name;
       private String id;

--- a/labs/virtualbox/src/main/java/org/jclouds/virtualbox/functions/CloneAndRegisterMachineFromIMachineIfNotAlreadyExists.java
+++ b/labs/virtualbox/src/main/java/org/jclouds/virtualbox/functions/CloneAndRegisterMachineFromIMachineIfNotAlreadyExists.java
@@ -22,7 +22,6 @@ package org.jclouds.virtualbox.functions;
 import static org.jclouds.virtualbox.config.VirtualBoxConstants.GUEST_OS_PASSWORD;
 import static org.jclouds.virtualbox.config.VirtualBoxConstants.GUEST_OS_USER;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.Resource;
@@ -46,6 +45,7 @@ import org.virtualbox_4_1.VirtualBoxManager;
 
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;
+import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 
 /**
@@ -103,7 +103,7 @@ public class CloneAndRegisterMachineFromIMachineIfNotAlreadyExists implements Fu
                .createMachine(settingsFile, vmSpec.getVmName(), vmSpec.getOsTypeId(), vmSpec.getVmId(),
                         vmSpec.isForceOverwrite());
 
-      List<CloneOptions> options = new ArrayList<CloneOptions>();
+      List<CloneOptions> options = Lists.newArrayList();
       if (isLinkedClone)
          options.add(CloneOptions.Link);
 

--- a/labs/virtualbox/src/main/java/org/jclouds/virtualbox/functions/IMachineToNodeMetadata.java
+++ b/labs/virtualbox/src/main/java/org/jclouds/virtualbox/functions/IMachineToNodeMetadata.java
@@ -24,7 +24,6 @@ import static org.jclouds.virtualbox.config.VirtualBoxConstants.GUEST_OS_USER;
 import static org.jclouds.virtualbox.config.VirtualBoxConstants.VIRTUALBOX_NODE_NAME_SEPARATOR;
 import static org.jclouds.virtualbox.config.VirtualBoxConstants.VIRTUALBOX_NODE_PREFIX;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -49,6 +48,7 @@ import org.virtualbox_4_1.NetworkAttachmentType;
 import com.google.common.base.Function;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
@@ -108,8 +108,8 @@ public class IMachineToNodeMetadata implements Function<IMachine, NodeMetadata> 
    }
    
    private NodeMetadataBuilder getIpAddresses(IMachine vm, NodeMetadataBuilder nodeMetadataBuilder) {
-      List<String> publicIpAddresses = new ArrayList<String>();
-      List<String> privateIpAddresses = new ArrayList<String>();
+      List<String> publicIpAddresses = Lists.newArrayList();
+      List<String> privateIpAddresses = Lists.newArrayList();
       for(long slot = 0; slot < 4; slot ++) {
          INetworkAdapter adapter = vm.getNetworkAdapter(slot);
          if(adapter != null) {

--- a/labs/virtualbox/src/main/java/org/jclouds/virtualbox/functions/MastersLoadingCache.java
+++ b/labs/virtualbox/src/main/java/org/jclouds/virtualbox/functions/MastersLoadingCache.java
@@ -34,7 +34,6 @@ import static org.jclouds.virtualbox.util.MachineUtils.machineNotFoundException;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -84,6 +83,7 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Supplier;
 import com.google.common.cache.AbstractLoadingCache;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.net.HostAndPort;
 
@@ -292,7 +292,7 @@ public class MastersLoadingCache extends AbstractLoadingCache<Image, Master> {
          throw new RuntimeException("could not connect to virtualbox");
       }
       File file = new File(isosDir, fileName);
-      List<Statement> statements = new ArrayList<Statement>();
+      List<Statement> statements = Lists.newArrayList();
       statements.add(Statements.saveHttpResponseTo(URI.create(httpUrl),
             isosDir, fileName));
       StatementList statementList = new StatementList(statements);

--- a/labs/virtualbox/src/main/java/org/jclouds/virtualbox/functions/StringToKeyCode.java
+++ b/labs/virtualbox/src/main/java/org/jclouds/virtualbox/functions/StringToKeyCode.java
@@ -18,7 +18,6 @@
  */
 package org.jclouds.virtualbox.functions;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -26,6 +25,7 @@ import org.jclouds.virtualbox.settings.KeyboardScancodes;
 
 import com.google.common.base.Function;
 import com.google.common.base.Splitter;
+import com.google.common.collect.Lists;
 
 public class StringToKeyCode implements Function<String, List<Integer>> {
 
@@ -43,7 +43,7 @@ public class StringToKeyCode implements Function<String, List<Integer>> {
    }
    
    private List<Integer> transformStandardCharacterIntoKeycodes(String s) {
-      List<Integer> values = new ArrayList<Integer>();
+      List<Integer> values = Lists.newArrayList();
       for (String digit : Splitter.fixedLength(1).split(s)) {
          Collection<Integer> hex = KeyboardScancodes.NORMAL_KEYBOARD_BUTTON_MAP_LIST.get(digit);
          if (hex != null)
@@ -54,7 +54,7 @@ public class StringToKeyCode implements Function<String, List<Integer>> {
    }
 
    private List<Integer> transformSpecialCharIntoKeycodes(String s) {
-      List<Integer> values = new ArrayList<Integer>();
+      List<Integer> values = Lists.newArrayList();
       for (String special : s.split("<")) {
          Collection<Integer> value = KeyboardScancodes.SPECIAL_KEYBOARD_BUTTON_MAP_LIST.get("<" + special);
          if (value != null)

--- a/labs/virtualbox/src/main/java/org/jclouds/virtualbox/functions/admin/StartVBoxIfNotAlreadyRunning.java
+++ b/labs/virtualbox/src/main/java/org/jclouds/virtualbox/functions/admin/StartVBoxIfNotAlreadyRunning.java
@@ -24,7 +24,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static org.jclouds.compute.options.RunScriptOptions.Builder.runAsRoot;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.PostConstruct;
@@ -49,6 +48,7 @@ import org.virtualbox_4_1.VirtualBoxManager;
 
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;
+import com.google.common.collect.Lists;
 import com.google.common.net.HostAndPort;
 
 @Singleton
@@ -120,7 +120,7 @@ public class StartVBoxIfNotAlreadyRunning implements Supplier<VirtualBoxManager>
 
    private void cleanUpHost(URI provider, NodeMetadata hostNodeMetadata) {
       // kill previously started vboxwebsrv (possibly dirty session)
-      List<Statement> statements = new ArrayList<Statement>();
+      List<Statement> statements = Lists.newArrayList();
       statements.add(Statements.findPid("vboxwebsrv"));
       statements.add(Statements.kill());
       StatementList statementList = new StatementList(statements);

--- a/labs/virtualbox/src/main/java/org/jclouds/virtualbox/statements/EnableNetworkInterface.java
+++ b/labs/virtualbox/src/main/java/org/jclouds/virtualbox/statements/EnableNetworkInterface.java
@@ -22,8 +22,9 @@ package org.jclouds.virtualbox.statements;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.jclouds.scriptbuilder.domain.Statements.exec;
 
-import java.util.ArrayList;
 import java.util.List;
+
+import com.google.common.collect.Lists;
 
 import org.jclouds.scriptbuilder.domain.OsFamily;
 import org.jclouds.scriptbuilder.domain.Statement;
@@ -63,7 +64,7 @@ public class EnableNetworkInterface implements Statement {
    }
 
    private List<Statement> getStatements(String iface) {
-      List<Statement> statements = new ArrayList<Statement>();
+      List<Statement> statements = Lists.newArrayList();
       statements.add(exec(String.format("echo auto %s >> /etc/network/interfaces", iface))); //
       statements.add(exec(String.format("echo iface %s inet dhcp >> /etc/network/interfaces", iface))); //
       statements.add(exec("/etc/init.d/networking restart"));

--- a/labs/virtualbox/src/main/java/org/jclouds/virtualbox/statements/InstallGuestAdditions.java
+++ b/labs/virtualbox/src/main/java/org/jclouds/virtualbox/statements/InstallGuestAdditions.java
@@ -25,7 +25,6 @@ import static org.jclouds.scriptbuilder.domain.Statements.exec;
 import static org.jclouds.scriptbuilder.domain.Statements.saveHttpResponseTo;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.Resource;
@@ -42,6 +41,7 @@ import org.jclouds.virtualbox.domain.VmSpec;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 
 /**
  * Mounts the DVD with guest additions that was downloaded and attached as removable storage. If no
@@ -62,7 +62,7 @@ public class InstallGuestAdditions implements Statement {
    }
 
    private List<Statement> getStatements(VmSpec vmSpecification, String vboxVersion) {
-      List<Statement> statements = new ArrayList<Statement>();
+      List<Statement> statements = Lists.newArrayList();
       statements.add(call("installModuleAssistantIfNeeded"));
       String mountPoint = "/mnt";
       if (Iterables.tryFind(vmSpecification.getControllers(), new Predicate<StorageController>() {

--- a/labs/virtualbox/src/test/java/org/jclouds/virtualbox/compute/VirtualBoxComputeServiceAdapterTest.java
+++ b/labs/virtualbox/src/test/java/org/jclouds/virtualbox/compute/VirtualBoxComputeServiceAdapterTest.java
@@ -24,7 +24,6 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.jclouds.virtualbox.config.VirtualBoxConstants.VIRTUALBOX_IMAGE_PREFIX;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -45,6 +44,7 @@ import org.virtualbox_4_1.VirtualBoxManager;
 
 import com.google.common.base.Function;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.Lists;
 import com.google.inject.Guice;
 
 @Test(groups = "unit")
@@ -61,7 +61,7 @@ public class VirtualBoxComputeServiceAdapterTest {
       IVirtualBox vBox = createNiceMock(IVirtualBox.class);
       IGuestOSType osType = createNiceMock(IGuestOSType.class);
 
-      List<IMachine> machines = new ArrayList<IMachine>();
+      List<IMachine> machines = Lists.newArrayList();
       IMachine imageMachine = createNiceMock(IMachine.class);
       IMachine clonedMachine = createNiceMock(IMachine.class);
       machines.add(imageMachine);

--- a/labs/virtualbox/src/test/java/org/jclouds/virtualbox/functions/admin/UnregisterMachineIfExistsAndDeleteItsMediaTest.java
+++ b/labs/virtualbox/src/test/java/org/jclouds/virtualbox/functions/admin/UnregisterMachineIfExistsAndDeleteItsMediaTest.java
@@ -24,9 +24,10 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import com.google.common.collect.Lists;
 
 import org.jclouds.virtualbox.domain.HardDisk;
 import org.jclouds.virtualbox.domain.StorageController;
@@ -55,7 +56,7 @@ public class UnregisterMachineIfExistsAndDeleteItsMediaTest {
       IVirtualBox vBox = createMock(IVirtualBox.class);
       IMachine registeredMachine = createMock(IMachine.class);
       IProgress progress = createNiceMock(IProgress.class);
-      List<IMedium> media = new ArrayList<IMedium>();
+      List<IMedium> media = Lists.newArrayList();
       List<IMedium> mediums = Collections.unmodifiableList(media);
       
       StorageController ideController = StorageController.builder().name(ideControllerName).bus(StorageBus.IDE)

--- a/providers/glesys/src/test/java/org/jclouds/glesys/features/ServerApiExpectTest.java
+++ b/providers/glesys/src/test/java/org/jclouds/glesys/features/ServerApiExpectTest.java
@@ -22,7 +22,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import javax.ws.rs.core.MediaType;
@@ -54,6 +53,7 @@ import org.jclouds.rest.ResourceNotFoundException;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 
 /**
  * Tests annotation parsing of {@code ServerAsyncApi}
@@ -92,7 +92,7 @@ public class ServerApiExpectTest extends BaseGleSYSApiExpectTest {
                        .addHeader("Authorization", "Basic aWRlbnRpdHk6Y3JlZGVudGlhbA==").build(),
             HttpResponse.builder().statusCode(204).payload(payloadFromResource("/server_allowed_arguments.json")).build()).getServerApi();
 
-      Map<String, AllowedArgumentsForCreateServer> expected = new LinkedHashMap<String, AllowedArgumentsForCreateServer>();
+      Map<String, AllowedArgumentsForCreateServer> expected = Maps.newLinkedHashMap();
       AllowedArgumentsForCreateServer openvz = AllowedArgumentsForCreateServer.builder()
             .dataCenters("Amsterdam", "Falkenberg", "New York City", "Stockholm")
             .memorySizes(128, 256, 512, 768, 1024, 1536, 2048, 2560, 3072, 3584, 4096, 5120, 6144, 7168, 8192, 9216, 10240, 11264, 12288)

--- a/providers/gogrid/src/test/java/org/jclouds/gogrid/GoGridLiveTestDisabled.java
+++ b/providers/gogrid/src/test/java/org/jclouds/gogrid/GoGridLiveTestDisabled.java
@@ -25,7 +25,6 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Iterator;
@@ -56,6 +55,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.net.HostAndPort;
 
 /**
@@ -79,8 +79,8 @@ public class GoGridLiveTestDisabled extends BaseComputeServiceContextLiveTest {
    /**
     * Keeps track of the servers, created during the tests, to remove them after all tests complete
     */
-   private List<String> serversToDeleteAfterTheTests = new ArrayList<String>();
-   private List<String> loadBalancersToDeleteAfterTest = new ArrayList<String>();
+   private List<String> serversToDeleteAfterTheTests = Lists.newArrayList();
+   private List<String> loadBalancersToDeleteAfterTest = Lists.newArrayList();
 
    private RestContext<GoGridClient, GoGridAsyncClient> gocontext;
 

--- a/providers/rimuhosting/src/main/java/org/jclouds/rimuhosting/miro/binder/CreateServerOptions.java
+++ b/providers/rimuhosting/src/main/java/org/jclouds/rimuhosting/miro/binder/CreateServerOptions.java
@@ -20,11 +20,12 @@ package org.jclouds.rimuhosting.miro.binder;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
+
+import com.google.common.collect.Lists;
 
 import org.jclouds.http.HttpRequest;
 import org.jclouds.json.Json;
@@ -42,7 +43,7 @@ public class CreateServerOptions extends RimuHostingJsonBinder {
    }
    
    private String password;
-   private List<MetaData> metaData = new ArrayList<MetaData>();
+   private List<MetaData> metaData = Lists.newArrayList();
 
    @Override
    public <R extends HttpRequest> R bindToRequest(R request, Map<String, Object> postParams) {

--- a/resources/checkstyle.xml
+++ b/resources/checkstyle.xml
@@ -14,4 +14,36 @@
         <module name="ModifierOrder"/>
         <module name="UnusedImports"/>
     </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="=\s*new ArrayList&lt;[^&gt;]"/>
+        <property name="message" value="Prefer com.google.common.collect.Lists"/>
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="=\s*new HashMap&lt;[^&gt;]"/>
+        <property name="message" value="Prefer com.google.common.collect.Maps"/>
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="=\s*new HashSet&lt;[^&gt;]"/>
+        <property name="message" value="Prefer com.google.common.collect.Sets"/>
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="=\s*new LinkedHashMap&lt;[^&gt;]"/>
+        <property name="message" value="Prefer com.google.common.collect.Maps"/>
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="=\s*new LinkedHashSet&lt;[^&gt;]"/>
+        <property name="message" value="Prefer com.google.common.collect.Sets"/>
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="=\s*new LinkedList&lt;[^&gt;]"/>
+        <property name="message" value="Prefer com.google.common.collect.Lists"/>
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="=\s*new TreeMap&lt;[^&gt;]"/>
+        <property name="message" value="Prefer com.google.common.collect.Maps"/>
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="=\s*new TreeSet&lt;[^&gt;]"/>
+        <property name="message" value="Prefer com.google.common.collect.Sets"/>
+    </module>
 </module>


### PR DESCRIPTION
This ensures that we do not repeat the type name.  Some instances remain
due to auto-generated code in dmtf/cim/Cim*.
