### PR TITLE
base64 tidies

### DIFF
--- a/core/src/main/java/org/jclouds/crypto/CryptoStreams.java
+++ b/core/src/main/java/org/jclouds/crypto/CryptoStreams.java
@@ -82,11 +82,15 @@ public class CryptoStreams {
     * encodes value substituting {@code '-' and '_'} for {@code '+' and '/'},
     * and without adding trailing {@code '='} padding.
     * 
+    * <h3>Note</h3>
+    * This utility will be replaced with Guava 14+ BaseEncoding.base64Url()
+    * 
     * @see <a
     *      href="http://en.wikipedia.org/wiki/Base64#URL_applications">url-safe
     *      encoding</a>
     */
-   public static String base64URLSafe(byte[] in) {
+   @Beta
+   public static String base64Url(byte[] in) {
       String provisional = base64(in);
       int length = provisional.length();
       if (length == 0)

--- a/core/src/test/java/org/jclouds/crypto/CryptoStreamsTest.java
+++ b/core/src/test/java/org/jclouds/crypto/CryptoStreamsTest.java
@@ -48,13 +48,13 @@ public class CryptoStreamsTest {
    }
 
    @Test
-   public void testBase64DecodeURLSafeJson() throws IOException {
+   public void testBase64DecodeUrlJson() throws IOException {
       byte[] decoded = CryptoStreams.base64("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9");
       assertEquals(new String(decoded, Charsets.UTF_8), "{\"alg\":\"RS256\",\"typ\":\"JWT\"}");
    }
 
    @Test
-   public void testBase64DecodeURLSafeNoPadding() throws IOException {
+   public void testBase64DecodeUrlNoPadding() throws IOException {
 
       byte[] decoded = CryptoStreams
             .base64("eyJpc3MiOiI3NjEzMjY3OTgwNjktcjVtbGpsbG4xcmQ0bHJiaGc3NWVmZ2lncDM2bTc4ajVAZGV2ZWxvcGVyLmdzZXJ2aWNlYWNjb3VudC5jb20iLCJzY29wZSI6Imh0dHBzOi8vd3d3Lmdvb2dsZWFwaXMuY29tL2F1dGgvcHJlZGljdGlvbiIsImF1ZCI6Imh0dHBzOi8vYWNjb3VudHMuZ29vZ2xlLmNvbS9vL29hdXRoMi90b2tlbiIsImV4cCI6MTMyODU1NDM4NSwiaWF0IjoxMzI4NTUwNzg1fQ");
@@ -67,27 +67,27 @@ public class CryptoStreamsTest {
    }
    
    @Test
-   public void testBase64EncodeURLSafeNoSinglePad() {
+   public void testBase64EncodeUrlNoSinglePad() {
       assertEquals(CryptoStreams.base64("any carnal pleasu".getBytes(Charsets.UTF_8)), "YW55IGNhcm5hbCBwbGVhc3U=");
-      assertEquals(CryptoStreams.base64URLSafe("any carnal pleasu".getBytes(Charsets.UTF_8)), "YW55IGNhcm5hbCBwbGVhc3U");
+      assertEquals(CryptoStreams.base64Url("any carnal pleasu".getBytes(Charsets.UTF_8)), "YW55IGNhcm5hbCBwbGVhc3U");
    }
 
    @Test
-   public void testBase64EncodeURLSafeNoDoublePad() {
+   public void testBase64EncodeUrlNoDoublePad() {
       assertEquals(CryptoStreams.base64("any carnal pleas".getBytes(Charsets.UTF_8)), "YW55IGNhcm5hbCBwbGVhcw==");
-      assertEquals(CryptoStreams.base64URLSafe("any carnal pleas".getBytes(Charsets.UTF_8)), "YW55IGNhcm5hbCBwbGVhcw");
+      assertEquals(CryptoStreams.base64Url("any carnal pleas".getBytes(Charsets.UTF_8)), "YW55IGNhcm5hbCBwbGVhcw");
    }
 
    @Test
-   public void testBase64EncodeURLSafeHyphenNotPlus() {
+   public void testBase64EncodeUrlHyphenNotPlus() {
       assertEquals(CryptoStreams.base64("i?>".getBytes(Charsets.UTF_8)), "aT8+");
-      assertEquals(CryptoStreams.base64URLSafe("i?>".getBytes(Charsets.UTF_8)), "aT8-");
+      assertEquals(CryptoStreams.base64Url("i?>".getBytes(Charsets.UTF_8)), "aT8-");
    }
    
    @Test
-   public void testBase64EncodeURLSafeUnderscoreNotSlash() {
+   public void testBase64EncodeUrlUnderscoreNotSlash() {
       assertEquals(CryptoStreams.base64("i??".getBytes(Charsets.UTF_8)), "aT8/");
-      assertEquals(CryptoStreams.base64URLSafe("i??".getBytes(Charsets.UTF_8)), "aT8_");
+      assertEquals(CryptoStreams.base64Url("i??".getBytes(Charsets.UTF_8)), "aT8_");
    }
    
    @Test

--- a/core/src/test/java/org/jclouds/io/CryptoTest.java
+++ b/core/src/test/java/org/jclouds/io/CryptoTest.java
@@ -18,6 +18,7 @@
  */
 package org.jclouds.io;
 
+import static javax.xml.bind.DatatypeConverter.parseBase64Binary;
 import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
@@ -28,8 +29,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
-
-import static javax.xml.bind.DatatypeConverter.*;
 
 import org.jclouds.PerformanceTest;
 import org.jclouds.crypto.Crypto;


### PR DESCRIPTION
renamed syntax of base64 url-safe to be consistent with guava 14 + fixed bad import from prior PR

This is intended for 1.5.x as well
