### PR TITLE
Don't install unnecessary Ruby packages

### DIFF
--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/chef/InstallChefGems.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/chef/InstallChefGems.java
@@ -18,7 +18,7 @@
  */
 package org.jclouds.scriptbuilder.statements.chef;
 
-import static org.jclouds.scriptbuilder.domain.Statements.call;
+import static org.jclouds.scriptbuilder.domain.Statements.exec;
 
 import org.jclouds.scriptbuilder.domain.OsFamily;
 import org.jclouds.scriptbuilder.domain.StatementList;
@@ -32,7 +32,7 @@ import org.jclouds.scriptbuilder.statements.ruby.InstallRuby;
 public class InstallChefGems extends StatementList {
 
    public InstallChefGems() {
-      super(new InstallRuby(), call("installChefGems"));
+      super(new InstallRuby(), exec("gem install ohai chef --no-rdoc --no-ri"));
    }
 
    @Override

--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/ruby/InstallRuby.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/ruby/InstallRuby.java
@@ -35,7 +35,7 @@ import org.jclouds.scriptbuilder.domain.StatementList;
  */
 public class InstallRuby extends StatementList {
 
-   private static final URI RUBYGEMS_URI = URI.create("http://production.cf.rubygems.org/rubygems/rubygems-1.3.7.tgz");
+   private static final URI RUBYGEMS_URI = URI.create("http://production.cf.rubygems.org/rubygems/rubygems-1.8.10.tgz");
 
    public static Statement installRubyGems() {
       return new StatementList(//
@@ -44,7 +44,10 @@ public class InstallRuby extends StatementList {
             exec("{cd} /tmp/rubygems"), //
             exec("ruby setup.rb --no-format-executable"), //
             exec("{rm} -fr /tmp/rubygems"), //
-            exec(")"));
+            exec(")"), //
+            // Make sure RubyGems is up to date
+            exec("gem update --system"), //
+            exec("gem update --no-rdoc --no-ri"));
    }
 
    public InstallRuby() {

--- a/scriptbuilder/src/main/resources/functions/installChefGems.sh
+++ b/scriptbuilder/src/main/resources/functions/installChefGems.sh
@@ -1,9 +1,0 @@
-function installChefGems() {
-  if ! hash chef-client 2>/dev/null; then
-    if which rpm &> /dev/null; then
-      #Install gems provided by libruby-extras deb package (based on https://launchpad.net/ubuntu/precise/+package/libruby-extras)
-      /usr/bin/gem install cmdparse daemons log4r mmap ncurses --no-rdoc --no-ri --verbose
-    fi
-    /usr/bin/gem install ohai chef --no-rdoc --no-ri --verbose
-  fi
-}

--- a/scriptbuilder/src/main/resources/functions/installRuby.sh
+++ b/scriptbuilder/src/main/resources/functions/installRuby.sh
@@ -2,14 +2,14 @@ function installRuby() {
   if ! hash ruby 2>/dev/null; then
     if which dpkg &> /dev/null; then
       apt-get-update
-      apt-get install -y ruby ruby1.8-dev build-essential wget libruby-extras libruby1.8-extras
+      apt-get install -y ruby ruby1.8-dev build-essential
     elif which rpm &> /dev/null; then
       # Disable chef from the base repo (http://tickets.opscode.com/browse/CHEF-2906)
       sed -i "s/\[base\]/\0\n\exclude=ruby*/g" /etc/yum.repos.d/CentOS-Base.repo
       # Make sure to install an appropriate ruby version
       yum erase -y ruby ruby-libs
       rpm -Uvh http://rbel.co/rbel5
-      yum install -y ruby ruby-devel make gcc gcc-c++ kernel-devel automake autoconf wget
+      yum install -y ruby ruby-devel make gcc gcc-c++ automake autoconf
     else
       abort "we only support apt-get and yum right now... please contribute"
     fi

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/chef/ChefSoloTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/chef/ChefSoloTest.java
@@ -382,7 +382,7 @@ public class ChefSoloTest {
 
    private static String installChefGems() throws IOException {
       return Resources.toString(Resources.getResource("test_install_ruby." + ShellToken.SH.to(OsFamily.UNIX)),
-            Charsets.UTF_8) + "installChefGems || return 1\n";
+            Charsets.UTF_8) + "gem install ohai chef --no-rdoc --no-ri\n";
    }
 
    private static String createConfigFile() {

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/chef/InstallChefGemsTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/chef/InstallChefGemsTest.java
@@ -30,6 +30,11 @@ import org.testng.annotations.Test;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 
+/**
+ * Unit tests for the {@link InstallChefGems} statement.
+ * 
+ * @author Ignasi Barrera
+ */
 @Test(groups = "unit", testName = "InstallChefGemsTest")
 public class InstallChefGemsTest {
 
@@ -43,7 +48,7 @@ public class InstallChefGemsTest {
       assertEquals(
             new InstallChefGems().render(OsFamily.UNIX),
             Resources.toString(Resources.getResource("test_install_ruby." + ShellToken.SH.to(OsFamily.UNIX)),
-                  Charsets.UTF_8) + "installChefGems || return 1\n");
+                  Charsets.UTF_8) + "gem install ohai chef --no-rdoc --no-ri\n");
    }
 
    public void installChefGemsUnixInScriptBuilderSourcesSetupPublicCurl() throws IOException {

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/ruby/InstallRubyTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/ruby/InstallRubyTest.java
@@ -30,6 +30,11 @@ import org.testng.annotations.Test;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 
+/**
+ * Unit tests for the {@link InstallRuby} statement.
+ * 
+ * @author Ignasi Barrera
+ */
 @Test(groups = "unit", testName = "InstallRubyTest")
 public class InstallRubyTest {
 

--- a/scriptbuilder/src/test/resources/test_install_chef_gems_scriptbuilder.sh
+++ b/scriptbuilder/src/test/resources/test_install_chef_gems_scriptbuilder.sh
@@ -140,26 +140,17 @@ function installRuby() {
   if ! hash ruby 2>/dev/null; then
     if which dpkg &> /dev/null; then
       apt-get-update
-      apt-get install -y ruby ruby1.8-dev build-essential wget libruby-extras libruby1.8-extras
+      apt-get install -y ruby ruby1.8-dev build-essential
     elif which rpm &> /dev/null; then
       # Disable chef from the base repo (http://tickets.opscode.com/browse/CHEF-2906)
       sed -i "s/\[base\]/\0\n\exclude=ruby*/g" /etc/yum.repos.d/CentOS-Base.repo
       # Make sure to install an appropriate ruby version
       yum erase -y ruby ruby-libs
       rpm -Uvh http://rbel.co/rbel5
-      yum install -y ruby ruby-devel make gcc gcc-c++ kernel-devel automake autoconf wget
+      yum install -y ruby ruby-devel make gcc gcc-c++ automake autoconf
     else
       abort "we only support apt-get and yum right now... please contribute"
     fi
-  fi
-}
-function installChefGems() {
-  if ! hash chef-client 2>/dev/null; then
-    if which rpm &> /dev/null; then
-      #Install gems provided by libruby-extras deb package (based on https://launchpad.net/ubuntu/precise/+package/libruby-extras)
-      /usr/bin/gem install cmdparse daemons log4r mmap ncurses --no-rdoc --no-ri --verbose
-    fi
-    /usr/bin/gem install ohai chef --no-rdoc --no-ri --verbose
   fi
 }
 
@@ -174,7 +165,7 @@ END_OF_JCLOUDS_SCRIPT
 	installRuby || exit 1
 	(
 	mkdir /tmp/$$
-	curl -q -s -S -L --connect-timeout 10 --max-time 600 --retry 20 -X GET  http://production.cf.rubygems.org/rubygems/rubygems-1.3.7.tgz |(mkdir -p /tmp/$$ &&cd /tmp/$$ &&tar -xpzf -)
+	curl -q -s -S -L --connect-timeout 10 --max-time 600 --retry 20 -X GET  http://production.cf.rubygems.org/rubygems/rubygems-1.8.10.tgz |(mkdir -p /tmp/$$ &&cd /tmp/$$ &&tar -xpzf -)
 	mkdir -p /tmp/rubygems
 	mv /tmp/$$/*/* /tmp/rubygems
 	rm -rf /tmp/$$
@@ -182,8 +173,10 @@ END_OF_JCLOUDS_SCRIPT
 	ruby setup.rb --no-format-executable
 	rm -fr /tmp/rubygems
 	)
+	gem update --system
+	gem update --no-rdoc --no-ri
 	
-	installChefGems || exit 1
+	gem install ohai chef --no-rdoc --no-ri
 	
 END_OF_JCLOUDS_SCRIPT
    

--- a/scriptbuilder/src/test/resources/test_install_ruby.sh
+++ b/scriptbuilder/src/test/resources/test_install_ruby.sh
@@ -2,7 +2,7 @@ setupPublicCurl || return 1
 installRuby || return 1
 (
 mkdir /tmp/$$
-curl -q -s -S -L --connect-timeout 10 --max-time 600 --retry 20 -X GET  http://production.cf.rubygems.org/rubygems/rubygems-1.3.7.tgz |(mkdir -p /tmp/$$ &&cd /tmp/$$ &&tar -xpzf -)
+curl -q -s -S -L --connect-timeout 10 --max-time 600 --retry 20 -X GET  http://production.cf.rubygems.org/rubygems/rubygems-1.8.10.tgz |(mkdir -p /tmp/$$ &&cd /tmp/$$ &&tar -xpzf -)
 mkdir -p /tmp/rubygems
 mv /tmp/$$/*/* /tmp/rubygems
 rm -rf /tmp/$$
@@ -10,3 +10,5 @@ cd /tmp/rubygems
 ruby setup.rb --no-format-executable
 rm -fr /tmp/rubygems
 )
+gem update --system
+gem update --no-rdoc --no-ri

--- a/scriptbuilder/src/test/resources/test_install_ruby_scriptbuilder.sh
+++ b/scriptbuilder/src/test/resources/test_install_ruby_scriptbuilder.sh
@@ -140,14 +140,14 @@ function installRuby() {
   if ! hash ruby 2>/dev/null; then
     if which dpkg &> /dev/null; then
       apt-get-update
-      apt-get install -y ruby ruby1.8-dev build-essential wget libruby-extras libruby1.8-extras
+      apt-get install -y ruby ruby1.8-dev build-essential
     elif which rpm &> /dev/null; then
       # Disable chef from the base repo (http://tickets.opscode.com/browse/CHEF-2906)
       sed -i "s/\[base\]/\0\n\exclude=ruby*/g" /etc/yum.repos.d/CentOS-Base.repo
       # Make sure to install an appropriate ruby version
       yum erase -y ruby ruby-libs
       rpm -Uvh http://rbel.co/rbel5
-      yum install -y ruby ruby-devel make gcc gcc-c++ kernel-devel automake autoconf wget
+      yum install -y ruby ruby-devel make gcc gcc-c++ automake autoconf
     else
       abort "we only support apt-get and yum right now... please contribute"
     fi
@@ -167,7 +167,7 @@ END_OF_JCLOUDS_SCRIPT
 	
 	(
 	mkdir /tmp/$$
-	curl -q -s -S -L --connect-timeout 10 --max-time 600 --retry 20 -X GET  http://production.cf.rubygems.org/rubygems/rubygems-1.3.7.tgz |(mkdir -p /tmp/$$ &&cd /tmp/$$ &&tar -xpzf -)
+	curl -q -s -S -L --connect-timeout 10 --max-time 600 --retry 20 -X GET  http://production.cf.rubygems.org/rubygems/rubygems-1.8.10.tgz |(mkdir -p /tmp/$$ &&cd /tmp/$$ &&tar -xpzf -)
 	mkdir -p /tmp/rubygems
 	mv /tmp/$$/*/* /tmp/rubygems
 	rm -rf /tmp/$$
@@ -175,6 +175,8 @@ END_OF_JCLOUDS_SCRIPT
 	ruby setup.rb --no-format-executable
 	rm -fr /tmp/rubygems
 	)
+	gem update --system
+	gem update --no-rdoc --no-ri
 	
 END_OF_JCLOUDS_SCRIPT
    


### PR DESCRIPTION
Removed libruby-extras package install, since it is no needed and it does not longer exist in Ubuntu 12.04. Also fixed RubyGems install statement to make sure it is updated to
the latest version.

This commit will break a test in jclouds-chef. I'll upload the fix as soon as this PR is merged.
