### PR TITLE
Jclouds 549 retry after -second revision

### DIFF
--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/handlers/NovaErrorHandler.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/handlers/NovaErrorHandler.java
@@ -139,13 +139,13 @@ public class NovaErrorHandler implements HttpErrorHandler {
         Integer retryAfter = parseRetryAfterField(jsonBody);
         if (retryAfter != null) {
            return new RetryLaterException(requestLine + " failed - retry after " + retryAfter,
-                                          retryAfter);
+                                          retryAfter, "");
         }
         //next look for the retryAt field.
         Date date = parseRetryAtField(jsonBody);
         if (date != null) {
            return new RetryLaterException(requestLine + " failed - retry at " + date,
-                                          date, now);
+                                          date, now, jsonBody);
         } else {
            //parsing failed.
            return new InsufficientResourcesException(message, exception);
@@ -184,12 +184,14 @@ public class NovaErrorHandler implements HttpErrorHandler {
    }
 
    /**
-    * Take the JSON response and parse it to the "overLimit" element
+    * Take the JSON response and parse it to the "overLimit" element then get the field under it
+    * field under it.
     * @param jsonText the text to parse
+    * @param field field to resolve
     * @return null if there is no overlimit element found.
     * @throws RuntimeException on JSON parse problems.
     */
-   private String parseToOverLimitSubElement(String jsonText, String subElement) {
+   private String parseToOverLimitSubElement(String jsonText, String field) {
       JsonParser parse = new JsonParser();
       JsonElement rootElt = parse.parse(jsonText);
       if (!(rootElt instanceof JsonObject)) {
@@ -200,7 +202,7 @@ public class NovaErrorHandler implements HttpErrorHandler {
       if (overLimit == null) {
          return null;
       }
-      JsonElement jsonElement = overLimit.get(subElement);
+      JsonElement jsonElement = overLimit.get(field);
       if (jsonElement == null) {
          return null;
       }

--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/handlers/RetryLaterException.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/handlers/RetryLaterException.java
@@ -25,8 +25,6 @@ import java.util.Date;
  * This exception is raised when the Nova endpoint returns with a response telling the caller to make
  * the same request later.
  * The "later" can be specified as a delta from the current time or as an absolute time.
- * In either constructor, a reference time must be supplied to calculate the offset in milliseconds.
- *
  */
 public class RetryLaterException extends RuntimeException {
 
@@ -35,27 +33,36 @@ public class RetryLaterException extends RuntimeException {
     */
    private final long retryAfter;
 
+   /***
+    * Raw JSON
+    */
+   private final String json;
+
    /**
-    * Construct an exception
+    * Construct an exception instance to happen at a time in the future
     * @param message message
     * @param retryAfter retry after time. Negative values are converted to zero
+    * @param json the original JSON
     */
-   public RetryLaterException(String message, long retryAfter) {
+   public RetryLaterException(String message, long retryAfter, String json) {
       super(message);
       this.retryAfter = Math.max(retryAfter, 0);
+      this.json = json;
    }
 
-/**
+   /**
     * Construct an exception using the specified retry date, and the reference date used to
     * calculate the difference.
     * If the difference is negative, the retryAfter field is set to 0.
     * @param message exception text
     * @param retryDate date when a retry is permitted.
     * @param now current time to use when calculating the offset.
+    * @param json the original JSON
     */
-   public RetryLaterException(String message, Date retryDate, Date now) {
+   public RetryLaterException(String message, Date retryDate, Date now, String json) {
       super(message);
-      retryAfter = Math.max((retryDate.getTime()/1000 - now.getTime()/1000), 0);
+      retryAfter = Math.max((retryDate.getTime() / 1000 - now.getTime() / 1000), 0);
+      this.json = json;
    }
 
    /**
@@ -66,8 +73,17 @@ public class RetryLaterException extends RuntimeException {
       return retryAfter;
    }
 
-@Override
+   /**
+    * Get the JSON message that generated this exception
+    * @return the original JSON
+    */
+   public String getJson() {
+      return json;
+   }
+
+   @Override
    public String toString() {
-      return super.toString() + " retry after " + retryAfter + "s";
+      return super.toString() + "  --retry after " + retryAfter + "s"
+             + "\n" + json;
    }
 }

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/handlers/NovaErrorHandlerTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/handlers/NovaErrorHandlerTest.java
@@ -19,7 +19,6 @@
 
 package org.jclouds.openstack.nova.v2_0.handlers;
 
-import org.jclouds.date.DateService;
 import org.jclouds.date.internal.SimpleDateFormatDateService;
 import org.jclouds.rest.InsufficientResourcesException;
 import org.testng.annotations.Test;
@@ -77,19 +76,20 @@ public class NovaErrorHandlerTest {
     * that the retryAfter field is picked up first
     */
    public static final String FOLSOM_JSON_WITH_RETRY_AT = "{ 'overLimit': " +
-                                            "{" +
-                                            " 'message': 'This request was rate-limited.', " +
-                                            " 'retryAfter': '54', " +
-                                            " 'retryAt' : '2012-11-14T21:51:28UTC'," +
-                                            " 'details': 'Only 1 POST request(s) can be made to \\'*\\' every minute.'" +
-                                            " }" +
-                                            "}";
+                                                          "{" +
+                                                          " 'message': 'This request was rate-limited.', " +
+                                                          " 'retryAfter': '54', " +
+                                                          " 'retryAt' : '2012-11-14T21:51:28UTC'," +
+                                                          " 'details': 'Only 1 POST request(s) can be made to \\'*\\' every minute.'" +
+                                                          " }" +
+                                                          "}";
 
 
    public void testParseRackspaceUKResponse() throws Exception {
       NovaErrorHandler novaErrorHandler = createErrorHandler();
       Date date = novaErrorHandler.parseRetryAtField(RACKSPACE_UK_JSON);
-      assertNotNull(date);verifyDateIsAsExpected(date);
+      assertNotNull(date);
+      verifyDateIsAsExpected(date);
    }
 
    public void testBuildExceptionFromRackspaceUK() throws Exception {
@@ -105,7 +105,7 @@ public class NovaErrorHandlerTest {
 
    public void testBuildExceptionFromRackspaceUKNegativeTime() throws Exception {
       //build the exception with a current time  the response time
-      validateRetryAtExceptionGeneration(new Date(RACKSPACE_UK_DATE.getTime()+20000), 0);
+      validateRetryAtExceptionGeneration(new Date(RACKSPACE_UK_DATE.getTime() + 20000), 0);
    }
 
    /**
@@ -181,7 +181,7 @@ public class NovaErrorHandlerTest {
     * @param date date to validate
     */
    private void verifyDateIsAsExpected(Date date) {
-      assertNotNull(date,"Null date");
+      assertNotNull(date, "Null date");
       Calendar calendar = new GregorianCalendar();
       calendar.setTime(date);
       assertEquals(calendar.get(Calendar.MONTH), Calendar.NOVEMBER);
@@ -211,7 +211,6 @@ public class NovaErrorHandlerTest {
       if (ex.getClass() != RetryLaterException.class) {
          throw ex;
       }
-      RetryLaterException retryEx = (RetryLaterException) ex;
       return (RetryLaterException) ex;
    }
 
@@ -250,8 +249,8 @@ public class NovaErrorHandlerTest {
     * @param val the value to insert. This is not quoted for JSON; use quotes if a string type is desired.
     * @return the created JSON (which may not parse, depending on the arguments)
     */
-   private String retryAtJSON(String s) {
-      return "{ 'overLimit' : { 'retryAt' : " + s + " }}";
+   private String retryAtJSON(String val) {
+      return "{ 'overLimit' : { 'retryAt' : " + val + " }}";
    }
 
    /**


### PR DESCRIPTION
Revision of the patch
- Renamed RetryAfter exception to  RetryLater, which contains the delta in time before retrying (and the original JSON).
- Constructor takes a delay or a date pair (retry time, current time) to calculate the offset.
- Error handler to look first for a retryAfter field in the JSON response, falling back to look for a "retryAt" before falling back to an InsufficientResourcesException
- The parsing does a lot of returning null rather than raising exceptions on failures. That was a choice on the basis that the nested try/catch logic may actually be messier. That decisions could be revisited. 
- Any exception raised during the parse process is considered an error- logged at error and included in the nested exception. I'm not 100% sure that including that trace is the right approach, but it is the only way to make the reason for downgrading the exception to be visible.
- Unit tests that work with the Rackspace UK and Folsom samples; there are also tests that look for the "both fields in JSON" situation -the retryAt field is picked up first.
- Time formatting was set up to be handed off to a DateService implementation -manually set up in the test runner, injected in the live system. However, because of issue 1127, the injection is being ignored and the SimpleDateService used.
- Functional testing against rackspace UK (but not a Folsom instance)

With this patch, a stack trace against Rackspace UK becomes (via Whirr/Log4J):

```
2012-11-26 19:52:10,087 ERROR [jclouds.compute] (user thread 2) << problem customizing node(LON/e82676b9-585f-4979-b95a-f62ed21188e7): 
org.jclouds.openstack.nova.v2_0.handlers.RetryLaterException: GET https://lon.servers.api.rackspacecloud.com/v2/10025232/servers/e82676b9-585f-4979-b95a-f62ed21188e7 HTTP/1.1 failed - retry at Mon Nov 26 19:52:20 GMT 2012  --retry after 10s
{
    "overLimit" : {
        "code" : 413,
        "message" : "OverLimit Retry...",
        "details" : "Error Details...",
        "retryAt" : "2012-11-26T19:52:20UTC"
    }
}
    at org.jclouds.openstack.nova.v2_0.handlers.NovaErrorHandler.buildRetryException(NovaErrorHandler.java:147)
    at org.jclouds.openstack.nova.v2_0.handlers.NovaErrorHandler.handleError(NovaErrorHandler.java:95)
    at org.jclouds.http.handlers.DelegatingErrorHandler.handleError(DelegatingErrorHandler.java:69)
    at org.jclouds.http.internal.BaseHttpCommandExecutorService$HttpResponseCallable.shouldContinue(BaseHttpCommandExecutorService.java:197)
    at org.jclouds.http.internal.BaseHttpCommandExecutorService$HttpResponseCallable.call(BaseHttpCommandExecutorService.java:167)
    at org.jclouds.http.internal.BaseHttpCommandExecutorService$HttpResponseCallable.call(BaseHttpCommandExecutorService.java:135)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
    at java.util.concurrent.FutureTask.run(FutureTask.java:138)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
    at java.lang.Thread.run(Thread.java:680)
    at org.jclouds.concurrent.config.DescribingExecutorService.submit(
```
