### PR TITLE
Do not try to install RubyGems if already installed

### DIFF
--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/ruby/InstallRuby.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/ruby/InstallRuby.java
@@ -39,12 +39,14 @@ public class InstallRuby extends StatementList {
 
    public static Statement installRubyGems() {
       return new StatementList(//
+            exec("if ! hash gem 2>/dev/null; then"), //
             exec("("), //
             extractTargzAndFlattenIntoDirectory(RUBYGEMS_URI, "/tmp/rubygems"), //
             exec("{cd} /tmp/rubygems"), //
             exec("ruby setup.rb --no-format-executable"), //
             exec("{rm} -fr /tmp/rubygems"), //
             exec(")"), //
+            exec("fi"), //
             // Make sure RubyGems is up to date
             exec("gem update --system"), //
             exec("gem update --no-rdoc --no-ri"));

--- a/scriptbuilder/src/test/resources/test_install_chef_gems_scriptbuilder.sh
+++ b/scriptbuilder/src/test/resources/test_install_chef_gems_scriptbuilder.sh
@@ -163,6 +163,7 @@ END_OF_JCLOUDS_SCRIPT
 	trap 'echo $?>$INSTANCE_HOME/rc' 0 1 2 3 15
 	setupPublicCurl || exit 1
 	installRuby || exit 1
+	if ! hash gem 2>/dev/null; then
 	(
 	mkdir /tmp/$$
 	curl -q -s -S -L --connect-timeout 10 --max-time 600 --retry 20 -X GET  http://production.cf.rubygems.org/rubygems/rubygems-1.8.10.tgz |(mkdir -p /tmp/$$ &&cd /tmp/$$ &&tar -xpzf -)
@@ -173,6 +174,7 @@ END_OF_JCLOUDS_SCRIPT
 	ruby setup.rb --no-format-executable
 	rm -fr /tmp/rubygems
 	)
+	fi
 	gem update --system
 	gem update --no-rdoc --no-ri
 	

--- a/scriptbuilder/src/test/resources/test_install_ruby.sh
+++ b/scriptbuilder/src/test/resources/test_install_ruby.sh
@@ -1,5 +1,6 @@
 setupPublicCurl || return 1
 installRuby || return 1
+if ! hash gem 2>/dev/null; then
 (
 mkdir /tmp/$$
 curl -q -s -S -L --connect-timeout 10 --max-time 600 --retry 20 -X GET  http://production.cf.rubygems.org/rubygems/rubygems-1.8.10.tgz |(mkdir -p /tmp/$$ &&cd /tmp/$$ &&tar -xpzf -)
@@ -10,5 +11,6 @@ cd /tmp/rubygems
 ruby setup.rb --no-format-executable
 rm -fr /tmp/rubygems
 )
+fi
 gem update --system
 gem update --no-rdoc --no-ri

--- a/scriptbuilder/src/test/resources/test_install_ruby_scriptbuilder.sh
+++ b/scriptbuilder/src/test/resources/test_install_ruby_scriptbuilder.sh
@@ -165,6 +165,7 @@ END_OF_JCLOUDS_SCRIPT
 	
 	installRuby || exit 1
 	
+	if ! hash gem 2>/dev/null; then
 	(
 	mkdir /tmp/$$
 	curl -q -s -S -L --connect-timeout 10 --max-time 600 --retry 20 -X GET  http://production.cf.rubygems.org/rubygems/rubygems-1.8.10.tgz |(mkdir -p /tmp/$$ &&cd /tmp/$$ &&tar -xpzf -)
@@ -175,6 +176,7 @@ END_OF_JCLOUDS_SCRIPT
 	ruby setup.rb --no-format-executable
 	rm -fr /tmp/rubygems
 	)
+	fi
 	gem update --system
 	gem update --no-rdoc --no-ri
 	


### PR DESCRIPTION
If the InstallRuby statement is used in a machine that already has Ruby and RubyGems, the statement fails to install the latter. This commit fixes it by introducing a check to test if the gem command already exists.
