### PR TITLE
Fully support all Chef Solo features

### DIFF
--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/domain/chef/DataBag.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/domain/chef/DataBag.java
@@ -20,11 +20,11 @@ package org.jclouds.scriptbuilder.domain.chef;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.List;
+import java.util.Map;
 
 import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
+import com.google.common.collect.ForwardingMap;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * A Data bag to be configured for a Chef Solo run.
@@ -32,73 +32,7 @@ import com.google.common.collect.Lists;
  * @author Ignasi Barrera
  * @since Chef 0.10.4
  */
-public class DataBag {
-
-   public static class Item {
-      public static Builder builder() {
-         return new Builder();
-      }
-
-      public static class Builder {
-         private String name;
-         private String jsonData;
-
-         public Builder name(String name) {
-            this.name = checkNotNull(name, "name must be set");
-            return this;
-         }
-
-         public Builder jsonData(String jsonData) {
-            this.jsonData = checkNotNull(jsonData, "jsonData must be set");
-            return this;
-         }
-
-         public Item build() {
-            return new Item(name, jsonData);
-         }
-      }
-
-      private String name;
-      private String jsonData;
-
-      public Item(String name, String jsonData) {
-         this.name = checkNotNull(name, "name must be set");
-         this.jsonData = checkNotNull(jsonData, "jsonData must be set");
-      }
-
-      public String getName() {
-         return name;
-      }
-
-      public String getJsonData() {
-         return jsonData;
-      }
-
-      @Override
-      public int hashCode() {
-         return Objects.hashCode(name);
-      }
-
-      @Override
-      public boolean equals(Object obj) {
-         if (this == obj) {
-            return true;
-         }
-         if (obj == null) {
-            return false;
-         }
-         if (getClass() != obj.getClass()) {
-            return false;
-         }
-         Item other = (Item) obj;
-         return Objects.equal(name, other.name);
-      }
-
-      @Override
-      public String toString() {
-         return Objects.toStringHelper(this).add("name", name).toString();
-      }
-   }
+public class DataBag extends ForwardingMap<String, String> {
 
    public static Builder builder() {
       return new Builder();
@@ -106,7 +40,7 @@ public class DataBag {
 
    public static class Builder {
       private String name;
-      private List<Item> items = Lists.newArrayList();
+      private ImmutableMap.Builder<String, String> items = ImmutableMap.builder();
 
       public Builder name(String name) {
          this.name = checkNotNull(name, "name must be set");
@@ -114,36 +48,40 @@ public class DataBag {
       }
 
       public Builder item(String name, String jsonData) {
-         Item item = Item.builder().name(checkNotNull(name, "name must be set"))
-               .jsonData(checkNotNull(jsonData, "jsonData must be set")).build();
-         this.items.add(item);
+         this.items.put(checkNotNull(name, "name must be set"), checkNotNull(jsonData, "jsonData must be set"));
          return this;
       }
 
-      public Builder items(Iterable<Item> items) {
-         this.items = ImmutableList.copyOf(checkNotNull(items, "items must be set"));
+      public Builder items(Map<String, String> items) {
+         this.items.putAll(checkNotNull(items, "items must be set"));
          return this;
       }
 
       public DataBag build() {
-         return new DataBag(name, items);
+         return new DataBag(name, items.build());
       }
 
    }
 
    private String name;
-   private List<Item> items;
 
-   public DataBag(String name, List<Item> items) {
+   private Map<String, String> items;
+
+   public DataBag(String name, Map<String, String> items) {
       this.name = checkNotNull(name, "name must be set");
-      this.items = ImmutableList.copyOf(checkNotNull(items, "items must be set"));
+      this.items = ImmutableMap.copyOf(checkNotNull(items, "items must be set"));
+   }
+
+   @Override
+   protected Map<String, String> delegate() {
+      return items;
    }
 
    public String getName() {
       return name;
    }
 
-   public List<Item> getItems() {
+   public Map<String, String> getItems() {
       return items;
    }
 
@@ -163,7 +101,7 @@ public class DataBag {
       if (getClass() != obj.getClass()) {
          return false;
       }
-      Item other = (Item) obj;
+      DataBag other = (DataBag) obj;
       return Objects.equal(name, other.name);
    }
 
@@ -171,4 +109,5 @@ public class DataBag {
    public String toString() {
       return Objects.toStringHelper(this).add("name", name).toString();
    }
+
 }

--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/domain/chef/RunList.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/domain/chef/RunList.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.scriptbuilder.domain.chef;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Iterables.transform;
+
+import java.util.List;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+/**
+ * A Run list to be executed in a Chef Solo run.
+ * 
+ * @author Ignasi Barrera
+ */
+public class RunList {
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public static class Builder {
+      private ImmutableList.Builder<String> runlist = ImmutableList.builder();
+
+      public Builder recipe(String recipe) {
+         this.runlist.add("recipe[" + checkNotNull(recipe, "recipe must be set") + "]");
+         return this;
+      }
+
+      public Builder recipes(Iterable<String> recipes) {
+         this.runlist.addAll(Lists.newArrayList(transform(checkNotNull(recipes, "recipes must be set"),
+               new Function<String, String>() {
+                  @Override
+                  public String apply(String input) {
+                     return "recipe[" + input + "]";
+                  }
+               })));
+         return this;
+      }
+
+      public Builder role(String role) {
+         this.runlist.add("role[" + checkNotNull(role, "role must be set") + "]");
+         return this;
+      }
+
+      public Builder roles(Iterable<String> roles) {
+         this.runlist.addAll(Lists.newArrayList(transform(checkNotNull(roles, "roles must be set"),
+               new Function<String, String>() {
+                  @Override
+                  public String apply(String input) {
+                     return "role[" + input + "]";
+                  }
+               })));
+         return this;
+      }
+
+      public RunList build() {
+         return new RunList(runlist.build());
+      }
+   }
+
+   private List<String> runlist;
+
+   protected RunList(List<String> runlist) {
+      this.runlist = ImmutableList.<String> copyOf(checkNotNull(runlist, "runlist must be set"));
+   }
+
+   public List<String> getRunlist() {
+      return runlist;
+   }
+
+   @Override
+   public String toString() {
+      return "[" + Joiner.on(',').join(transform(runlist, new Function<String, String>() {
+         @Override
+         public String apply(String input) {
+            return "\"" + input + "\"";
+         }
+      })) + "]";
+   }
+
+}

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/domain/chef/RoleTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/domain/chef/RoleTest.java
@@ -22,8 +22,6 @@ import static org.testng.Assert.assertEquals;
 
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableList;
-
 /**
  * Unit tests for the {@link Role} class.
  * 
@@ -60,22 +58,16 @@ public class RoleTest {
    }
 
    public void testToJsonStringWithSingleRecipe() {
-      Role role = Role.builder().name("foo").installRecipe("apache2").build();
+      RunList runlist = RunList.builder().recipe("apache2").build();
+      Role role = Role.builder().name("foo").runlist(runlist).build();
       assertEquals(role.toJsonString(),
             "{\"name\": \"foo\",\"description\":\"\",\"default_attributes\":{},\"override_attributes\":{},"
                   + "\"json_class\":\"Chef::Role\",\"chef_type\":\"role\",\"run_list\":[\"recipe[apache2]\"]}");
    }
 
    public void testToJsonStringWithMultipleRecipes() {
-      Role role = Role.builder().name("foo").installRecipe("apache2").installRecipe("git").build();
-      assertEquals(role.toJsonString(),
-            "{\"name\": \"foo\",\"description\":\"\",\"default_attributes\":{},\"override_attributes\":{},"
-                  + "\"json_class\":\"Chef::Role\",\"chef_type\":\"role\","
-                  + "\"run_list\":[\"recipe[apache2]\",\"recipe[git]\"]}");
-   }
-
-   public void testToJsonStringWithMultipleRecipesInList() {
-      Role role = Role.builder().name("foo").installRecipes(ImmutableList.of("apache2", "git")).build();
+      RunList runlist = RunList.builder().recipe("apache2").recipe("git").build();
+      Role role = Role.builder().name("foo").runlist(runlist).build();
       assertEquals(role.toJsonString(),
             "{\"name\": \"foo\",\"description\":\"\",\"default_attributes\":{},\"override_attributes\":{},"
                   + "\"json_class\":\"Chef::Role\",\"chef_type\":\"role\","
@@ -83,22 +75,16 @@ public class RoleTest {
    }
 
    public void testToJsonStringWithSingleRole() {
-      Role role = Role.builder().name("foo").installRole("webserver").build();
+      RunList runlist = RunList.builder().role("webserver").build();
+      Role role = Role.builder().name("foo").runlist(runlist).build();
       assertEquals(role.toJsonString(),
             "{\"name\": \"foo\",\"description\":\"\",\"default_attributes\":{},\"override_attributes\":{},"
                   + "\"json_class\":\"Chef::Role\",\"chef_type\":\"role\",\"run_list\":[\"role[webserver]\"]}");
    }
 
    public void testToJsonStringWithMultipleRoles() {
-      Role role = Role.builder().name("foo").installRole("webserver").installRole("firewall").build();
-      assertEquals(role.toJsonString(),
-            "{\"name\": \"foo\",\"description\":\"\",\"default_attributes\":{},\"override_attributes\":{},"
-                  + "\"json_class\":\"Chef::Role\",\"chef_type\":\"role\","
-                  + "\"run_list\":[\"role[webserver]\",\"role[firewall]\"]}");
-   }
-
-   public void testToJsonStringWithMultipleRolesInList() {
-      Role role = Role.builder().name("foo").installRoles(ImmutableList.of("webserver", "firewall")).build();
+      RunList runlist = RunList.builder().role("webserver").role("firewall").build();
+      Role role = Role.builder().name("foo").runlist(runlist).build();
       assertEquals(role.toJsonString(),
             "{\"name\": \"foo\",\"description\":\"\",\"default_attributes\":{},\"override_attributes\":{},"
                   + "\"json_class\":\"Chef::Role\",\"chef_type\":\"role\","
@@ -106,7 +92,8 @@ public class RoleTest {
    }
 
    public void testToJsonStringWithRolesAndRecipes() {
-      Role role = Role.builder().name("foo").installRole("webserver").installRecipe("git").build();
+      RunList runlist = RunList.builder().role("webserver").recipe("git").build();
+      Role role = Role.builder().name("foo").runlist(runlist).build();
       assertEquals(role.toJsonString(),
             "{\"name\": \"foo\",\"description\":\"\",\"default_attributes\":{},\"override_attributes\":{},"
                   + "\"json_class\":\"Chef::Role\",\"chef_type\":\"role\","

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/domain/chef/RunListTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/domain/chef/RunListTest.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.scriptbuilder.domain.chef;
+
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for the {@link RunList} class.
+ * 
+ * @author Ignasi Barrera
+ */
+@Test(groups = "unit", testName = "RunListTest")
+public class RunListTest {
+
+   public void testToStringEmptyRunlist() {
+      assertEquals(RunList.builder().build().toString(), "[]");
+   }
+
+   public void testToStringWithRecipe() {
+      assertEquals(RunList.builder().recipe("apache2").build().toString(), "[\"recipe[apache2]\"]");
+   }
+
+   public void testToStringWithRole() {
+      assertEquals(RunList.builder().role("webserver").build().toString(), "[\"role[webserver]\"]");
+   }
+
+   public void testToStringWithRecipeAndRole() {
+      assertEquals(RunList.builder().recipe("apache2").role("webserver").build().toString(),
+            "[\"recipe[apache2]\",\"role[webserver]\"]");
+   }
+
+}

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/chef/ChefSoloTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/chef/ChefSoloTest.java
@@ -30,6 +30,7 @@ import org.jclouds.scriptbuilder.domain.ShellToken;
 import org.jclouds.scriptbuilder.domain.Statement;
 import org.jclouds.scriptbuilder.domain.chef.DataBag;
 import org.jclouds.scriptbuilder.domain.chef.Role;
+import org.jclouds.scriptbuilder.domain.chef.RunList;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Charsets;
@@ -115,7 +116,8 @@ public class ChefSoloTest {
 
    public void testCreateNodeConfigurationWithRunList() {
       ImmutableList.Builder<Statement> statements = ImmutableList.builder();
-      ChefSolo solo = ChefSolo.builder().installRecipe("foo").installRole("bar").build();
+      RunList runlist = RunList.builder().recipe("foo").role("bar").build();
+      ChefSolo solo = ChefSolo.builder().runlist(runlist).build();
 
       solo.createNodeConfiguration(statements);
       ImmutableList<Statement> statementList = statements.build();
@@ -129,8 +131,8 @@ public class ChefSoloTest {
 
    public void testCreateNodeConfigurationWithJsonAttributesAndRunList() {
       ImmutableList.Builder<Statement> statements = ImmutableList.builder();
-      ChefSolo solo = ChefSolo.builder().jsonAttributes("{\"foo\":\"bar\"}").installRecipe("foo").installRole("bar")
-            .build();
+      RunList runlist = RunList.builder().recipe("foo").role("bar").build();
+      ChefSolo solo = ChefSolo.builder().jsonAttributes("{\"foo\":\"bar\"}").runlist(runlist).build();
 
       solo.createNodeConfiguration(statements);
       ImmutableList<Statement> statementList = statements.build();
@@ -154,7 +156,8 @@ public class ChefSoloTest {
 
    public void testCreateRolesIfNecessaryWithOneRole() {
       ImmutableList.Builder<Statement> statements = ImmutableList.builder();
-      Role role = Role.builder().name("foo").installRecipe("bar").build();
+      RunList runlist = RunList.builder().recipe("bar").build();
+      Role role = Role.builder().name("foo").runlist(runlist).build();
       ChefSolo solo = ChefSolo.builder().defineRole(role).build();
 
       solo.createRolesIfNecessary(statements);
@@ -170,7 +173,8 @@ public class ChefSoloTest {
 
    public void testCreateRolesIfNecessaryWithOneRoleAndCustomPath() {
       ImmutableList.Builder<Statement> statements = ImmutableList.builder();
-      Role role = Role.builder().name("foo").installRecipe("bar").build();
+      RunList runlist = RunList.builder().recipe("bar").build();
+      Role role = Role.builder().name("foo").runlist(runlist).build();
       ChefSolo solo = ChefSolo.builder().rolePath("/tmp/roles").defineRole(role).build();
 
       solo.createRolesIfNecessary(statements);
@@ -186,8 +190,8 @@ public class ChefSoloTest {
 
    public void testCreateRolesIfNecessaryWithMultipleRoleAndCustomPath() {
       ImmutableList.Builder<Statement> statements = ImmutableList.builder();
-      Role roleFoo = Role.builder().name("foo").installRecipe("bar").build();
-      Role roleBar = Role.builder().name("bar").installRecipe("foo").build();
+      Role roleFoo = Role.builder().name("foo").runlist(RunList.builder().recipe("foo").build()).build();
+      Role roleBar = Role.builder().name("bar").runlist(RunList.builder().recipe("bar").build()).build();
       ChefSolo solo = ChefSolo.builder().rolePath("/tmp/roles").defineRole(roleFoo).defineRole(roleBar).build();
 
       solo.createRolesIfNecessary(statements);


### PR DESCRIPTION
Added the remaining features to fully support Chef Solo. These include:
- Allow users to specify custom json attributes to be computed when installing cookbooks.
- Allow users to define roles.
- Allow users to define custom databags.

The following example illustrates how the roles and databags can be used to customize the behavior of the cookbooks:

``` java
// Define a role that will install an Apache with SSL support
Role webserver = Role.builder()
    .name("webserver")
    .installRecipe("apache2")
    .installRecipe("apache2::mod_ssl")
    .build();

// Define a databag containing data the cookbooks may use
DataBag databag = DataBag.builder()
    .name("bootstrap")
    .item("group", "{\"foo\":\"bar\"}")
    .build();

// Create the Chef bootstrap statement to install Apache in a custom port
Statement chefBootstrap = ChefSolo.builder()
    .cookbooksArchiveLocation("http://foo/bar/cookbooks.tar.gz")
    .jsonAttributes("{\"apache\":{\"listen_ports\":[\"8888\"]}}")
    .defineRole(webserver)
    .defineDataBag(databag)
    .installRole("webserver")
    .build();

// Deploy and bootstrap the node using Chef!
compute.createNodesInGroup("group", 1, runScript(chefBootstrap)));
```
