### PR TITLE
use absolute link for Apache License

### DIFF
--- a/project/pom.xml
+++ b/project/pom.xml
@@ -37,8 +37,9 @@
 
     <licenses>
         <license>
-            <name>Apache License</name>
-            <url>../resources/LICENSE.txt</url>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
         </license>
     </licenses>
 


### PR DESCRIPTION
the current (relative) link doesn't resolve in artifacts/reports that maven builds.
most projects use absolute links, and the full name of the license, as added here.  (see e.g. [1])

also sets "repo" as the distribution type, giving permission for this to be hosted e.g. at maven central.  (see [2])

[1] http://maven.apache.org/guides/mini/guide-central-repository-upload.html

[2] http://maven.apache.org/pom.html
