### PR TITLE
Serverlove api version should be 2.0

### DIFF
--- a/providers/serverlove-z1-man/src/main/java/org/jclouds/serverlove/ServerloveManchesterProviderMetadata.java
+++ b/providers/serverlove-z1-man/src/main/java/org/jclouds/serverlove/ServerloveManchesterProviderMetadata.java
@@ -61,7 +61,7 @@ public class ServerloveManchesterProviderMetadata extends BaseProviderMetadata {
       protected Builder() {
          id("serverlove-z1-man")
          .name("Serverlove Manchester")
-         .apiMetadata(new ElasticStackApiMetadata())
+         .apiMetadata(new ElasticStackApiMetadata().toBuilder().version("2.0").build())
          .homepage(URI.create("http://www.serverlove.com"))
          .console(URI.create("http://www.serverlove.com/accounts"))
          .iso3166Codes("GB-MAN")


### PR DESCRIPTION
Server love has updated the ElasticStack api to 2.0. 
This needs to be reflected in the medatdata otherwise api calls 
use vnc:ip=auto instead of vnc=auto
