### PR TITLE
Enforce use of Atomics.newReference via Checkstyle

### DIFF
--- a/apis/deltacloud/src/main/java/org/jclouds/deltacloud/config/DeltacloudRestClientModule.java
+++ b/apis/deltacloud/src/main/java/org/jclouds/deltacloud/config/DeltacloudRestClientModule.java
@@ -55,6 +55,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.Atomics;
 import com.google.inject.Provides;
 
 /**
@@ -77,7 +78,7 @@ public class DeltacloudRestClientModule extends RestClientModule<DeltacloudClien
       bind(HttpRetryHandler.class).annotatedWith(Redirection.class).to(DeltacloudRedirectionRetryHandler.class);
    }
 
-   protected AtomicReference<AuthorizationException> authException = new AtomicReference<AuthorizationException>();
+   protected AtomicReference<AuthorizationException> authException = Atomics.newReference();
 
    @Provides
    @Singleton

--- a/apis/ec2/src/main/java/org/jclouds/ec2/compute/config/EC2ComputeServiceContextModule.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/compute/config/EC2ComputeServiceContextModule.java
@@ -47,6 +47,7 @@ import com.google.common.base.Throwables;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.Atomics;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Provides;
@@ -103,7 +104,7 @@ public class EC2ComputeServiceContextModule extends BaseComputeServiceContextMod
    protected Supplier<CacheLoader<RegionAndName, Image>> provideRegionAndNameToImageSupplierCacheLoader(
             final RegionAndIdToImage delegate) {
       return Suppliers.<CacheLoader<RegionAndName, Image>>ofInstance(new CacheLoader<RegionAndName, Image>() {
-         private final AtomicReference<AuthorizationException> authException = new AtomicReference<AuthorizationException>();
+         private final AtomicReference<AuthorizationException> authException = Atomics.newReference();
 
          @Override
          public Image load(final RegionAndName key) throws Exception {

--- a/apis/ec2/src/main/java/org/jclouds/ec2/compute/functions/PasswordCredentialsFromWindowsInstance.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/compute/functions/PasswordCredentialsFromWindowsInstance.java
@@ -46,6 +46,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
+import com.google.common.util.concurrent.Atomics;
 
 /**
  * @author Adrian Cole
@@ -82,7 +83,7 @@ public class PasswordCredentialsFromWindowsInstance implements Function<RunningI
       // 15 minutes.
       // So we create a predicate that tests if the password is ready, and wrap it in a retryable
       // predicate.
-      final AtomicReference<PasswordData> data = new AtomicReference<PasswordData>();
+      final AtomicReference<PasswordData> data = Atomics.newReference();
       Predicate<String> passwordReady = new Predicate<String>() {
          @Override
          public boolean apply(@Nullable String s) {

--- a/apis/ec2/src/main/java/org/jclouds/ec2/compute/strategy/EC2CreateNodesInGroupThenAddToSet.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/compute/strategy/EC2CreateNodesInGroupThenAddToSet.java
@@ -63,6 +63,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
+import com.google.common.util.concurrent.Atomics;
 
 /**
  * creates futures that correlate to
@@ -200,7 +201,7 @@ public class EC2CreateNodesInGroupThenAddToSet implements CreateNodesInGroupThen
 
          // block until instance is running
          logger.debug(">> awaiting status running instance(%s)", coordinates);
-         AtomicReference<NodeMetadata> node = new AtomicReference<NodeMetadata>(runningInstanceToNodeMetadata.apply(startedInstance));
+         AtomicReference<NodeMetadata> node = Atomics.newReference(runningInstanceToNodeMetadata.apply(startedInstance));
          nodeRunning.apply(node);
          logger.trace("<< running instance(%s)", coordinates);
          logger.debug(">> associating elastic IP %s to instance %s", ip, coordinates);

--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/compute/loaders/FindSecurityGroupOrCreate.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/compute/loaders/FindSecurityGroupOrCreate.java
@@ -33,6 +33,7 @@ import org.jclouds.openstack.nova.v2_0.domain.zonescoped.ZoneSecurityGroupNameAn
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.cache.CacheLoader;
+import com.google.common.util.concurrent.Atomics;
 
 /**
  * 
@@ -54,7 +55,7 @@ public class FindSecurityGroupOrCreate extends CacheLoader<ZoneAndName, Security
 
    @Override
    public SecurityGroupInZone load(ZoneAndName in) {
-      AtomicReference<ZoneAndName> securityGroupInZoneRef = new AtomicReference<ZoneAndName>(checkNotNull(in,
+      AtomicReference<ZoneAndName> securityGroupInZoneRef = Atomics.newReference(checkNotNull(in,
                "zoneSecurityGroupNameAndPorts"));
       if (returnSecurityGroupExistsInZone.apply(securityGroupInZoneRef)) {
          return returnExistingSecurityGroup(securityGroupInZoneRef);

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/compute/functions/AllocateAndAddFloatingIpToNodeExpectTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/compute/functions/AllocateAndAddFloatingIpToNodeExpectTest.java
@@ -39,6 +39,7 @@ import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.Atomics;
 
 /**
  * Tests the compute service abstraction of the nova api.
@@ -77,7 +78,7 @@ public class AllocateAndAddFloatingIpToNodeExpectTest extends BaseNovaComputeSer
                         .put(addFloatingIPRequest, addFloatingIPResponse).build()).getContext().utils().injector()
                .getInstance(AllocateAndAddFloatingIpToNode.class);
 
-      AtomicReference<NodeMetadata> nodeRef = new AtomicReference<NodeMetadata>(node);
+      AtomicReference<NodeMetadata> nodeRef = Atomics.newReference(node);
       fn.apply(nodeRef);
       NodeMetadata node1 = nodeRef.get();
       assertNotNull(node1);
@@ -124,7 +125,7 @@ public class AllocateAndAddFloatingIpToNodeExpectTest extends BaseNovaComputeSer
                                  listResponseForUnassigned).build()).getContext().utils().injector()
                .getInstance(AllocateAndAddFloatingIpToNode.class);
 
-      AtomicReference<NodeMetadata> nodeRef = new AtomicReference<NodeMetadata>(node);
+      AtomicReference<NodeMetadata> nodeRef = Atomics.newReference(node);
       fn.apply(nodeRef);
       NodeMetadata node1 = nodeRef.get();
       assertNotNull(node1);

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/functions/FindSecurityGroupWithNameAndReturnTrueExpectTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/functions/FindSecurityGroupWithNameAndReturnTrueExpectTest.java
@@ -37,6 +37,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.Atomics;
 
 /**
  * 
@@ -61,7 +62,7 @@ public class FindSecurityGroupWithNameAndReturnTrueExpectTest extends BaseNovaAp
       FindSecurityGroupWithNameAndReturnTrue predicate = new FindSecurityGroupWithNameAndReturnTrue(
                apiWhenSecurityGroupsExist);
 
-      AtomicReference<ZoneAndName> securityGroupInZoneRef = new AtomicReference<ZoneAndName>(ZoneAndName
+      AtomicReference<ZoneAndName> securityGroupInZoneRef = Atomics.newReference(ZoneAndName
                .fromZoneAndName("az-1.region-a.geo-1", "name1"));
 
       // we can find it
@@ -91,7 +92,7 @@ public class FindSecurityGroupWithNameAndReturnTrueExpectTest extends BaseNovaAp
 
       ZoneAndName zoneAndGroup = ZoneAndName.fromZoneAndName("az-1.region-a.geo-1", "name2");
 
-      AtomicReference<ZoneAndName> securityGroupInZoneRef = new AtomicReference<ZoneAndName>(zoneAndGroup);
+      AtomicReference<ZoneAndName> securityGroupInZoneRef = Atomics.newReference(zoneAndGroup);
 
       // we cannot find it
       assertFalse(predicate.apply(securityGroupInZoneRef));

--- a/apis/sqs/src/test/java/org/jclouds/sqs/internal/BaseSQSApiLiveTest.java
+++ b/apis/sqs/src/test/java/org/jclouds/sqs/internal/BaseSQSApiLiveTest.java
@@ -42,6 +42,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Sets;
 import com.google.common.reflect.TypeToken;
+import com.google.common.util.concurrent.Atomics;
 import com.google.common.util.concurrent.Uninterruptibles;
 
 /**
@@ -81,7 +82,7 @@ public class BaseSQSApiLiveTest extends BaseContextLiveTest<RestContext<SQSApi, 
    }
 
    protected String assertPolicyPresent(final URI queue) {
-      final AtomicReference<String> policy = new AtomicReference<String>();
+      final AtomicReference<String> policy = Atomics.newReference();
       assertEventually(new Runnable() {
          public void run() {
             String policyForAuthorizationByAccount = api().getQueueApi().getAttribute(queue, "Policy");

--- a/compute/src/main/java/org/jclouds/compute/internal/BaseComputeService.java
+++ b/compute/src/main/java/org/jclouds/compute/internal/BaseComputeService.java
@@ -105,6 +105,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
+import com.google.common.util.concurrent.Atomics;
 import com.google.common.util.concurrent.ListenableFuture;
 
 /**
@@ -294,7 +295,7 @@ public class BaseComputeService implements ComputeService {
    protected NodeMetadata doDestroyNode(final String id) {
       checkNotNull(id, "id");
       logger.debug(">> destroying node(%s)", id);
-      final AtomicReference<NodeMetadata> node = new AtomicReference<NodeMetadata>();
+      final AtomicReference<NodeMetadata> node = Atomics.newReference();
       RetryablePredicate<String> tester = new RetryablePredicate<String>(new Predicate<String>() {
 
          @Override
@@ -419,7 +420,7 @@ public class BaseComputeService implements ComputeService {
    public void rebootNode(String id) {
       checkNotNull(id, "id");
       logger.debug(">> rebooting node(%s)", id);
-      AtomicReference<NodeMetadata> node = new AtomicReference<NodeMetadata>(rebootNodeStrategy.rebootNode(id));
+      AtomicReference<NodeMetadata> node = Atomics.newReference(rebootNodeStrategy.rebootNode(id));
       boolean successful = nodeRunning.apply(node);
       logger.debug("<< rebooted node(%s) success(%s)", id, successful);
    }
@@ -450,7 +451,7 @@ public class BaseComputeService implements ComputeService {
    public void resumeNode(String id) {
       checkNotNull(id, "id");
       logger.debug(">> resuming node(%s)", id);
-      AtomicReference<NodeMetadata> node = new AtomicReference<NodeMetadata>(resumeNodeStrategy.resumeNode(id));
+      AtomicReference<NodeMetadata> node = Atomics.newReference(resumeNodeStrategy.resumeNode(id));
       boolean successful = nodeRunning.apply(node);
       logger.debug("<< resumed node(%s) success(%s)", id, successful);
    }
@@ -481,7 +482,7 @@ public class BaseComputeService implements ComputeService {
    public void suspendNode(String id) {
       checkNotNull(id, "id");
       logger.debug(">> suspending node(%s)", id);
-      AtomicReference<NodeMetadata> node = new AtomicReference<NodeMetadata>(suspendNodeStrategy.suspendNode(id));
+      AtomicReference<NodeMetadata> node = Atomics.newReference(suspendNodeStrategy.suspendNode(id));
       boolean successful = nodeSuspended.apply(node);
       logger.debug("<< suspended node(%s) success(%s)", id, successful);
    }

--- a/compute/src/main/java/org/jclouds/compute/util/ConcurrentOpenSocketFinder.java
+++ b/compute/src/main/java/org/jclouds/compute/util/ConcurrentOpenSocketFinder.java
@@ -30,10 +30,12 @@ import com.google.common.base.Predicate;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
+import com.google.common.util.concurrent.Atomics;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
+
 public class ConcurrentOpenSocketFinder implements OpenSocketFinder {
 
    @Resource
@@ -62,7 +64,7 @@ public class ConcurrentOpenSocketFinder implements OpenSocketFinder {
       long period = timeUnits.convert(1, TimeUnit.SECONDS);
 
       // For storing the result; needed because predicate will just tell us true/false
-      final AtomicReference<HostAndPort> result = new AtomicReference<HostAndPort>();
+      final AtomicReference<HostAndPort> result = Atomics.newReference();
 
       Predicate<Collection<HostAndPort>> concurrentOpenSocketFinder = new Predicate<Collection<HostAndPort>>() {
 
@@ -109,7 +111,7 @@ public class ConcurrentOpenSocketFinder implements OpenSocketFinder {
     * @throws InterruptedException 
     */
    private HostAndPort findOpenSocket(final Collection<HostAndPort> sockets) {
-      final AtomicReference<HostAndPort> result = new AtomicReference<HostAndPort>();
+      final AtomicReference<HostAndPort> result = Atomics.newReference();
       final CountDownLatch latch = new CountDownLatch(1);
       final AtomicInteger completeCount = new AtomicInteger();
       

--- a/compute/src/test/java/org/jclouds/compute/functions/PollNodeRunningTest.java
+++ b/compute/src/test/java/org/jclouds/compute/functions/PollNodeRunningTest.java
@@ -38,6 +38,7 @@ import org.jclouds.compute.strategy.GetNodeMetadataStrategy;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Predicate;
+import com.google.common.util.concurrent.Atomics;
 
 /**
  * @author Adrian Cole
@@ -60,7 +61,7 @@ public class PollNodeRunningTest {
 
       };
 
-      AtomicReference<NodeMetadata> atomicNode = new AtomicReference<NodeMetadata>(pendingNode);
+      AtomicReference<NodeMetadata> atomicNode = Atomics.newReference(pendingNode);
       try {
          new PollNodeRunning(nodeRunning).apply(atomicNode);
       } finally {
@@ -84,7 +85,7 @@ public class PollNodeRunningTest {
 
       };
 
-      AtomicReference<NodeMetadata> atomicNode = new AtomicReference<NodeMetadata>(pendingNode);
+      AtomicReference<NodeMetadata> atomicNode = Atomics.newReference(pendingNode);
       try {
          new PollNodeRunning(nodeRunning).apply(atomicNode);
       } finally {
@@ -107,7 +108,7 @@ public class PollNodeRunningTest {
 
       };
 
-      AtomicReference<NodeMetadata> atomicNode = new AtomicReference<NodeMetadata>(pendingNode);
+      AtomicReference<NodeMetadata> atomicNode = Atomics.newReference(pendingNode);
       try {
          new PollNodeRunning(nodeRunning).apply(atomicNode);
       } finally {
@@ -131,7 +132,7 @@ public class PollNodeRunningTest {
             return super.nodeRunning(statusRunning, timeouts, period);
          }
       }.nodeRunning(nodeRunning, timeouts, period);
-      AtomicReference<NodeMetadata> atomicNode = new AtomicReference<NodeMetadata>(pendingNode);
+      AtomicReference<NodeMetadata> atomicNode = Atomics.newReference(pendingNode);
 
       // Simulate transient error: first call returns null; subsequent calls
       // return the running node

--- a/compute/src/test/java/org/jclouds/compute/predicates/AtomicNodePredicatesTest.java
+++ b/compute/src/test/java/org/jclouds/compute/predicates/AtomicNodePredicatesTest.java
@@ -25,6 +25,8 @@ import static org.easymock.EasyMock.verify;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.google.common.util.concurrent.Atomics;
+
 import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.NodeMetadataBuilder;
 import org.jclouds.compute.domain.NodeMetadata.Status;
@@ -53,7 +55,7 @@ public class AtomicNodePredicatesTest {
       replay(computeService);
 
       AtomicNodeRunning nodeRunning = new AtomicNodeRunning(computeService);
-      AtomicReference<NodeMetadata> reference = new AtomicReference<NodeMetadata>(running);
+      AtomicReference<NodeMetadata> reference = Atomics.newReference(running);
       Assert.assertTrue(nodeRunning.apply(reference));
       Assert.assertEquals(reference.get(), running);
 
@@ -71,7 +73,7 @@ public class AtomicNodePredicatesTest {
       replay(computeService);
 
       AtomicNodeRunning nodeRunning = new AtomicNodeRunning(computeService);
-      AtomicReference<NodeMetadata> reference = new AtomicReference<NodeMetadata>(pending);
+      AtomicReference<NodeMetadata> reference = Atomics.newReference(pending);
       Assert.assertFalse(nodeRunning.apply(reference));
       Assert.assertEquals(reference.get(), pending);
 
@@ -95,7 +97,7 @@ public class AtomicNodePredicatesTest {
       replay(computeService);
 
       AtomicNodeRunning nodeRunning = new AtomicNodeRunning(computeService);
-      AtomicReference<NodeMetadata> reference = new AtomicReference<NodeMetadata>(newNode);
+      AtomicReference<NodeMetadata> reference = Atomics.newReference(newNode);
       Assert.assertFalse(nodeRunning.apply(reference));
       Assert.assertEquals(reference.get(), pending);
 
@@ -113,7 +115,7 @@ public class AtomicNodePredicatesTest {
       replay(computeService);
 
       AtomicNodeRunning nodeRunning = new AtomicNodeRunning(computeService);
-      AtomicReference<NodeMetadata> reference = new AtomicReference<NodeMetadata>(pending);
+      AtomicReference<NodeMetadata> reference = Atomics.newReference(pending);
       Assert.assertTrue(nodeRunning.apply(reference));
       Assert.assertEquals(reference.get(), running);
 
@@ -139,7 +141,7 @@ public class AtomicNodePredicatesTest {
       replay(computeService);
 
       AtomicNodeRunning nodeRunning = new AtomicNodeRunning(computeService);
-      AtomicReference<NodeMetadata> reference = new AtomicReference<NodeMetadata>(node);
+      AtomicReference<NodeMetadata> reference = Atomics.newReference(node);
       Assert.assertTrue(nodeRunning.apply(reference));
       Assert.assertEquals(reference.get(), node);
    }
@@ -152,7 +154,7 @@ public class AtomicNodePredicatesTest {
       replay(computeService);
 
       AtomicNodeRunning nodeRunning = new AtomicNodeRunning(computeService);
-      AtomicReference<NodeMetadata> reference = new AtomicReference<NodeMetadata>(node);
+      AtomicReference<NodeMetadata> reference = Atomics.newReference(node);
       nodeRunning.apply(reference);
       Assert.assertEquals(reference.get(), node);
    }
@@ -165,7 +167,7 @@ public class AtomicNodePredicatesTest {
       replay(computeService);
 
       AtomicNodeRunning nodeRunning = new AtomicNodeRunning(computeService);
-      AtomicReference<NodeMetadata> reference = new AtomicReference<NodeMetadata>(node);
+      AtomicReference<NodeMetadata> reference = Atomics.newReference(node);
       nodeRunning.apply(reference);
       Assert.assertEquals(reference.get(), node);
    }

--- a/compute/src/test/java/org/jclouds/compute/strategy/CustomizeNodeAndAddToGoodMapOrPutExceptionIntoBadMapTest.java
+++ b/compute/src/test/java/org/jclouds/compute/strategy/CustomizeNodeAndAddToGoodMapOrPutExceptionIntoBadMapTest.java
@@ -47,6 +47,7 @@ import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.Atomics;
 
 /**
  * @author Adrian Cole
@@ -81,7 +82,7 @@ public class CustomizeNodeAndAddToGoodMapOrPutExceptionIntoBadMapTest {
       // replay mocks
       replay(initScriptRunnerFactory, openSocketFinder);
       // run
-      AtomicReference<NodeMetadata> atomicNode = new AtomicReference<NodeMetadata>(pendingNode);
+      AtomicReference<NodeMetadata> atomicNode = Atomics.newReference(pendingNode);
       new CustomizeNodeAndAddToGoodMapOrPutExceptionIntoBadMap(pollNodeRunning, openSocketFinder,
             templateOptionsToStatement, initScriptRunnerFactory, options, atomicNode, goodNodes, badNodes,
             customizationResponses).apply(atomicNode);
@@ -126,7 +127,7 @@ public class CustomizeNodeAndAddToGoodMapOrPutExceptionIntoBadMapTest {
       replay(initScriptRunnerFactory, openSocketFinder);
 
       // run
-      AtomicReference<NodeMetadata> atomicNode = new AtomicReference<NodeMetadata>(pendingNode);
+      AtomicReference<NodeMetadata> atomicNode = Atomics.newReference(pendingNode);
       new CustomizeNodeAndAddToGoodMapOrPutExceptionIntoBadMap(pollNodeRunning, openSocketFinder,
             templateOptionsToStatement, initScriptRunnerFactory, options, atomicNode, goodNodes, badNodes,
             customizationResponses).apply(atomicNode);

--- a/core/src/main/java/org/jclouds/http/functions/ParseFirstJsonValueNamed.java
+++ b/core/src/main/java/org/jclouds/http/functions/ParseFirstJsonValueNamed.java
@@ -38,6 +38,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Closeables;
+import com.google.common.util.concurrent.Atomics;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.inject.TypeLiteral;
@@ -69,7 +70,7 @@ public class ParseFirstJsonValueNamed<T> implements Function<HttpResponse, T> {
          reader = new JsonReader(new InputStreamReader(arg0.getPayload().getInput()));
          // in case keys are not in quotes
          reader.setLenient(true);
-         AtomicReference<String> name = new AtomicReference<String>();
+         AtomicReference<String> name = Atomics.newReference();
          JsonToken token = reader.peek();
          for (; token != JsonToken.END_DOCUMENT && nnn(this.name, reader, token, name); token = skipAndPeek(token,
                reader)) {

--- a/core/src/main/java/org/jclouds/lifecycle/BaseLifeCycle.java
+++ b/core/src/main/java/org/jclouds/lifecycle/BaseLifeCycle.java
@@ -28,6 +28,7 @@ import javax.annotation.PreDestroy;
 import javax.annotation.Resource;
 
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Atomics;
 
 import org.jclouds.logging.Logger;
 
@@ -44,7 +45,7 @@ public abstract class BaseLifeCycle implements Runnable, LifeCycle {
    protected final List<LifeCycle> dependencies;
    protected final Object statusLock;
    protected volatile Status status;
-   protected AtomicReference<Exception> exception = new AtomicReference<Exception>();
+   protected AtomicReference<Exception> exception = Atomics.newReference();
 
    public BaseLifeCycle(ExecutorService executor, LifeCycle... dependencies) {
       this.executorService = executor;

--- a/core/src/main/java/org/jclouds/rest/config/RestModule.java
+++ b/core/src/main/java/org/jclouds/rest/config/RestModule.java
@@ -61,6 +61,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.Atomics;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -78,7 +79,7 @@ public class RestModule extends AbstractModule {
    public static final TypeLiteral<Supplier<URI>> URI_SUPPLIER_TYPE = new TypeLiteral<Supplier<URI>>() {
    };
    protected final Map<Class<?>, Class<?>> sync2Async;
-   protected final AtomicReference<AuthorizationException> authException = new AtomicReference<AuthorizationException>();
+   protected final AtomicReference<AuthorizationException> authException = Atomics.newReference();
    
    public RestModule() {
       this(ImmutableMap.<Class<?>, Class<?>> of());

--- a/core/src/test/java/org/jclouds/json/GsonExperimentsTest.java
+++ b/core/src/test/java/org/jclouds/json/GsonExperimentsTest.java
@@ -34,6 +34,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Atomics;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
@@ -173,7 +174,7 @@ public class GsonExperimentsTest {
    }
 
    protected <T> T parseThingFromReaderOrNull(String toFind, JsonReader reader, Type type) throws IOException {
-      AtomicReference<String> name = new AtomicReference<String>();
+      AtomicReference<String> name = Atomics.newReference();
       JsonToken token = reader.peek();
       for (; token != JsonToken.END_DOCUMENT && nnn(toFind, reader, token, name); token = skipAndPeek(token, reader))
          ;

--- a/core/src/test/java/org/jclouds/rest/suppliers/MemoizedRetryOnTimeOutButNotOnAuthorizationExceptionSupplierTest.java
+++ b/core/src/test/java/org/jclouds/rest/suppliers/MemoizedRetryOnTimeOutButNotOnAuthorizationExceptionSupplierTest.java
@@ -41,6 +41,7 @@ import org.testng.annotations.Test;
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.google.common.util.concurrent.Atomics;
 
 /**
  * 
@@ -51,7 +52,7 @@ import com.google.common.base.Suppliers;
 public class MemoizedRetryOnTimeOutButNotOnAuthorizationExceptionSupplierTest {
    @Test
    public void testLoaderNormal() {
-      AtomicReference<AuthorizationException> authException = new AtomicReference<AuthorizationException>();
+      AtomicReference<AuthorizationException> authException = Atomics.newReference();
       assertEquals(new SetAndThrowAuthorizationExceptionSupplierBackedLoader<String>(Suppliers.ofInstance("foo"),
                authException).load("KEY"), "foo");
       assertEquals(authException.get(), null);
@@ -59,7 +60,7 @@ public class MemoizedRetryOnTimeOutButNotOnAuthorizationExceptionSupplierTest {
 
    @Test(expectedExceptions = AuthorizationException.class)
    public void testLoaderThrowsAuthorizationExceptionAndAlsoSetsExceptionType() {
-      AtomicReference<AuthorizationException> authException = new AtomicReference<AuthorizationException>();
+      AtomicReference<AuthorizationException> authException = Atomics.newReference();
       try {
          new SetAndThrowAuthorizationExceptionSupplierBackedLoader<String>(new Supplier<String>() {
 
@@ -75,7 +76,7 @@ public class MemoizedRetryOnTimeOutButNotOnAuthorizationExceptionSupplierTest {
 
    @Test(expectedExceptions = AuthorizationException.class)
    public void testLoaderThrowsAuthorizationExceptionAndAlsoSetsExceptionTypeWhenNested() {
-      AtomicReference<AuthorizationException> authException = new AtomicReference<AuthorizationException>();
+      AtomicReference<AuthorizationException> authException = Atomics.newReference();
       try {
          new SetAndThrowAuthorizationExceptionSupplierBackedLoader<String>(new Supplier<String>() {
 
@@ -91,7 +92,7 @@ public class MemoizedRetryOnTimeOutButNotOnAuthorizationExceptionSupplierTest {
 
    @Test(expectedExceptions = RuntimeException.class)
    public void testLoaderThrowsOriginalExceptionAndAlsoSetsExceptionTypeWhenNestedAndNotAuthorizationException() {
-      AtomicReference<AuthorizationException> authException = new AtomicReference<AuthorizationException>();
+      AtomicReference<AuthorizationException> authException = Atomics.newReference();
       try {
          new SetAndThrowAuthorizationExceptionSupplierBackedLoader<String>(new Supplier<String>() {
 
@@ -214,7 +215,7 @@ public class MemoizedRetryOnTimeOutButNotOnAuthorizationExceptionSupplierTest {
 
    private void supplierThreadSafe(Function<Supplier<Boolean>, Supplier<Boolean>> memoizer) throws Throwable {
       final AtomicInteger count = new AtomicInteger(0);
-      final AtomicReference<Throwable> thrown = new AtomicReference<Throwable>(null);
+      final AtomicReference<Throwable> thrown = Atomics.newReference(null);
       final int numThreads = 3;
       final Thread[] threads = new Thread[numThreads];
       final long timeout = TimeUnit.SECONDS.toNanos(60);

--- a/core/src/test/java/org/jclouds/rest/suppliers/SetAndThrowAuthorizationExceptionSupplierTest.java
+++ b/core/src/test/java/org/jclouds/rest/suppliers/SetAndThrowAuthorizationExceptionSupplierTest.java
@@ -28,6 +28,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.google.common.util.concurrent.Atomics;
 
 /**
  * 
@@ -37,7 +38,7 @@ import com.google.common.base.Suppliers;
 public class SetAndThrowAuthorizationExceptionSupplierTest {
    @Test
    public void testNormal() {
-      AtomicReference<AuthorizationException> authException = new AtomicReference<AuthorizationException>();
+      AtomicReference<AuthorizationException> authException = Atomics.newReference();
       assertEquals(
             new SetAndThrowAuthorizationExceptionSupplier<String>(Suppliers.ofInstance("foo"), authException).get(),
             "foo");
@@ -46,7 +47,7 @@ public class SetAndThrowAuthorizationExceptionSupplierTest {
 
    @Test(expectedExceptions = AuthorizationException.class)
    public void testThrowsAuthorizationExceptionAndAlsoSetsExceptionType() {
-      AtomicReference<AuthorizationException> authException = new AtomicReference<AuthorizationException>();
+      AtomicReference<AuthorizationException> authException = Atomics.newReference();
       try {
          new SetAndThrowAuthorizationExceptionSupplier<String>(new Supplier<String>() {
 
@@ -62,7 +63,7 @@ public class SetAndThrowAuthorizationExceptionSupplierTest {
 
    @Test(expectedExceptions = AuthorizationException.class)
    public void testThrowsAuthorizationExceptionAndAlsoSetsExceptionTypeWhenNested() {
-      AtomicReference<AuthorizationException> authException = new AtomicReference<AuthorizationException>();
+      AtomicReference<AuthorizationException> authException = Atomics.newReference();
       try {
          new SetAndThrowAuthorizationExceptionSupplier<String>(new Supplier<String>() {
 
@@ -78,7 +79,7 @@ public class SetAndThrowAuthorizationExceptionSupplierTest {
 
    @Test(expectedExceptions = RuntimeException.class)
    public void testThrowsOriginalExceptionAndAlsoSetsExceptionTypeWhenNestedAndNotAuthorizationException() {
-      AtomicReference<AuthorizationException> authException = new AtomicReference<AuthorizationException>();
+      AtomicReference<AuthorizationException> authException = Atomics.newReference();
       try {
          new SetAndThrowAuthorizationExceptionSupplier<String>(new Supplier<String>() {
 

--- a/loadbalancer/src/main/java/org/jclouds/loadbalancer/internal/BaseLoadBalancerService.java
+++ b/loadbalancer/src/main/java/org/jclouds/loadbalancer/internal/BaseLoadBalancerService.java
@@ -48,6 +48,7 @@ import org.jclouds.predicates.RetryablePredicate;
 
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
+import com.google.common.util.concurrent.Atomics;
 import com.google.inject.Inject;
 
 /**
@@ -136,7 +137,7 @@ public class BaseLoadBalancerService implements LoadBalancerService {
    public void destroyLoadBalancer(final String id) {
       checkNotNull(id, "id");
       logger.debug(">> destroying load balancer(%s)", id);
-      final AtomicReference<LoadBalancerMetadata> loadBalancer = new AtomicReference<LoadBalancerMetadata>();
+      final AtomicReference<LoadBalancerMetadata> loadBalancer = Atomics.newReference();
       RetryablePredicate<String> tester = new RetryablePredicate<String>(new Predicate<String>() {
 
          @Override

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/config/AWSEC2ComputeServiceContextModule.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/config/AWSEC2ComputeServiceContextModule.java
@@ -68,6 +68,7 @@ import com.google.common.base.Throwables;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.Atomics;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Provides;
@@ -132,7 +133,7 @@ public class AWSEC2ComputeServiceContextModule extends BaseComputeServiceContext
    protected Supplier<CacheLoader<RegionAndName, Image>> provideRegionAndNameToImageSupplierCacheLoader(
             final RegionAndIdToImage delegate) {
       return Suppliers.<CacheLoader<RegionAndName, Image>>ofInstance(new CacheLoader<RegionAndName, Image>() {
-         private final AtomicReference<AuthorizationException> authException = new AtomicReference<AuthorizationException>();
+         private final AtomicReference<AuthorizationException> authException = Atomics.newReference();
 
          @Override
          public Image load(final RegionAndName key) throws Exception {

--- a/resources/checkstyle.xml
+++ b/resources/checkstyle.xml
@@ -57,6 +57,10 @@
         <property name="message" value="Prefer com.google.common.collect.Sets"/>
     </module>
     <module name="RegexpMultiline">
+        <property name="format" value="=\s*new AtomicReference&lt;[^&gt;]"/>
+        <property name="message" value="Prefer com.google.common.util.concurrent.Atomics"/>
+    </module>
+    <module name="RegexpMultiline">
         <property name="format" value="new StringBuffer"/>
         <property name="message" value="Prefer java.lang.StringBuilder"/>
     </module>

--- a/sandbox-apis/nirvanix/src/main/java/org/jclouds/nirvanix/sdn/filters/AddSessionTokenToRequest.java
+++ b/sandbox-apis/nirvanix/src/main/java/org/jclouds/nirvanix/sdn/filters/AddSessionTokenToRequest.java
@@ -26,6 +26,8 @@ import javax.inject.Provider;
 import javax.inject.Singleton;
 import javax.ws.rs.core.UriBuilder;
 
+import com.google.commons.util.concurrent.Atomitcs;
+
 import org.jclouds.http.HttpException;
 import org.jclouds.http.HttpRequest;
 import org.jclouds.http.HttpRequestFilter;
@@ -82,7 +84,7 @@ public class AddSessionTokenToRequest implements HttpRequestFilter {
    public AddSessionTokenToRequest(@SessionToken Provider<String> authTokenProvider, Provider<UriBuilder> builder) {
       this.builder = builder;
       this.authTokenProvider = authTokenProvider;
-      authToken = new AtomicReference<String>();
+      authToken = Atomics.newReference();
    }
 
    @Override

--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/functionloader/CurrentFunctionLoader.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/functionloader/CurrentFunctionLoader.java
@@ -20,12 +20,14 @@ package org.jclouds.scriptbuilder.functionloader;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.google.common.util.concurrent.Atomics;
+
 /**
  * Means to access the current {@link FunctionLoader} instance;
  */
 public class CurrentFunctionLoader {
 
-   private static final AtomicReference<FunctionLoader> ref = new AtomicReference<FunctionLoader>(
+   private static final AtomicReference<FunctionLoader> ref = Atomics.<FunctionLoader>newReference(
             BasicFunctionLoader.INSTANCE);
 
    public static FunctionLoader get() {

--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/functions/CredentialsFromAdminAccess.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/functions/CredentialsFromAdminAccess.java
@@ -28,6 +28,7 @@ import org.jclouds.scriptbuilder.domain.StatementVisitor;
 import org.jclouds.scriptbuilder.statements.login.AdminAccess;
 
 import com.google.common.base.Function;
+import com.google.common.util.concurrent.Atomics;
 
 /**
  * 
@@ -40,7 +41,7 @@ public enum CredentialsFromAdminAccess implements Function<Statement, Credential
       if (input == null)
          return null;
       if (input instanceof AcceptsStatementVisitor) {
-         final AtomicReference<Credentials> credsHolder = new AtomicReference<Credentials>();
+         final AtomicReference<Credentials> credsHolder = Atomics.newReference();
          AcceptsStatementVisitor.class.cast(input).accept(new StatementVisitor() {
 
             @Override


### PR DESCRIPTION
Avoids duplicating types.
