### PR TITLE
Enforce use of StringBuilder via Checkstyle

### DIFF
--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/AdminResources.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/AdminResources.java
@@ -50,7 +50,7 @@ public class AdminResources {
    }
 
    public static String rolePostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<role>");
       buffer.append(link("/admin/roles/1/action/privileges", "privileges"));
       buffer.append("<blocked>false</blocked>");
@@ -60,7 +60,7 @@ public class AdminResources {
    }
 
    public static String rolePutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<role>");
       buffer.append(link("/admin/roles/1/action/privileges", "privileges"));
       buffer.append(link("/admin/roles/1", "edit"));
@@ -92,7 +92,7 @@ public class AdminResources {
    }
 
    public static String datacenterLimitsPostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<limit>");
       buffer.append("<cpuHard>0</cpuHard>");
       buffer.append("<cpuSoft>0</cpuSoft>");
@@ -113,7 +113,7 @@ public class AdminResources {
    }
 
    public static String datacenterLimitsPutPayload(final EnterpriseDto enterprise) {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<limit>");
       buffer.append(link("/admin/enterprises/" + enterprise.getId() + "/limits/1", "edit"));
       buffer.append("<cpuHard>0</cpuHard>");
@@ -136,7 +136,7 @@ public class AdminResources {
    }
 
    public static String userPostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<user>");
       buffer.append(link("/admin/roles/1", "role"));
       buffer.append("<active>true</active>");
@@ -168,7 +168,7 @@ public class AdminResources {
    }
 
    public static String userPutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<user>");
       buffer.append(link("/admin/roles/1", "role"));
       buffer.append(link("/admin/enterprises/1/users/1", "edit"));

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/CloudResources.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/CloudResources.java
@@ -149,7 +149,7 @@ public class CloudResources {
    }
 
    public static String virtualMachineStatePayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<virtualmachinestate>");
       buffer.append("<state>ON</state>");
       buffer.append("</virtualmachinestate>");
@@ -223,7 +223,7 @@ public class CloudResources {
    }
 
    public static String virtualDatacenterPostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<virtualDatacenter>");
       buffer.append("<cpuHard>0</cpuHard>");
       buffer.append("<cpuSoft>0</cpuSoft>");
@@ -245,7 +245,7 @@ public class CloudResources {
    }
 
    public static String virtualAppliancePostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<virtualAppliance>");
       buffer.append("<error>0</error>");
       buffer.append("<highDisponibility>0</highDisponibility>");
@@ -256,7 +256,7 @@ public class CloudResources {
    }
 
    public static String virtualMachinePostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<virtualMachine>");
       buffer.append("<cpu>0</cpu>");
       buffer.append("<hdInBytes>0</hdInBytes>");
@@ -271,7 +271,7 @@ public class CloudResources {
    }
 
    public static String virtualDatacenterPutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<virtualDatacenter>");
       buffer.append(link("/admin/datacenters/1", "datacenter"));
       buffer.append(link("/cloud/virtualdatacenters/1/disks", "disks"));
@@ -307,7 +307,7 @@ public class CloudResources {
    }
 
    public static String virtualDatacenterRefPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<links>");
       buffer.append(link("/cloud/virtualdatacenters/1", "virtualdatacenter"));
       buffer.append("</links>");
@@ -315,7 +315,7 @@ public class CloudResources {
    }
 
    public static String virtualAppliancePutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<virtualAppliance>");
       buffer.append(link("/cloud/virtualdatacenters/1", "virtualdatacenter"));
       buffer.append(link("/cloud/virtualdatacenters/1/virtualappliances/1/action/deploy", "deploy"));
@@ -334,7 +334,7 @@ public class CloudResources {
    }
 
    public static String virtualMachinePutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<virtualMachine>");
       buffer.append(link("/cloud/virtualdatacenters/1/virtualappliances/1/virtualmachines/1/action/deploy", "deploy"));
       buffer.append(link("/cloud/virtualdatacenters/1/virtualappliances/1/virtualmachines/1/storage/disks", "disks"));
@@ -368,7 +368,7 @@ public class CloudResources {
    }
 
    public static String volumePostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<volume>");
       buffer.append(link("/cloud/virtualdatacenters/1/tiers/1", "tier"));
       buffer.append("<name>Volume</name>");
@@ -378,7 +378,7 @@ public class CloudResources {
    }
 
    public static String volumePutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<volume>");
       buffer.append(link("/cloud/virtualdatacenters/1/volumes/1/action/initiatormappings", "action",
             "initiator mappings"));
@@ -394,7 +394,7 @@ public class CloudResources {
    }
 
    public static String cloudTierPutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<tier>");
       buffer.append(link("/cloud/virtualdatacenters/1/tiers/1", "edit"));
       buffer.append("<enabled>true</enabled>");
@@ -405,7 +405,7 @@ public class CloudResources {
    }
 
    public static String deployPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<virtualmachinetask>");
       buffer.append("<forceEnterpriseSoftLimits>false</forceEnterpriseSoftLimits>");
       buffer.append("</virtualmachinetask>");
@@ -413,7 +413,7 @@ public class CloudResources {
    }
 
    public static String undeployPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<virtualmachinetask>");
       buffer.append("<forceEnterpriseSoftLimits>false</forceEnterpriseSoftLimits>");
       buffer.append("<forceUndeploy>true</forceUndeploy>");
@@ -435,7 +435,7 @@ public class CloudResources {
    }
 
    public static String hardDiskPostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<disk>");
       buffer.append("<sizeInMb>1024</sizeInMb>");
       buffer.append("</disk>");
@@ -443,7 +443,7 @@ public class CloudResources {
    }
 
    public static String hardDiskPutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<disk>");
       buffer.append(link("/cloud/virtualdatacenters/1", "virtualdatacenter"));
       buffer.append(link("/cloud/virtualdatacenters/1/disks/1", "edit"));

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/ConfigResources.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/ConfigResources.java
@@ -80,7 +80,7 @@ public class ConfigResources {
    }
 
    public static String licensePutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<license>");
       buffer.append(link("/admin/enterprises/config/licenses/1", "edit"));
       buffer.append("<customerid>3bca6d1d-5fe2-42c5-82ea-a5276ea8c71c</customerid>");
@@ -91,7 +91,7 @@ public class ConfigResources {
    }
 
    public static String licensePostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<license>");
       buffer.append("<customerid>3bca6d1d-5fe2-42c5-82ea-a5276ea8c71c</customerid>");
       buffer.append("<code>" + readLicense("license/expired") + "</code>");
@@ -100,7 +100,7 @@ public class ConfigResources {
    }
 
    public static String categoryPostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<category>");
       buffer.append("<defaultCategory>false</defaultCategory>");
       buffer.append("<erasable>false</erasable>");
@@ -110,7 +110,7 @@ public class ConfigResources {
    }
 
    public static String categoryPutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<category>");
       buffer.append(link("/config/categories/1", "edit"));
       buffer.append("<defaultCategory>false</defaultCategory>");
@@ -122,7 +122,7 @@ public class ConfigResources {
    }
 
    public static String iconPutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<icon>");
       buffer.append(link("/config/icons/1", "edit"));
       buffer.append("<id>1</id>");
@@ -133,7 +133,7 @@ public class ConfigResources {
    }
 
    public static String iconPostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<icon>");
       buffer.append("<name>icon</name>");
       buffer.append("<path>http://www.pixeljoint.com/files/icons/mipreview1.gif</path>");
@@ -142,7 +142,7 @@ public class ConfigResources {
    }
 
    public static String propertyPutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<property>");
       buffer.append(link("/config/properties/1", "edit"));
       buffer.append("<description>Time interval in seconds</description>");

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/EnterpriseResources.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/EnterpriseResources.java
@@ -81,7 +81,7 @@ public class EnterpriseResources {
    }
 
    public static String enterprisePostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<enterprise>");
       buffer.append("<cpuHard>0</cpuHard>");
       buffer.append("<cpuSoft>0</cpuSoft>");
@@ -104,7 +104,7 @@ public class EnterpriseResources {
    }
 
    public static String enterprisePutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<enterprise>");
       buffer.append(link("/admin/enterprises/1", "edit"));
       buffer.append(link("/admin/enterprises/1/limits", "limits"));
@@ -139,7 +139,7 @@ public class EnterpriseResources {
    }
 
    public static String enterprisePropertiesPutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<enterpriseProperties>");
       buffer.append(link("/admin/enterprises/1/properties", "edit"));
       buffer.append(link("/admin/enterprises/1", "enterprise"));
@@ -192,7 +192,7 @@ public class EnterpriseResources {
    }
 
    public static String datacenterLimitsPostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<limit>");
       buffer.append("<cpuHard>0</cpuHard>");
       buffer.append("<cpuSoft>0</cpuSoft>");
@@ -213,7 +213,7 @@ public class EnterpriseResources {
    }
 
    public static String templateListPostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<templateDefinitionList>");
       buffer.append("<name>myList</name>");
       buffer.append("<url>http://virtualapp-repository.com/vapp1.ovf</url>");
@@ -222,7 +222,7 @@ public class EnterpriseResources {
    }
 
    public static String templateListPutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<templateDefinitionList>");
       buffer.append(link("/admin/enterprises/1/appslib/templateDefinitionLists/1", "edit"));
       buffer.append(link("/admin/enterprises/1/appslib/templateDefinitionLists/1/actions/repositoryStatus",
@@ -235,7 +235,7 @@ public class EnterpriseResources {
    }
 
    public static String datacenterLimitsPutPayload(final EnterpriseDto enterprise) {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<limit>");
       buffer.append(link("/admin/enterprises/" + enterprise.getId() + "/limits/1", "edit"));
       buffer.append("<cpuHard>0</cpuHard>");
@@ -258,7 +258,7 @@ public class EnterpriseResources {
    }
 
    public static String userPostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<user>");
       buffer.append(link("/admin/roles/1", "role"));
       buffer.append("<active>true</active>");
@@ -290,7 +290,7 @@ public class EnterpriseResources {
    }
 
    public static String userPutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<user>");
       buffer.append(link("/admin/roles/1", "role"));
       buffer.append(link("/admin/enterprises/1/users/1", "edit"));

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/InfrastructureResources.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/InfrastructureResources.java
@@ -251,7 +251,7 @@ public class InfrastructureResources {
    }
 
    public static String datacenterPostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<datacenter>");
       buffer.append("<location>Honolulu</location>");
       buffer.append("<name>DC</name>");
@@ -260,7 +260,7 @@ public class InfrastructureResources {
    }
 
    public static String rackPostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<rack>");
       buffer.append("<haEnabled>false</haEnabled>");
       buffer.append("<name>Aloha</name>");
@@ -274,7 +274,7 @@ public class InfrastructureResources {
    }
 
    public static String managedRackPostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<ucsrack>");
       buffer.append("<haEnabled>false</haEnabled>");
       buffer.append("<name>Aloha</name>");
@@ -288,7 +288,7 @@ public class InfrastructureResources {
    }
 
    public static String storagePoolPostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<storagePool>");
       buffer.append("<availableSizeInMb>0</availableSizeInMb>");
       buffer.append("<enabled>false</enabled>");
@@ -300,7 +300,7 @@ public class InfrastructureResources {
    }
 
    public static String storageDevicePostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<device>");
       buffer.append("<iscsiIp>10.10.10.10</iscsiIp>");
       buffer.append("<iscsiPort>99</iscsiPort>");
@@ -311,7 +311,7 @@ public class InfrastructureResources {
    }
 
    public static String machinePostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<machine>");
       buffer.append("<datastores/>");
       buffer.append("<description>A hawaian machine</description>");
@@ -326,7 +326,7 @@ public class InfrastructureResources {
    }
 
    public static String remoteServicePostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<remoteService>");
       buffer.append("<status>0</status>");
       buffer.append("<type>NODE_COLLECTOR</type>");
@@ -336,7 +336,7 @@ public class InfrastructureResources {
    }
 
    public static String datacenterPutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<datacenter>");
       buffer.append(link("/admin/datacenters/1/action/checkmachinestate", "checkmachinestate"));
       buffer.append(link("/admin/datacenters/1/action/checkmachineipmistate", "checkmachineipmistate"));
@@ -361,7 +361,7 @@ public class InfrastructureResources {
    }
 
    public static String storagePoolPutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<storagePool>");
       buffer.append(link("/admin/datacenters/1/storage/devices/1", "device"));
       buffer.append(link("/admin/datacenters/1/storage/devices/1/pools/tururututu", "edit"));
@@ -376,7 +376,7 @@ public class InfrastructureResources {
    }
 
    public static String tierPutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<tier>");
       buffer.append(link("/admin/datacenters/1/storage/tiers/1", "edit"));
       buffer.append(link("/admin/datacenters/1", "datacenter"));
@@ -389,7 +389,7 @@ public class InfrastructureResources {
    }
 
    public static String rackPutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<rack>");
       buffer.append(link("/admin/datacenters/1", "datacenter"));
       buffer.append(link("/admin/datacenters/1/racks/1", "edit"));
@@ -407,7 +407,7 @@ public class InfrastructureResources {
    }
 
    public static String managedRackPutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<ucsrack>");
       buffer.append(link("/admin/datacenters/1", "datacenter"));
       buffer.append(link("/admin/datacenters/1/racks/1", "edit"));
@@ -434,7 +434,7 @@ public class InfrastructureResources {
    }
 
    public static String storageDevicePutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<device>");
       buffer.append(link("/admin/datacenters/1", "datacenter"));
       buffer.append(link("/admin/datacenters/1/storage/devices/1", "edit"));
@@ -449,7 +449,7 @@ public class InfrastructureResources {
    }
 
    public static String remoteServicePutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<remoteService>");
       buffer.append(link("/admin/datacenters/1/remoteservices/nodecollector/action/check", "check"));
       buffer.append(link("/admin/datacenters/1", "datacenter"));
@@ -463,7 +463,7 @@ public class InfrastructureResources {
    }
 
    public static String machinePutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<machine>");
       buffer.append(link("/admin/datacenters/1/racks/1/machines/1", "edit"));
       buffer.append(link("/admin/datacenters/1/racks/1", "rack"));

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/NetworkResources.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/NetworkResources.java
@@ -146,7 +146,7 @@ public class NetworkResources {
    }
 
    public static String vlanNetworkPostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<network>");
       buffer.append("<address>192.168.1.0</address>");
       buffer.append("<defaultNetwork>true</defaultNetwork>");
@@ -158,7 +158,7 @@ public class NetworkResources {
    }
 
    public static String privateNetworkPutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<network>");
       buffer.append(link("/cloud/virtualdatacenters/1/privatenetworks/1", "edit"));
       buffer.append(link("/cloud/virtualdatacenters/1/privatenetworks/1/ips", "ips"));
@@ -174,7 +174,7 @@ public class NetworkResources {
    }
 
    public static String publicNetworkPutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<network>");
       buffer.append(link("/admin/datacenters/1/network/1", "edit"));
       buffer.append(link("/admin/datacenters/1/network/1/ips", "ips"));
@@ -190,7 +190,7 @@ public class NetworkResources {
    }
 
    public static String externalNetworkPutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<network>");
       buffer.append(link("/admin/datacenters/1/network/1", "edit"));
       buffer.append(link("/admin/enterprises/1", "enterprise"));
@@ -207,7 +207,7 @@ public class NetworkResources {
    }
 
    public static String unmanagedNetworkPutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<network>");
       buffer.append(link("/admin/datacenters/1/network/1", "edit"));
       buffer.append(link("/admin/enterprises/1", "enterprise"));
@@ -224,7 +224,7 @@ public class NetworkResources {
    }
 
    public static String privateIpPutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<ipPoolManagement>");
       buffer.append(link("/cloud/virtualdatacenters/1/privatenetworks/1/ips/1", "self", "privateip"));
       buffer.append("<available>false</available>");
@@ -237,7 +237,7 @@ public class NetworkResources {
    }
 
    public static String linksDtoPayload(final LinksDto dto) {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<links>");
       for (RESTLink link : dto.getLinks()) {
          buffer.append(link(link));

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/PricingResources.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/PricingResources.java
@@ -59,7 +59,7 @@ public class PricingResources {
    }
 
    public static String currencyPostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<currency>");
       buffer.append("<symbol>DUMMY</symbol>");
       buffer.append("<digits>3</digits>");
@@ -69,7 +69,7 @@ public class PricingResources {
    }
 
    public static String currencyPutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<currency>");
       buffer.append(link("/config/currencies/1", "edit"));
       buffer.append("<symbol>DUMMY</symbol>");
@@ -97,7 +97,7 @@ public class PricingResources {
    }
 
    public static String costcodePostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<costCode>");
       buffer.append("<name>cost code</name>");
       buffer.append("<description>description</description>");
@@ -106,7 +106,7 @@ public class PricingResources {
    }
 
    public static String costcodePutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<costCode>");
       buffer.append(link("/config/costcodes/1", "edit"));
       buffer.append("<description>description</description>");
@@ -159,7 +159,7 @@ public class PricingResources {
    }
 
    public static String pricingtemplatePostPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<pricingTemplate>");
       buffer.append("<name>pricing template</name>");
       buffer.append("<description>pt_description</description>");
@@ -182,7 +182,7 @@ public class PricingResources {
    }
 
    public static String pricingtemplatePutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<pricingTemplate>");
       buffer.append("<name>pricing template</name>");
       buffer.append("<description>pt_description</description>");
@@ -217,7 +217,7 @@ public class PricingResources {
    }
 
    public static String costcodecurrencyPutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<costCodeCurrencies>");
       buffer.append("<costCodeCurrency>");
       buffer.append("<price>300</price>");
@@ -240,7 +240,7 @@ public class PricingResources {
    }
 
    public static String pricingCostCodePutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<pricingCostCode>");
       buffer.append("<link href='http://localhost/api/config/costcodes/1' rel='costcode'/>");
       buffer.append("<link href='http://localhost/api/config/pricingtemplates/1' rel='pricingtemplate'/>");
@@ -262,7 +262,7 @@ public class PricingResources {
    }
 
    public static String pricingTierPutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<pricingTier>");
       buffer.append("<link href='http://localhost/api/admin/datacenters/1/storage/tiers/2' rel='tier'/>");
       buffer.append("<link href='http://localhost/api/config/pricingtemplates/1' rel='pricingtemplate'/>");

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/TemplateResources.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/TemplateResources.java
@@ -71,7 +71,7 @@ public class TemplateResources {
    }
 
    public static String virtualMachineTemplatePutPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<virtualMachineTemplate>");
       buffer.append(link("/admin/enterprises/1/datacenterrepositories/1/virtualmachinetemplates/1", "edit"));
       buffer.append(link("/admin/enterprises/1", "enterprise"));
@@ -105,7 +105,7 @@ public class TemplateResources {
    }
 
    public static String persistentPayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<virtualmachinetemplatepersistent>");
       buffer.append(link("/cloud/virtualdatacenters/1/tiers/1", "tier"));
       buffer.append(link("/cloud/virtualdatacenters/1", "virtualdatacenter"));
@@ -136,7 +136,7 @@ public class TemplateResources {
    }
 
    public static String conversionPutPlayload() {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append("<conversion>");
       buffer.append(link("/admin/enterprises/1/datacenterrepositories/1/virtualmachinetemplates/1/conversions/RAW",
             "edit"));

--- a/resources/checkstyle.xml
+++ b/resources/checkstyle.xml
@@ -56,4 +56,8 @@
         <property name="format" value="=\s*new TreeSet&lt;[^&gt;]"/>
         <property name="message" value="Prefer com.google.common.collect.Sets"/>
     </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="new StringBuffer"/>
+        <property name="message" value="Prefer java.lang.StringBuilder"/>
+    </module>
 </module>

--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/chef/ChefSolo.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/chef/ChefSolo.java
@@ -356,7 +356,7 @@ public class ChefSolo implements Statement {
 
    @VisibleForTesting
    void createNodeConfiguration(ImmutableList.Builder<Statement> statements) {
-      StringBuffer json = new StringBuffer();
+      StringBuilder json = new StringBuilder();
       if (jsonAttributes.isPresent()) {
          // Start the node configuration with the attributes, but remove the
          // last bracket to append the run list to the json configuration


### PR DESCRIPTION
Callers usually do not intend to use a synchronized StringBuffer.
EasyMock requires use of StringBuffer in some situations.
