### PR TITLE
updated to employ Reflection.newProxy + AbstractInvocationHandler

### DIFF
--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/v2_0/functions/PresentWhenExtensionAnnotationNamespaceEqualsAnyNamespaceInExtensionsSet.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/v2_0/functions/PresentWhenExtensionAnnotationNamespaceEqualsAnyNamespaceInExtensionsSet.java
@@ -62,11 +62,11 @@ public class PresentWhenExtensionAnnotationNamespaceEqualsAnyNamespaceInExtensio
             org.jclouds.openstack.v2_0.services.Extension.class));
       if (ext.isPresent()) {
          URI namespace = URI.create(ext.get().namespace());
-         if (input.getArgs() == null || input.getArgs().length == 0) {
+         if (input.getArgs().length == 0) {
 	        if (Iterables.any(extensions.getUnchecked(""),
 	              ExtensionPredicates.namespaceOrAliasEquals(namespace, aliases.get(namespace))))
 	           return Optional.of(input.getReturnVal());
-	     } else if (input.getArgs() != null && input.getArgs().length == 1) {
+	     } else if (input.getArgs().length == 1) {
 	        if (Iterables.any(extensions.getUnchecked(checkNotNull(input.getArgs()[0], "arg[0] in %s", input).toString()),
 	              ExtensionPredicates.namespaceOrAliasEquals(namespace, aliases.get(namespace))))
 	           return Optional.of(input.getReturnVal());

--- a/core/src/main/java/org/jclouds/collect/internal/CallerArg0ToPagedIterable.java
+++ b/core/src/main/java/org/jclouds/collect/internal/CallerArg0ToPagedIterable.java
@@ -63,7 +63,7 @@ public abstract class CallerArg0ToPagedIterable<T, I extends CallerArg0ToPagedIt
          return PagedIterables.of(input);
 
       Optional<String> arg0Option = Optional.absent();
-      if (request.getCaller().get().getArgs() != null && request.getCaller().get().getArgs().length > 0) {
+      if (request.getCaller().get().getArgs().length > 0) {
          Object arg0 = request.getCaller().get().getArgs()[0];
          if (arg0 != null)
             arg0Option = Optional.of(arg0.toString());

--- a/core/src/main/java/org/jclouds/internal/ClassMethodArgs.java
+++ b/core/src/main/java/org/jclouds/internal/ClassMethodArgs.java
@@ -24,8 +24,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 
-import org.jclouds.javax.annotation.Nullable;
-
 import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
 
@@ -48,7 +46,7 @@ public class ClassMethodArgs {
    public abstract static class Builder<B extends Builder<B>> {
       private Class<?> clazz;
       private Method method;
-      private Object[] args;
+      private Object[] args = {};
 
       @SuppressWarnings("unchecked")
       protected B self() {
@@ -96,10 +94,10 @@ public class ClassMethodArgs {
       this(builder.clazz, builder.method, builder.args);
    }
 
-   public ClassMethodArgs(Class<?> clazz, Method method, @Nullable Object[] args) {
+   public ClassMethodArgs(Class<?> clazz, Method method, Object[] args) {
       this.clazz = checkNotNull(clazz, "clazz");
       this.method = checkNotNull(method, "method");
-      this.args = args;
+      this.args = checkNotNull(args, "args");
    }
 
    public Class<?> getClazz() {
@@ -110,7 +108,7 @@ public class ClassMethodArgs {
       return method;
    }
 
-   @Nullable public Object[] getArgs() {
+   public Object[] getArgs() {
       return args;
    }
 
@@ -136,6 +134,6 @@ public class ClassMethodArgs {
 
    protected ToStringHelper string() {
       return Objects.toStringHelper("").omitNullValues().add("clazz", clazz).add("method", method)
-               .add("args", args != null ? Arrays.asList(args) : null);
+               .add("args", args.length != 0 ? Arrays.asList(args) : null);
    }
 }

--- a/core/src/main/java/org/jclouds/internal/ClassMethodArgsAndReturnVal.java
+++ b/core/src/main/java/org/jclouds/internal/ClassMethodArgsAndReturnVal.java
@@ -22,8 +22,6 @@ import static com.google.common.base.Objects.equal;
 
 import java.lang.reflect.Method;
 
-import org.jclouds.javax.annotation.Nullable;
-
 import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
 
@@ -68,7 +66,7 @@ public class ClassMethodArgsAndReturnVal extends ClassMethodArgs {
 
    private final Object returnVal;
 
-   public ClassMethodArgsAndReturnVal(Class<?> clazz, Method method, @Nullable Object[] args, Object returnVal) {
+   public ClassMethodArgsAndReturnVal(Class<?> clazz, Method method, Object[] args, Object returnVal) {
       super(clazz, method, args);
       this.returnVal = returnVal;
    }

--- a/core/src/main/java/org/jclouds/rest/AsyncClientFactory.java
+++ b/core/src/main/java/org/jclouds/rest/AsyncClientFactory.java
@@ -18,7 +18,8 @@
  */
 package org.jclouds.rest;
 
-import java.lang.reflect.Proxy;
+import static com.google.common.reflect.Reflection.newProxy;
+import static com.google.inject.util.Types.newParameterizedType;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -28,7 +29,6 @@ import org.jclouds.rest.internal.AsyncRestClientProxy;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
-import com.google.inject.util.Types;
 
 /**
  * 
@@ -45,12 +45,9 @@ public class AsyncClientFactory {
 
    @SuppressWarnings("unchecked")
    public <T> T create(Class<T> clazz) {
-      return (T) create(clazz, (AsyncRestClientProxy<T>) injector.getInstance(Key.get(TypeLiteral
-               .get(Types.newParameterizedType(AsyncRestClientProxy.class, clazz)))));
+      Key<AsyncRestClientProxy<T>> key = (Key<AsyncRestClientProxy<T>>) Key.get(TypeLiteral.get(newParameterizedType(
+            AsyncRestClientProxy.class, clazz)));
+      return newProxy(clazz, injector.getInstance(key));
    }
 
-   @SuppressWarnings("unchecked")
-   public static <T> T create(Class<T> clazz, AsyncRestClientProxy<T> proxy) {
-      return (T) Proxy.newProxyInstance(clazz.getClassLoader(), new Class<?>[] { clazz }, proxy);
-   }
 }

--- a/core/src/main/java/org/jclouds/rest/config/BinderUtils.java
+++ b/core/src/main/java/org/jclouds/rest/config/BinderUtils.java
@@ -94,15 +94,4 @@ public class BinderUtils {
       binder.bind(asyncClientType).toProvider(asyncProvider);
    }
 
-   @SuppressWarnings("unchecked")
-   public static <T> T newNullProxy(Class<T> clazz) {
-      return (T) Proxy.newProxyInstance(clazz.getClassLoader(), new Class<?>[] { clazz }, new InvocationHandler() {
-
-         @Override
-         public Object invoke(Object proxy, Method method, Object[] args) {
-            return null;
-         }
-
-      });
-   }
 }

--- a/core/src/main/java/org/jclouds/rest/config/RestModule.java
+++ b/core/src/main/java/org/jclouds/rest/config/RestModule.java
@@ -18,6 +18,7 @@
  */
 package org.jclouds.rest.config;
 
+import static com.google.common.reflect.Reflection.newProxy;
 import static org.jclouds.Constants.PROPERTY_TIMEOUTS_PREFIX;
 
 import java.lang.reflect.Method;
@@ -40,7 +41,6 @@ import org.jclouds.internal.ClassMethodArgs;
 import org.jclouds.internal.FilterStringsBoundToInjectorByName;
 import org.jclouds.json.config.GsonModule;
 import org.jclouds.location.config.LocationModule;
-import org.jclouds.rest.AsyncClientFactory;
 import org.jclouds.rest.AuthorizationException;
 import org.jclouds.rest.HttpAsyncClient;
 import org.jclouds.rest.HttpClient;
@@ -178,15 +178,14 @@ public class RestModule extends AbstractModule {
          TypeLiteral typeLiteral = TypeLiteral.get(clazz);
          RestAnnotationProcessor util = (RestAnnotationProcessor) injector.getInstance(Key.get(TypeLiteral.get(Types
                   .newParameterizedType(RestAnnotationProcessor.class, clazz))));
-         // cannot use child injectors due to the super coarse guice lock on
-         // Singleton
+         // cannot use child injectors due to the super coarse guice lock on Singleton
          util.setCaller(from);
          LoadingCache<ClassMethodArgs, Object> delegateMap = injector.getInstance(Key.get(
                   new TypeLiteral<LoadingCache<ClassMethodArgs, Object>>() {
                   }, Names.named("async")));
          AsyncRestClientProxy proxy = new AsyncRestClientProxy(injector, factory, util, typeLiteral, delegateMap);
          injector.injectMembers(proxy);
-         return AsyncClientFactory.create(clazz, proxy);
+         return newProxy(clazz, proxy);
       }
    }
 


### PR DESCRIPTION
Reflection.newProxy elimated our code which did the same
AbstractInvocationHandler ridded nullability of ClassMethodArgs.getArgs() + reduced clutter in eq/hc/tostring
