### PR TITLE
Parser , Region , Client related initial commits for CloudStack EC2 Query API

### DIFF
--- a/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/CloudStackEC2ApiMetadata.java
+++ b/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/CloudStackEC2ApiMetadata.java
@@ -31,19 +31,20 @@ import org.jclouds.rest.RestContext;
 import java.net.URI;
 import java.util.Properties;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.jclouds.Constants.PROPERTY_CONNECTION_TIMEOUT;
 import static org.jclouds.Constants.PROPERTY_SO_TIMEOUT;
-import static java.util.concurrent.TimeUnit.MINUTES;
 
 /**
  * Implementation of {@link ApiMetadata} for the CloudStack's EC2-clone API
- * 
+ *
  * @author Adrian Cole
  */
 public class CloudStackEC2ApiMetadata extends EC2ApiMetadata {
 
-   public static final TypeToken<RestContext<CloudStackEC2Client, CloudStackEC2AsyncClient>> CONTEXT_TOKEN = new TypeToken<RestContext<CloudStackEC2Client, CloudStackEC2AsyncClient>>() {
-   };
+   public static final TypeToken<RestContext<CloudStackEC2Client, CloudStackEC2AsyncClient>> CONTEXT_TOKEN = new
+           TypeToken<RestContext<CloudStackEC2Client, CloudStackEC2AsyncClient>>() {
+           };
 
    private static Builder builder() {
       return new Builder();
@@ -61,31 +62,33 @@ public class CloudStackEC2ApiMetadata extends EC2ApiMetadata {
    protected CloudStackEC2ApiMetadata(Builder builder) {
       super(builder);
    }
-   
+
    public static Properties defaultProperties() {
       Properties properties = EC2ApiMetadata.defaultProperties();
-       properties.setProperty(PROPERTY_CONNECTION_TIMEOUT, MINUTES.toMillis(10) + "");
-       properties.setProperty(PROPERTY_SO_TIMEOUT, MINUTES.toMillis(10) + "");
+
+      //increasing these timeout as first instance creation takes lot of time in CloudStack
+      properties.setProperty(PROPERTY_CONNECTION_TIMEOUT, MINUTES.toMillis(10) + "");
+      properties.setProperty(PROPERTY_SO_TIMEOUT, MINUTES.toMillis(10) + "");
 
       return properties;
    }
 
    public static class Builder extends EC2ApiMetadata.Builder {
-      protected Builder(){
+      protected Builder() {
          super(CloudStackEC2Client.class, CloudStackEC2AsyncClient.class);
          id("cloudstack-ec2")
-         .name("CloudBridge (EC2 clone) API")
-         .version("2012-08-15")
-         .defaultEndpoint("http://localhost:7080/awsapi")
-         .documentation(URI.create("http://docs.cloudstack.org/CloudBridge_Documentation"))
-         .defaultProperties(CloudStackEC2ApiMetadata.defaultProperties())
-         .context(CONTEXT_TOKEN)
-         .defaultModules(ImmutableSet.<Class<? extends Module>>builder()
-                                     .add(CloudStackEC2RestClientModule.class)
-                                     .add(EC2ResolveImagesModule.class)
-                                     .add(EC2ComputeServiceContextModule.class).build());
+                 .name("CloudBridge (EC2 clone) API")
+                 .version("2012-08-15")
+                 .defaultEndpoint("http://localhost:7080/awsapi")
+                 .documentation(URI.create("http://docs.cloudstack.org/CloudBridge_Documentation"))
+                 .defaultProperties(CloudStackEC2ApiMetadata.defaultProperties())
+                 .context(CONTEXT_TOKEN)
+                 .defaultModules(ImmutableSet.<Class<? extends Module>>builder()
+                         .add(CloudStackEC2RestClientModule.class)
+                         .add(EC2ResolveImagesModule.class)
+                         .add(EC2ComputeServiceContextModule.class).build());
       }
-      
+
       @Override
       public CloudStackEC2ApiMetadata build() {
          return new CloudStackEC2ApiMetadata(this);
@@ -97,5 +100,4 @@ public class CloudStackEC2ApiMetadata extends EC2ApiMetadata {
          return this;
       }
    }
-
 }

--- a/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/CloudStackEC2AsyncClient.java
+++ b/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/CloudStackEC2AsyncClient.java
@@ -29,18 +29,18 @@ import org.jclouds.rest.annotations.Delegate;
  * @author Adrian Cole
  */
 public interface CloudStackEC2AsyncClient extends EC2AsyncClient {
-    /**
-     * {@inheritDoc}
-     */
-    @Delegate
-    @Override
-    CloudStackAMIAsyncClient getAMIServices();
 
-    /**
-     * {@inheritDoc}
-     */
-    @Delegate
-    @Override
-    CloudStackEC2InstanceAsyncClient getInstanceServices();
+   /**
+    * {@inheritDoc}
+    */
+   @Delegate
+   @Override
+   CloudStackAMIAsyncClient getAMIServices();
 
+   /**
+    * {@inheritDoc}
+    */
+   @Delegate
+   @Override
+   CloudStackEC2InstanceAsyncClient getInstanceServices();
 }

--- a/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/CloudStackEC2Client.java
+++ b/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/CloudStackEC2Client.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Provides synchronous access to EC2 services.
- * 
+ *
  * @author Adrian Cole
  */
 @Timeout(duration = 180, timeUnit = TimeUnit.SECONDS)

--- a/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/config/CloudStackEC2RestClientModule.java
+++ b/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/config/CloudStackEC2RestClientModule.java
@@ -29,20 +29,43 @@ import org.jclouds.cloudstack.ec2.services.CloudStackAMIClient;
 import org.jclouds.cloudstack.ec2.services.CloudStackEC2InstanceAsyncClient;
 import org.jclouds.cloudstack.ec2.services.CloudStackEC2InstanceClient;
 import org.jclouds.cloudstack.ec2.suppliers.CloudStackEC2DescribeRegionsForRegionURIs;
-import org.jclouds.cloudstack.ec2.xml.*;
+import org.jclouds.cloudstack.ec2.xml.CloudStackEC2CreateVolumeResponseHandler;
+import org.jclouds.cloudstack.ec2.xml.CloudStackEC2DescribeImagesResponseHandler;
+import org.jclouds.cloudstack.ec2.xml.CloudStackEC2DescribeInstancesResponseHandler;
+import org.jclouds.cloudstack.ec2.xml.CloudStackEC2DescribeVolumesResponseHandler;
+import org.jclouds.cloudstack.ec2.xml.CloudStackEC2RunInstancesResponseHandler;
 import org.jclouds.ec2.EC2AsyncClient;
 import org.jclouds.ec2.EC2Client;
 import org.jclouds.ec2.config.EC2RestClientModule;
 import org.jclouds.ec2.features.WindowsApi;
 import org.jclouds.ec2.features.WindowsAsyncApi;
-import org.jclouds.ec2.services.*;
+import org.jclouds.ec2.services.AvailabilityZoneAndRegionAsyncClient;
+import org.jclouds.ec2.services.AvailabilityZoneAndRegionClient;
+import org.jclouds.ec2.services.ElasticBlockStoreAsyncClient;
+import org.jclouds.ec2.services.ElasticBlockStoreClient;
+import org.jclouds.ec2.services.ElasticIPAddressAsyncClient;
+import org.jclouds.ec2.services.ElasticIPAddressClient;
+import org.jclouds.ec2.services.KeyPairAsyncClient;
+import org.jclouds.ec2.services.KeyPairClient;
+import org.jclouds.ec2.services.SecurityGroupAsyncClient;
+import org.jclouds.ec2.services.SecurityGroupClient;
+import org.jclouds.ec2.services.WindowsAsyncClient;
+import org.jclouds.ec2.services.WindowsClient;
 import org.jclouds.ec2.suppliers.DescribeAvailabilityZonesInRegion;
-import org.jclouds.ec2.xml.*;
+import org.jclouds.ec2.xml.CreateVolumeResponseHandler;
+import org.jclouds.ec2.xml.DescribeImagesResponseHandler;
+import org.jclouds.ec2.xml.DescribeInstancesResponseHandler;
+import org.jclouds.ec2.xml.DescribeVolumesResponseHandler;
+import org.jclouds.ec2.xml.RunInstancesResponseHandler;
 import org.jclouds.http.HttpRetryHandler;
 import org.jclouds.http.IOExceptionRetryHandler;
 import org.jclouds.http.annotation.ClientError;
 import org.jclouds.location.config.LocationModule;
-import org.jclouds.location.suppliers.*;
+import org.jclouds.location.suppliers.RegionIdToURISupplier;
+import org.jclouds.location.suppliers.RegionIdToZoneIdsSupplier;
+import org.jclouds.location.suppliers.RegionIdsSupplier;
+import org.jclouds.location.suppliers.ZoneIdToURISupplier;
+import org.jclouds.location.suppliers.ZoneIdsSupplier;
 import org.jclouds.location.suppliers.derived.RegionIdsFromRegionIdToURIKeySet;
 import org.jclouds.location.suppliers.derived.ZoneIdToURIFromJoinOnRegionIdToURI;
 import org.jclouds.location.suppliers.derived.ZoneIdsFromRegionIdToZoneIdsValues;
@@ -52,24 +75,21 @@ import javax.inject.Singleton;
 import java.util.Map;
 
 /**
- * 
  * @author Adrian Cole
  */
 @ConfiguresRestClient
 public class CloudStackEC2RestClientModule extends EC2RestClientModule<CloudStackEC2Client, CloudStackEC2AsyncClient> {
-
-
-   public static final Map<Class<?>, Class<?>> DELEGATE_MAP = ImmutableMap.<Class<?>, Class<?>> builder()//
-         .put(CloudStackAMIClient.class, CloudStackAMIAsyncClient.class)//
-         .put(ElasticIPAddressClient.class, ElasticIPAddressAsyncClient.class)//
-         .put(CloudStackEC2InstanceClient.class, CloudStackEC2InstanceAsyncClient.class)//
-         .put(KeyPairClient.class, KeyPairAsyncClient.class)//
-         .put(SecurityGroupClient.class, SecurityGroupAsyncClient.class)//
-         .put(WindowsClient.class, WindowsAsyncClient.class)//
-         .put(AvailabilityZoneAndRegionClient.class, AvailabilityZoneAndRegionAsyncClient.class)//
-         .put(ElasticBlockStoreClient.class, ElasticBlockStoreAsyncClient.class)//
-         .put(WindowsApi.class, WindowsAsyncApi.class)//
-         .build();
+   public static final Map<Class<?>, Class<?>> DELEGATE_MAP = ImmutableMap.<Class<?>, Class<?>>builder()//
+           .put(CloudStackAMIClient.class, CloudStackAMIAsyncClient.class)//
+           .put(ElasticIPAddressClient.class, ElasticIPAddressAsyncClient.class)//
+           .put(CloudStackEC2InstanceClient.class, CloudStackEC2InstanceAsyncClient.class)//
+           .put(KeyPairClient.class, KeyPairAsyncClient.class)//
+           .put(SecurityGroupClient.class, SecurityGroupAsyncClient.class)//
+           .put(WindowsClient.class, WindowsAsyncClient.class)//
+           .put(AvailabilityZoneAndRegionClient.class, AvailabilityZoneAndRegionAsyncClient.class)//
+           .put(ElasticBlockStoreClient.class, ElasticBlockStoreAsyncClient.class)//
+           .put(WindowsApi.class, WindowsAsyncApi.class)//
+           .build();
 
    public CloudStackEC2RestClientModule() {
       super(TypeToken.of(CloudStackEC2Client.class), TypeToken.of(CloudStackEC2AsyncClient.class), DELEGATE_MAP);
@@ -85,21 +105,24 @@ public class CloudStackEC2RestClientModule extends EC2RestClientModule<CloudStac
       bind(CreateVolumeResponseHandler.class).to(CloudStackEC2CreateVolumeResponseHandler.class);
    }
 
-    @Override
-    protected void installLocations() {
-        install(new LocationModule());
-        bind(RegionIdToZoneIdsSupplier.class).to(DescribeAvailabilityZonesInRegion.class).in(Scopes.SINGLETON);
-        bind(RegionIdToURISupplier.class).to(CloudStackEC2DescribeRegionsForRegionURIs.class).in(Scopes.SINGLETON);
-        bind(ZoneIdsSupplier.class).to(ZoneIdsFromRegionIdToZoneIdsValues.class).in(Scopes.SINGLETON);
-        bind(RegionIdsSupplier.class).to(RegionIdsFromRegionIdToURIKeySet.class).in(Scopes.SINGLETON);
-        bind(ZoneIdToURISupplier.class).to(ZoneIdToURIFromJoinOnRegionIdToURI.class).in(Scopes.SINGLETON);
-    }
+   @Override
+   protected void installLocations() {
+      install(new LocationModule());
+      bind(RegionIdToZoneIdsSupplier.class).to(DescribeAvailabilityZonesInRegion.class).in(Scopes.SINGLETON);
+      bind(RegionIdToURISupplier.class).to(CloudStackEC2DescribeRegionsForRegionURIs.class).in(Scopes.SINGLETON);
+      bind(ZoneIdsSupplier.class).to(ZoneIdsFromRegionIdToZoneIdsValues.class).in(Scopes.SINGLETON);
+      bind(RegionIdsSupplier.class).to(RegionIdsFromRegionIdToURIKeySet.class).in(Scopes.SINGLETON);
+      bind(ZoneIdToURISupplier.class).to(ZoneIdToURIFromJoinOnRegionIdToURI.class).in(Scopes.SINGLETON);
+   }
 
-    @Override
-    protected void bindRetryHandlers() {
-        bind(HttpRetryHandler.class).annotatedWith(ClientError.class).toInstance(HttpRetryHandler.NEVER_RETRY);
-        bind(IOExceptionRetryHandler.class).toInstance(IOExceptionRetryHandler.NEVER_RETRY);
-    }
+   @Override
+   protected void bindRetryHandlers() {
+      //Changing these to NEVER_RETRY as retrying may leads to unknown state
+      bind(HttpRetryHandler.class).annotatedWith(ClientError.class).toInstance(HttpRetryHandler.NEVER_RETRY);
+      //first instance creation takes lot of time in CloudStack
+      //It is misinterpreting this as failure so changing it to NEVER_RETRY
+      bind(IOExceptionRetryHandler.class).toInstance(IOExceptionRetryHandler.NEVER_RETRY);
+   }
 
    @Singleton
    @Provides
@@ -112,5 +135,4 @@ public class CloudStackEC2RestClientModule extends EC2RestClientModule<CloudStac
    EC2AsyncClient provide(CloudStackEC2AsyncClient in) {
       return in;
    }
-
 }

--- a/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/options/CloudStackEC2RegisterImageOptions.java
+++ b/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/options/CloudStackEC2RegisterImageOptions.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.cloudstack.ec2.options;
 
 import org.jclouds.ec2.options.internal.BaseEC2RequestOptions;
@@ -5,96 +23,95 @@ import org.jclouds.ec2.options.internal.BaseEC2RequestOptions;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * Created with IntelliJ IDEA.
- * User: anshul
- * Date: 11/29/12
- * Time: 3:35 PM
- * To change this template use File | Settings | File Templates.
+ * Please refer to ec2-register on following link
+ *
+ * @author Anshul Gangwar
+ * @see <a href="http://docs.cloudstack.org/CloudBridge_Documentation/Supported_Amazon_EC2_Commands_in_CloudBridge">
+ *      Supported Amazon EC2 Commands in CloudBridge </a>
  */
 public class CloudStackEC2RegisterImageOptions extends BaseEC2RequestOptions {
 
-    /**
-     * The architecture of the image.
-     */
-    public CloudStackEC2RegisterImageOptions asArchitecture(String architecture) {
-        formParameters.put("Architecture", checkNotNull(architecture, "architecture"));
-        return this;
-    }
+   /**
+    * The architecture of the image.
+    */
+   public CloudStackEC2RegisterImageOptions asArchitecture(String architecture) {
+      formParameters.put("Architecture", checkNotNull(architecture, "architecture"));
+      return this;
+   }
 
-    String getArchitecture() {
-        return getFirstFormOrNull("Architecture");
-    }
+   String getArchitecture() {
+      return getFirstFormOrNull("Architecture");
+   }
 
-    /**
-     *The description of the AMI. "Up to 255 characters."
-     */
-    public CloudStackEC2RegisterImageOptions withDescription(String info) {
-        formParameters.put("Description", checkNotNull(info, "info"));
-        return this;
-    }
+   /**
+    * The description of the AMI. "Up to 255 characters."
+    */
+   public CloudStackEC2RegisterImageOptions withDescription(String info) {
+      formParameters.put("Description", checkNotNull(info, "info"));
+      return this;
+   }
 
-    String getDescription() {
-        return getFirstFormOrNull("Description");
-    }
+   String getDescription() {
+      return getFirstFormOrNull("Description");
+   }
 
-    /**
-     * The ID of the kernel to select.
-     */
-    public CloudStackEC2RegisterImageOptions withKernelId(String kernelId) {
-        formParameters.put("KernelId", checkNotNull(kernelId, "kernelId"));
-        return this;
-    }
+   /**
+    * The ID of the kernel to select.
+    */
+   public CloudStackEC2RegisterImageOptions withKernelId(String kernelId) {
+      formParameters.put("KernelId", checkNotNull(kernelId, "kernelId"));
+      return this;
+   }
 
-    String getKernelId() {
-        return getFirstFormOrNull("KernelId");
-    }
+   String getKernelId() {
+      return getFirstFormOrNull("KernelId");
+   }
 
-    /**
-     * The ID of the RAM disk to select. Some kernels require additional drivers at launch. Check the
-     * kernel requirements for information on whether you need to specify a RAM disk. To find kernel
-     * requirements, refer to the Resource Center and search for the kernel ID.
-     */
-    public CloudStackEC2RegisterImageOptions withRamdisk(String ramDiskId) {
-        formParameters.put("RamdiskId", checkNotNull(ramDiskId, "ramDiskId"));
-        return this;
-    }
+   /**
+    * The ID of the RAM disk to select. Some kernels require additional drivers at launch. Check the
+    * kernel requirements for information on whether you need to specify a RAM disk. To find kernel
+    * requirements, refer to the Resource Center and search for the kernel ID.
+    */
+   public CloudStackEC2RegisterImageOptions withRamdisk(String ramDiskId) {
+      formParameters.put("RamdiskId", checkNotNull(ramDiskId, "ramDiskId"));
+      return this;
+   }
 
-    String getRamdiskId() {
-        return getFirstFormOrNull("RamdiskId");
-    }
+   String getRamdiskId() {
+      return getFirstFormOrNull("RamdiskId");
+   }
 
-    public static class Builder {
-        /**
-         * @see CloudStackEC2RegisterImageOptions#asArchitecture(String)
-         */
-        public static CloudStackEC2RegisterImageOptions asArchitecture(String architecture) {
-            CloudStackEC2RegisterImageOptions options = new CloudStackEC2RegisterImageOptions();
-            return options.asArchitecture(architecture);
-        }
+   public static class Builder {
+      /**
+       * @see CloudStackEC2RegisterImageOptions#asArchitecture(String)
+       */
+      public static CloudStackEC2RegisterImageOptions asArchitecture(String architecture) {
+         CloudStackEC2RegisterImageOptions options = new CloudStackEC2RegisterImageOptions();
+         return options.asArchitecture(architecture);
+      }
 
-        /**
-         * @see CloudStackEC2RegisterImageOptions#withDescription(String)
-         */
-        public static CloudStackEC2RegisterImageOptions withDescription(String additionalInfo) {
-            CloudStackEC2RegisterImageOptions options = new CloudStackEC2RegisterImageOptions();
-            return options.withDescription(additionalInfo);
-        }
+      /**
+       * @see CloudStackEC2RegisterImageOptions#withDescription(String)
+       */
+      public static CloudStackEC2RegisterImageOptions withDescription(String additionalInfo) {
+         CloudStackEC2RegisterImageOptions options = new CloudStackEC2RegisterImageOptions();
+         return options.withDescription(additionalInfo);
+      }
 
-        /**
-         * @see CloudStackEC2RegisterImageOptions#withKernelId(String)
-         */
-        public static CloudStackEC2RegisterImageOptions withKernelId(String kernelId) {
-            CloudStackEC2RegisterImageOptions options = new CloudStackEC2RegisterImageOptions();
-            return options.withKernelId(kernelId);
-        }
+      /**
+       * @see CloudStackEC2RegisterImageOptions#withKernelId(String)
+       */
+      public static CloudStackEC2RegisterImageOptions withKernelId(String kernelId) {
+         CloudStackEC2RegisterImageOptions options = new CloudStackEC2RegisterImageOptions();
+         return options.withKernelId(kernelId);
+      }
 
-        /**
-         * @see CloudStackEC2RegisterImageOptions#withRamdisk(String)
-         */
-        public static CloudStackEC2RegisterImageOptions withRamdisk(String ramdiskId) {
-            CloudStackEC2RegisterImageOptions options = new CloudStackEC2RegisterImageOptions();
-            return options.withRamdisk(ramdiskId);
-        }
-
-    }
+      /**
+       * @see CloudStackEC2RegisterImageOptions#withRamdisk(String)
+       */
+      public static CloudStackEC2RegisterImageOptions withRamdisk(String ramdiskId) {
+         CloudStackEC2RegisterImageOptions options = new CloudStackEC2RegisterImageOptions();
+         return options.withRamdisk(ramdiskId);
+      }
+   }
 }

--- a/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/services/CloudStackAMIAsyncClient.java
+++ b/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/services/CloudStackAMIAsyncClient.java
@@ -25,7 +25,11 @@ import org.jclouds.ec2.services.AMIAsyncClient;
 import org.jclouds.ec2.xml.ImageIdHandler;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.location.functions.RegionToEndpointOrProviderIfNull;
-import org.jclouds.rest.annotations.*;
+import org.jclouds.rest.annotations.EndpointParam;
+import org.jclouds.rest.annotations.FormParams;
+import org.jclouds.rest.annotations.RequestFilters;
+import org.jclouds.rest.annotations.VirtualHost;
+import org.jclouds.rest.annotations.XMLResponseParser;
 
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
@@ -40,15 +44,15 @@ import static org.jclouds.aws.reference.FormParameters.ACTION;
 @VirtualHost
 public interface CloudStackAMIAsyncClient extends AMIAsyncClient {
 
-    /**
+   /**
     * @see CloudStackAMIClient#registerImageFromManifestInRegion
     */
-    @POST
-    @Path("/")
-    @FormParams(keys = ACTION, values = "RegisterImage")
-    @XMLResponseParser(ImageIdHandler.class)
-    ListenableFuture<String> registerImageFromManifestInRegion(
-            @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
-            @FormParam("Name") String imageName, @FormParam("ImageLocation") String pathToManifest,
-            CloudStackEC2RegisterImageOptions... options);
+   @POST
+   @Path("/")
+   @FormParams(keys = ACTION, values = "RegisterImage")
+   @XMLResponseParser(ImageIdHandler.class)
+   ListenableFuture<String> registerImageFromManifestInRegion(
+           @EndpointParam(parser = RegionToEndpointOrProviderIfNull.class) @Nullable String region,
+           @FormParam("Name") String imageName, @FormParam("ImageLocation") String pathToManifest,
+           CloudStackEC2RegisterImageOptions... options);
 }

--- a/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/services/CloudStackAMIClient.java
+++ b/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/services/CloudStackAMIClient.java
@@ -27,7 +27,6 @@ import org.jclouds.javax.annotation.Nullable;
 import java.util.concurrent.TimeUnit;
 
 /**
- * 
  * @author Adrian Cole
  */
 @Timeout(duration = 90, timeUnit = TimeUnit.SECONDS)
@@ -40,37 +39,13 @@ public interface CloudStackAMIClient extends AMIClient {
    @Timeout(duration = 10, timeUnit = TimeUnit.MINUTES)
    String createImageInRegion(@Nullable String region, String name, String instanceId, CreateImageOptions... options);
 
-    /**
-     * Registers an AMI with Amazon EC2. Images must be registered before they can be launched. To
-     * launch instances, use the {@link org.jclouds.cloudstack.ec2.services.CloudStackEC2InstanceClient#runInstancesInRegion} operation.
-     * <p/>
-     * Each AMI is associated with an unique ID which is provided by the Amazon EC2 service through
-     * this operation. If needed, you can deregister an AMI at any time.
-     * <p/>
-     * <h3>Note</h3> Any modifications to an AMI backed by Amazon S3 invalidates this registration.
-     * If you make changes to an image, deregister the previous image and register the new image.
-     *
-     * @param region
-     *           AMIs are tied to the Region where its files are located within Amazon S3.
-     * @param name
-     *           The name of the AMI that was provided during image creation. 3-128 alphanumeric
-     *           characters, parenthesis (()), commas (,), slashes (/), dashes (-), or underscores(_)
-     * @param pathToManifest
-     *           Full path to your AMI manifest in Amazon S3 storage.
-     * @param options
-     *           Options to specify metadata such as architecture or secondary volumes to be
-     *           associated with this image.
-     * @return imageId
-     *
-     * @see #describeImages
-     * @see #deregisterImage
-     * @see <a href=
-     *      "http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-RegisterImage.html"
-     *      />
-     */
-    String registerImageFromManifestInRegion(@Nullable String region, String name, String pathToManifest,
-                                             CloudStackEC2RegisterImageOptions... options);
-
-
-
+   /**
+    * This method is overloaded<br/>
+    * Here CloudStackEC2RegisterImageOptions parameter is changed as architecture has different meaning in CloudStack
+    *
+    * @see CloudStackEC2RegisterImageOptions
+    * @see AMIClient#registerImageFromManifestInRegion
+    */
+   String registerImageFromManifestInRegion(@Nullable String region, String name, String pathToManifest,
+                                            CloudStackEC2RegisterImageOptions... options);
 }

--- a/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/services/CloudStackEC2InstanceAsyncClient.java
+++ b/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/services/CloudStackEC2InstanceAsyncClient.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.cloudstack.ec2.services;
 
 import org.jclouds.aws.filters.FormSigner;
@@ -6,15 +24,9 @@ import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.VirtualHost;
 
 /**
- * Created with IntelliJ IDEA.
- * User: anshul
- * Date: 11/28/12
- * Time: 11:04 AM
- * To change this template use File | Settings | File Templates.
+ * @author Anshul Gangwar
  */
 @RequestFilters(FormSigner.class)
 @VirtualHost
 public interface CloudStackEC2InstanceAsyncClient extends InstanceAsyncClient {
-
-
 }

--- a/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/services/CloudStackEC2InstanceClient.java
+++ b/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/services/CloudStackEC2InstanceClient.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.cloudstack.ec2.services;
 
 import org.jclouds.concurrent.Timeout;
@@ -10,21 +28,21 @@ import org.jclouds.javax.annotation.Nullable;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Created with IntelliJ IDEA.
- * User: anshul
- * Date: 11/28/12
- * Time: 11:05 AM
- * To change this template use File | Settings | File Templates.
+ * changed timeout of runInstance API call
+ *
+ * @author Anshul Gangwar
  */
 @Timeout(duration = 90, timeUnit = TimeUnit.SECONDS)
 public interface CloudStackEC2InstanceClient extends InstanceClient {
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    @Timeout(duration = 10, timeUnit = TimeUnit.MINUTES)
-    Reservation<? extends RunningInstance> runInstancesInRegion(@Nullable String region,
-                                                                @Nullable String nullableAvailabilityZone, String imageId,
-                                                                int minCount, int maxCount, RunInstancesOptions... options);
 
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   @Timeout(duration = 10, timeUnit = TimeUnit.MINUTES)
+   Reservation<? extends RunningInstance> runInstancesInRegion(@Nullable String region,
+                                                               @Nullable String nullableAvailabilityZone,
+                                                               String imageId,
+                                                               int minCount, int maxCount,
+                                                               RunInstancesOptions... options);
 }

--- a/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/suppliers/CloudStackEC2DescribeRegionsForRegionURIs.java
+++ b/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/suppliers/CloudStackEC2DescribeRegionsForRegionURIs.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.cloudstack.ec2.suppliers;
 
 import com.google.common.base.Supplier;
@@ -10,27 +28,23 @@ import javax.inject.Inject;
 import java.net.URI;
 import java.util.Map;
 
+
 /**
- * Created with IntelliJ IDEA.
- * User: anshul
- * Date: 11/28/12
- * Time: 10:28 AM
- * To change this template use File | Settings | File Templates.
+ * CloudStack Doesn't support regions
+ *
+ * @author Anshul Gangwar
  */
 public class CloudStackEC2DescribeRegionsForRegionURIs extends DescribeRegionsForRegionURIs {
-    private Supplier<URI> defaultURISupplier;
+   private Supplier<URI> defaultURISupplier;
 
-    @Inject
-    public CloudStackEC2DescribeRegionsForRegionURIs(@Provider Supplier<URI> defaultURISupplier, EC2Client client) {
-        super(client);
-        this.defaultURISupplier = defaultURISupplier;
-    }
+   @Inject
+   public CloudStackEC2DescribeRegionsForRegionURIs(@Provider Supplier<URI> defaultURISupplier, EC2Client client) {
+      super(client);
+      this.defaultURISupplier = defaultURISupplier;
+   }
 
-    @Override
-    public Map<String, Supplier<URI>> get() {
-        Map<String, Supplier<URI>> regionToUris = null;
-        regionToUris = ImmutableMap.of("AmazonEC2", defaultURISupplier);
-
-        return regionToUris;
-    }
+   @Override
+   public Map<String, Supplier<URI>> get() {
+      return ImmutableMap.of("AmazonEC2", defaultURISupplier);
+   }
 }

--- a/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/xml/CloudStackEC2CreateVolumeResponseHandler.java
+++ b/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/xml/CloudStackEC2CreateVolumeResponseHandler.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.cloudstack.ec2.xml;
 
 import com.google.common.base.Supplier;
@@ -12,36 +30,40 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Created with IntelliJ IDEA.
- * User: anshul
- * Date: 12/4/12
- * Time: 3:02 PM
- * To change this template use File | Settings | File Templates.
+ * Element introduced in newer API are causing random errors
+ *
+ * @author Anshul Gangwar
  */
 public class CloudStackEC2CreateVolumeResponseHandler extends CreateVolumeResponseHandler {
+   //tagSet element introduced is cause of errors
+   //The element's sub-element contain item element which is the cause of errors
+   //Due to this some unexpected code gets executed and results in error
+   private boolean inTagSet = false;
 
-    private boolean inTagSet;
+   @Inject
+   protected CloudStackEC2CreateVolumeResponseHandler(DateCodecFactory dateCodecFactory,
+                                                      @Region Supplier<String> defaultRegion,
+                                                      @Zone Supplier<Map<String,
+                                                              Supplier<Set<String>>>> regionToZonesSupplier,
+                                                      @Zone Supplier<Set<String>> zonesSupplier) {
+      super(dateCodecFactory, defaultRegion, regionToZonesSupplier, zonesSupplier);
+   }
 
-    @Inject
-    protected CloudStackEC2CreateVolumeResponseHandler(DateCodecFactory dateCodecFactory, @Region Supplier<String> defaultRegion, @Zone Supplier<Map<String, Supplier<Set<String>>>> regionToZonesSupplier, @Zone Supplier<Set<String>> zonesSupplier) {
-        super(dateCodecFactory, defaultRegion, regionToZonesSupplier, zonesSupplier);
-    }
+   @Override
+   public void startElement(String uri, String localName, String qName, Attributes attributes) {
+      if (qName.equals("tagSet")) {
+         inTagSet = true;
+      } else if (!inTagSet) {
+         super.startElement(uri, localName, qName, attributes);
+      }
+   }
 
-    @Override
-    public void startElement(String uri, String localName, String qName, Attributes attributes) {
-        if (qName.equals("tagSet")) {
-            inTagSet = true;
-        } else if (!inTagSet) {
-            super.startElement(uri, localName, qName, attributes);
-        }
-    }
-
-    @Override
-    public void endElement(String uri, String localName, String qName) {
-        if (qName.equals("tagSet")) {
-            inTagSet = false;
-        } else if (!inTagSet) {
-            super.endElement(uri, localName, qName);
-        }
-    }
+   @Override
+   public void endElement(String uri, String localName, String qName) {
+      if (qName.equals("tagSet")) {
+         inTagSet = false;
+      } else if (!inTagSet) {
+         super.endElement(uri, localName, qName);
+      }
+   }
 }

--- a/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/xml/CloudStackEC2DescribeImagesResponseHandler.java
+++ b/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/xml/CloudStackEC2DescribeImagesResponseHandler.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.cloudstack.ec2.xml;
 
 import com.google.common.base.Supplier;
@@ -8,34 +26,34 @@ import org.xml.sax.Attributes;
 import javax.inject.Inject;
 
 /**
- * Created with IntelliJ IDEA.
- * User: anshul
- * Date: 11/28/12
- * Time: 12:19 PM
- * To change this template use File | Settings | File Templates.
+ * Element introduced in newer API are causing random errors
+ *
+ * @author Anshul Gangwar
  */
 public class CloudStackEC2DescribeImagesResponseHandler extends DescribeImagesResponseHandler {
+   //tagSet element introduced is cause of errors
+   //The element's sub-element contain item element which is the cause of errors
+   //Due to this some unexpected code gets executed and results in error
+   private boolean inTagSet = false;
 
-    private boolean inTagSet;
+   @Inject
+   public CloudStackEC2DescribeImagesResponseHandler(@Region Supplier<String> defaultRegion) {
+      super(defaultRegion);
+   }
 
-    @Inject
-    public CloudStackEC2DescribeImagesResponseHandler(@Region Supplier<String> defaultRegion) {
-        super(defaultRegion);
-    }
+   public void startElement(String uri, String name, String qName, Attributes attrs) {
+      if (qName.equals("tagSet")) {
+         inTagSet = true;
+      } else if (!inTagSet) {
+         super.startElement(uri, name, qName, attrs);
+      }
+   }
 
-    public void startElement(String uri, String name, String qName, Attributes attrs) {
-        if (qName.equals("tagSet")) {
-            inTagSet = true;
-        } else if(!inTagSet){
-            super.startElement(uri, name, qName, attrs);
-        }
-    }
-
-    public void endElement(String uri, String name, String qName) {
-        if (qName.equals("tagSet")) {
-            inTagSet = false;
-        } else if (!inTagSet) {
-            super.endElement(uri, name, qName);
-        }
-    }
+   public void endElement(String uri, String name, String qName) {
+      if (qName.equals("tagSet")) {
+         inTagSet = false;
+      } else if (!inTagSet) {
+         super.endElement(uri, name, qName);
+      }
+   }
 }

--- a/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/xml/CloudStackEC2DescribeInstancesResponseHandler.java
+++ b/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/xml/CloudStackEC2DescribeInstancesResponseHandler.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.cloudstack.ec2.xml;
 
 import com.google.common.base.Supplier;
@@ -17,82 +35,80 @@ import java.util.Set;
 import static org.jclouds.util.SaxUtils.equalsOrSuffix;
 
 /**
- * Created with IntelliJ IDEA.
- * User: anshul
- * Date: 11/28/12
- * Time: 12:00 PM
- * To change this template use File | Settings | File Templates.
+ * Element introduced in newer API are causing random errors
+ *
+ * @author Anshul Gangwar
  */
 public class CloudStackEC2DescribeInstancesResponseHandler extends
         DescribeInstancesResponseHandler {
+   private Set<Reservation<? extends RunningInstance>> cloudstackReservations = Sets.newLinkedHashSet();
 
-    private Set<Reservation<? extends RunningInstance>> reservations = Sets.newLinkedHashSet();
+   //groupSet for vpc and tagSet element introduced are cause of errors
+   //These elements sub-element contain item element which is the cause of errors
+   //Due to this some unexpected code gets executed and results in error
+   protected boolean inTagSet = false;
+   protected boolean inVpcGroupSet = false;
 
-    protected boolean inTagSet;
-    protected boolean inVpcGroupSet;
 
+   @Inject
+   CloudStackEC2DescribeInstancesResponseHandler(DateCodecFactory dateCodecFactory,
+                                                 @Region Supplier<String> defaultRegion,
+                                                 Provider<RunningInstance.Builder> builderProvider) {
+      super(dateCodecFactory, defaultRegion, builderProvider);
+   }
 
-    @Inject
-    CloudStackEC2DescribeInstancesResponseHandler(DateCodecFactory dateCodecFactory,
-                                     @Region Supplier<String> defaultRegion, Provider<RunningInstance.Builder> builderProvider) {
-        super(dateCodecFactory, defaultRegion, builderProvider);
-    }
+   @Override
+   public Set<Reservation<? extends RunningInstance>> getResult() {
+      return cloudstackReservations;
+   }
 
-    @Override
-    public Set<Reservation<? extends RunningInstance>> getResult() {
-        return reservations;
-    }
+   @Override
+   public void startElement(String uri, String name, String qName, Attributes attrs) {
+      if (equalsOrSuffix(qName, "groupSet")) {
+         if (!inInstancesSet) {
+            inGroupSet = true;
+         } else {
+            inVpcGroupSet = true;
+         }
+      } else if (equalsOrSuffix(qName, "tagSet")) {
+         inTagSet = true;
+      } else if (!inTagSet) {
+         super.startElement(uri, name, qName, attrs);
+      }
+   }
 
-    @Override
-    public void startElement(String uri, String name, String qName, Attributes attrs) {
-        if (equalsOrSuffix(qName, "groupSet")) {
-            if(!inInstancesSet) {
-                inGroupSet = true;
-            } else {
-                inVpcGroupSet = true;
-            }
-        }  else if (equalsOrSuffix(qName, "tagSet")) {
-            inTagSet = true;
-        }  else if(!inTagSet){
-            super.startElement(uri, name, qName, attrs);
-        }
-    }
+   @Override
+   public void endElement(String uri, String name, String qName) {
+      if (equalsOrSuffix(qName, "groupSet")) {
+         if (!inInstancesSet) {
+            inGroupSet = false;
+         } else {
+            inVpcGroupSet = false;
+         }
+      } else if (equalsOrSuffix(qName, "tagSet")) {
+         inTagSet = false;
+      } else if (equalsOrSuffix(qName, "rootDeviceType")) {
+         //CloudStack sends this element as empty string so putting some value otherwise NPE
+         builder.rootDeviceType(RootDeviceType.fromValue("ebs"));
+      } else if (equalsOrSuffix(qName, "groupId") && !inGroupSet) {
+         //  to remove NPE because of GroupSet element of vpc
+      } else if (!inTagSet) {
+         super.endElement(uri, name, qName);
+      }
+   }
 
-    @Override
-    public void endElement(String uri, String name, String qName) {
-        if (equalsOrSuffix(qName, "groupSet")) {
-            if(!inInstancesSet) {
-                inGroupSet = false;
-            } else {
-                inVpcGroupSet = false;
-            }
-        } else if (equalsOrSuffix(qName, "tagSet")) {
-            inTagSet = false;
-        } else if (equalsOrSuffix(qName, "rootDeviceType")) {
-            builder.rootDeviceType(RootDeviceType.fromValue("ebs"));
-        } else if (equalsOrSuffix(qName, "groupId") && !inGroupSet) {
-            //  to remove null pointer exception because of vpcGroupSet
-        }else if(!inTagSet){
-            super.endElement(uri, name, qName);
-        }
-    }
+   @Override
+   protected boolean endOfInstanceItem() {
+      return super.endOfInstanceItem() && !inTagSet && !inVpcGroupSet;
+   }
 
-    @Override
-    protected boolean endOfInstanceItem() {
-        return itemDepth <= 2 && inInstancesSet && !inProductCodes && !inGroupSet && !inTagSet && !inVpcGroupSet;
-    }
-
-    protected boolean endOfReservationItem() {
-        return itemDepth == 1;
-    }
-
-    @Override
-    protected void inItem() {
-        if (endOfReservationItem()) {
-            reservations.add(super.newReservation());
-        } else {
-            super.inItem();
-        }
-    }
-
+   //This method is a copy/paste of super class as reservations is private in super class
+   @Override
+   protected void inItem() {
+      if (endOfReservationItem()) {
+         cloudstackReservations.add(super.newReservation());
+      } else {
+         super.inItem();
+      }
+   }
 }

--- a/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/xml/CloudStackEC2DescribeVolumesResponseHandler.java
+++ b/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/xml/CloudStackEC2DescribeVolumesResponseHandler.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.cloudstack.ec2.xml;
 
 import org.jclouds.ec2.xml.CreateVolumeResponseHandler;
@@ -8,37 +26,37 @@ import org.xml.sax.SAXException;
 import javax.inject.Inject;
 
 /**
- * Created with IntelliJ IDEA.
- * User: anshul
- * Date: 12/4/12
- * Time: 2:56 PM
- * To change this template use File | Settings | File Templates.
+ * Element introduced in newer API are causing random errors
+ *
+ * @author Anshul Gangwar
  */
 public class CloudStackEC2DescribeVolumesResponseHandler extends DescribeVolumesResponseHandler {
+   //tagSet element introduced is cause of errors
+   //The element's sub-element contain item element which is the cause of errors
+   //Due to this some unexpected code gets executed and results in error
+   private boolean inTagSet = false;
 
-    private boolean inTagSet;
+   @Inject
+   public CloudStackEC2DescribeVolumesResponseHandler(CreateVolumeResponseHandler volumeHandler) {
+      super(volumeHandler);
+   }
 
-    @Inject
-    public CloudStackEC2DescribeVolumesResponseHandler(CreateVolumeResponseHandler volumeHandler) {
-        super(volumeHandler);
-    }
+   @Override
+   public void startElement(String uri, String localName, String qName, Attributes attributes)
+           throws SAXException {
+      if (qName.equals("tagSet")) {
+         inTagSet = true;
+      } else if (!inTagSet) {
+         super.startElement(uri, localName, qName, attributes);
+      }
+   }
 
-    @Override
-    public void startElement(String uri, String localName, String qName, Attributes attributes)
-            throws SAXException {
-        if (qName.equals("tagSet")) {
-            inTagSet = true;
-        } else if(!inTagSet) {
-            super.startElement(uri, localName, qName, attributes);
-        }
-    }
-
-    @Override
-    public void endElement(String uri, String localName, String qName) throws SAXException {
-       if (qName.equals("tagSet")) {
-            inTagSet = false;
-        } else if(!inTagSet) {
-            super.endElement(uri, localName, qName);
-        }
-    }
+   @Override
+   public void endElement(String uri, String localName, String qName) throws SAXException {
+      if (qName.equals("tagSet")) {
+         inTagSet = false;
+      } else if (!inTagSet) {
+         super.endElement(uri, localName, qName);
+      }
+   }
 }

--- a/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/xml/CloudStackEC2RunInstancesResponseHandler.java
+++ b/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/xml/CloudStackEC2RunInstancesResponseHandler.java
@@ -1,9 +1,26 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jclouds.cloudstack.ec2.xml;
 
 import com.google.common.base.Supplier;
 import com.google.inject.Provider;
 import org.jclouds.date.DateCodecFactory;
-import org.jclouds.ec2.domain.Reservation;
 import org.jclouds.ec2.domain.RootDeviceType;
 import org.jclouds.ec2.domain.RunningInstance;
 import org.jclouds.ec2.xml.RunInstancesResponseHandler;
@@ -15,66 +32,60 @@ import javax.inject.Inject;
 import static org.jclouds.util.SaxUtils.equalsOrSuffix;
 
 /**
- * Created with IntelliJ IDEA.
- * User: anshul
- * Date: 11/28/12
- * Time: 11:54 AM
- * To change this template use File | Settings | File Templates.
+ * Element introduced in newer API are causing random errors
+ *
+ * @author Anshul Gangwar
  */
 public class CloudStackEC2RunInstancesResponseHandler extends RunInstancesResponseHandler {
+   //groupSet for vpc and tagSet element introduced are cause of errors
+   //These elements sub-element contain item element which is the cause of errors
+   //Due to this some unexpected code gets executed and results in error
+   protected boolean inTagSet = false;
+   protected boolean inVpcGroupSet = false;
 
+   @Inject
+   CloudStackEC2RunInstancesResponseHandler(DateCodecFactory dateCodecFactory, @Region Supplier<String> defaultRegion,
+                                            Provider<RunningInstance.Builder> builderProvider) {
+      super(dateCodecFactory, defaultRegion, builderProvider);
+   }
 
-    protected boolean inTagSet;
-    protected boolean inVpcGroupSet;
+   @Override
+   public void startElement(String uri, String name, String qName, Attributes attrs) {
+      if (equalsOrSuffix(qName, "groupSet")) {
+         if (!inInstancesSet) {
+            inGroupSet = true;
+         } else {
+            inVpcGroupSet = true;
+         }
+      } else if (equalsOrSuffix(qName, "tagSet")) {
+         inTagSet = true;
+      } else if (!inTagSet) {
+         super.startElement(uri, name, qName, attrs);
+      }
+   }
 
-    @Inject
-    CloudStackEC2RunInstancesResponseHandler(DateCodecFactory dateCodecFactory, @Region Supplier<String> defaultRegion,
-                                Provider<RunningInstance.Builder> builderProvider) {
-        super(dateCodecFactory, defaultRegion, builderProvider);
-    }
+   @Override
+   public void endElement(String uri, String name, String qName) {
+      if (equalsOrSuffix(qName, "groupSet")) {
+         if (!inInstancesSet) {
+            inGroupSet = false;
+         } else {
+            inVpcGroupSet = false;
+         }
+      } else if (equalsOrSuffix(qName, "tagSet")) {
+         inTagSet = false;
+      } else if (equalsOrSuffix(qName, "rootDeviceType")) {
+         //CloudStack sends this element as empty string so putting some value otherwise NPE
+         builder.rootDeviceType(RootDeviceType.fromValue("ebs"));
+      } else if (equalsOrSuffix(qName, "groupId") && !inGroupSet) {
+         //to remove null pointer exception because of GroupSet element for vpc
+      } else if (!inTagSet) {
+         super.endElement(uri, name, qName);
+      }
+   }
 
-    @Override
-    public void startElement(String uri, String name, String qName, Attributes attrs) {
-        if (equalsOrSuffix(qName, "groupSet")) {
-            if(!inInstancesSet) {
-                inGroupSet = true;
-            } else {
-                inVpcGroupSet = true;
-            }
-        }  else if (equalsOrSuffix(qName, "tagSet")) {
-            inTagSet = true;
-        }  else if(!inTagSet){
-            super.startElement(uri, name, qName, attrs);
-        }
-    }
-
-    @Override
-    public void endElement(String uri, String name, String qName) {
-        if (equalsOrSuffix(qName, "groupSet")) {
-            if(!inInstancesSet) {
-                inGroupSet = false;
-            } else {
-                inVpcGroupSet = false;
-            }
-        } else if (equalsOrSuffix(qName, "tagSet")) {
-            inTagSet = false;
-        } else if (equalsOrSuffix(qName, "rootDeviceType")) {
-            builder.rootDeviceType(RootDeviceType.fromValue("ebs"));
-        } else if (equalsOrSuffix(qName, "groupId") && !inGroupSet) {
-            //  to remove null pointer exception because of vpcGroupSet
-        }else if(!inTagSet){
-            super.endElement(uri, name, qName);
-        }
-    }
-
-    @Override
-    protected boolean endOfInstanceItem() {
-        return itemDepth <= 2 && inInstancesSet && !inProductCodes && !inGroupSet && !inTagSet && !inVpcGroupSet;
-    }
-
-    @Override
-    public Reservation<? extends RunningInstance> getResult() {
-        return newReservation();
-    }
-
+   @Override
+   protected boolean endOfInstanceItem() {
+      return super.endOfInstanceItem() && !inTagSet && !inVpcGroupSet;
+   }
 }

--- a/labs/cloudstack-ec2/src/test/java/org/jclouds/cloudstack/ec2/services/CloudStackEC2AMIClientLiveTest.java
+++ b/labs/cloudstack-ec2/src/test/java/org/jclouds/cloudstack/ec2/services/CloudStackEC2AMIClientLiveTest.java
@@ -41,132 +41,130 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static org.jclouds.ec2.options.DescribeImagesOptions.Builder.imageIds;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author Adrian Cole
  */
 @Test(groups = "live", singleThreaded = true, testName = "CloudStackEC2AMIClientLiveTest")
 public class CloudStackEC2AMIClientLiveTest extends AMIClientLiveTest {
+   private CloudStackEC2Client cloudstackEc2Client;
+   private CloudStackAMIClient cloudstackClient;
 
+   private String defaultZone = null;
+   private RunningInstance instance;
+   private String instanceId;
 
+   private TemplateBuilderSpec cloudstackTemplate;
+   private String createdImageId;
 
-    private CloudStackEC2Client cloudstackEc2Client;
-    private CloudStackAMIClient cloudstackClient;
+   public CloudStackEC2AMIClientLiveTest() {
+      provider = "cloudstack-ec2";
+   }
 
-    private String defaultZone = null;
-    private RunningInstance instance;
-    private String instanceId;
+   @Override
+   protected Properties setupProperties() {
+      Properties overrides = super.setupProperties();
+      String ebsSpec = checkNotNull(setIfTestSystemPropertyPresent(overrides, provider + ".ebs-template"), provider
+              + ".ebs-template");
+      cloudstackTemplate = TemplateBuilderSpec.parse(ebsSpec);
+      return overrides;
+   }
 
-    private TemplateBuilderSpec cloudstackTemplate;
-    private String createdImageId;
+   @Override
+   @BeforeClass(groups = {"integration", "live"})
+   public void setupContext() {
+      //This is kind of copy/pasted as as client is changed
+      // and super class setupContext will not set variables correct
+      initializeContext();
+      cloudstackEc2Client = view.unwrap(CloudStackEC2ApiMetadata.CONTEXT_TOKEN).getApi();
+      cloudstackClient = cloudstackEc2Client.getAMIServices();
+      runningTester = new RetryablePredicate<RunningInstance>(new InstanceStateRunning(cloudstackEc2Client), 600, 5,
+              TimeUnit.SECONDS);
 
-    public CloudStackEC2AMIClientLiveTest() {
-        provider = "cloudstack-ec2";
-    }
+      if (cloudstackTemplate != null) {
+         Template template = view.getComputeService().templateBuilder().from(cloudstackTemplate).build();
+         regionId = template.getLocation().getId();
+         imageId = template.getImage().getProviderId();
+         for (Image image : cloudstackClient.describeImagesInRegion(regionId)) {
+            if (ebsBackedImageName.equals(image.getName()))
+               cloudstackClient.deregisterImageInRegion(regionId, image.getId());
+         }
+      }
+      if (imageId != null) {
+         runInstance();
+      }
+   }
 
-    @Override
-    protected Properties setupProperties() {
-        Properties overrides = super.setupProperties();
-        String ebsSpec = checkNotNull(setIfTestSystemPropertyPresent(overrides, provider + ".ebs-template"), provider
-                + ".ebs-template");
-        cloudstackTemplate = TemplateBuilderSpec.parse(ebsSpec);
-        return overrides;
-    }
+   private void runInstance() {
+      Reservation<? extends RunningInstance> runningInstances = cloudstackEc2Client.getInstanceServices()
+              .runInstancesInRegion(
+                      regionId, defaultZone, imageId, 1, 1);
+      instance = getOnlyElement(concat(runningInstances));
+      instanceId = instance.getId();
+      assertTrue(runningTester.apply(instance), instanceId + "didn't achieve the state running!");
+      instance = (RunningInstance) (getOnlyElement(concat(cloudstackEc2Client.getInstanceServices()
+              .describeInstancesInRegion(regionId,
+                      instanceId))));
+   }
 
-    @Override
-    @BeforeClass(groups = {"integration", "live"})
-    public void setupContext() {
-        initializeContext();
-        cloudstackEc2Client = view.unwrap(CloudStackEC2ApiMetadata.CONTEXT_TOKEN).getApi();
-        cloudstackClient = cloudstackEc2Client.getAMIServices();
-        runningTester = new RetryablePredicate<RunningInstance>(new InstanceStateRunning(cloudstackEc2Client), 600, 5,
-                TimeUnit.SECONDS);
+   @Override
+   @Test
+   public void testDescribeImages() {
+      Set<? extends Image> allResults = cloudstackClient.describeImagesInRegion(null);
+      assertNotNull(allResults);
+      assert allResults.size() >= 1 : allResults.size();
+      Iterator<? extends Image> iterator = allResults.iterator();
+      String id1 = iterator.next().getId();
+      Set<? extends Image> twoResults = cloudstackClient.describeImagesInRegion(null, imageIds(id1));
+      assertNotNull(twoResults);
+      assertEquals(twoResults.size(), 1);
+      iterator = twoResults.iterator();
+      assertEquals(iterator.next().getId(), id1);
+   }
 
-        if (cloudstackTemplate != null) {
-            Template template = view.getComputeService().templateBuilder().from(cloudstackTemplate).build();
-            regionId = template.getLocation().getId();
-            imageId = template.getImage().getProviderId();
-            for (Image image : cloudstackClient.describeImagesInRegion(regionId)) {
-                if (ebsBackedImageName.equals(image.getName()))
-                    cloudstackClient.deregisterImageInRegion(regionId, image.getId());
-            }
-        }
-        if (imageId != null) {
-            runInstance();
-        }
-    }
+   @Test
+   public void testCreateImage() {
+      cloudstackEc2Client.getInstanceServices().stopInstancesInRegion(regionId, false, instanceId);
+      createdImageId = cloudstackClient.createImageInRegion(regionId, "jclouds-cloudstack-ec2", instanceId);
+   }
 
-    private void runInstance() {
-        Reservation<? extends RunningInstance> runningInstances = cloudstackEc2Client.getInstanceServices().runInstancesInRegion(
-                regionId, defaultZone, imageId, 1, 1);
-        instance = getOnlyElement(concat(runningInstances));
-        instanceId = instance.getId();
-        assertTrue(runningTester.apply(instance), instanceId + "didn't achieve the state running!");
-        instance = (RunningInstance) (getOnlyElement(concat(cloudstackEc2Client.getInstanceServices().describeInstancesInRegion(regionId,
-                instanceId))));
-    }
+   @Test(dependsOnMethods = "testCreateImage")
+   void testDeregisterImageInRegion() {
+      cloudstackClient.deregisterImageInRegion(regionId, createdImageId);
+   }
 
-    @Override
-    @Test
-    public void testDescribeImages() {
-        Set<? extends Image> allResults = cloudstackClient.describeImagesInRegion(null);
-        assertNotNull(allResults);
-        assert allResults.size() >= 1 : allResults.size();
-        Iterator<? extends Image> iterator = allResults.iterator();
-        String id1 = iterator.next().getId();
-        Set<? extends Image> twoResults = cloudstackClient.describeImagesInRegion(null, imageIds(id1));
-        assertNotNull(twoResults);
-        assertEquals(twoResults.size(), 1);
-        iterator = twoResults.iterator();
-        assertEquals(iterator.next().getId(), id1);
-    }
+   @Test
+   void testGetLaunchPermissionForImageInRegion() {
+      cloudstackClient.getLaunchPermissionForImageInRegion(regionId, imageId);
+   }
 
+   @Override
+   @Test
+   public void testCreateAndListEBSBackedImage() throws Exception {
+      throw new org.testng.SkipException("it is done differently in CloudStack ");
+   }
 
+   @Override
+   @Test(dependsOnMethods = "testCreateAndListEBSBackedImage")
+   public void testGetLaunchPermissionForImage() {
+      throw new org.testng.SkipException("its depend on skipped test");
+   }
 
-    @Test
-    public void testCreateImage(){
-        cloudstackEc2Client.getInstanceServices().stopInstancesInRegion(regionId,false,instanceId);
-        createdImageId = cloudstackClient.createImageInRegion(regionId,"jclouds-cloudstack-ec2",instanceId);
-    }
+   @Override
+   @AfterClass(groups = {"integration", "live"})
+   protected void tearDownContext() {
+      for (String imageId : imagesToDeregister)
+         cloudstackClient.deregisterImageInRegion(regionId, imageId);
 
-    @Test(dependsOnMethods = "testCreateImage")
-    void testDeregisterImageInRegion(){
-        cloudstackClient.deregisterImageInRegion(regionId, createdImageId);
-    }
+      for (String snapshotId : snapshotsToDelete)
+         cloudstackEc2Client.getElasticBlockStoreServices().deleteSnapshotInRegion(regionId, snapshotId);
 
-    @Test
-    void testGetLaunchPermissionForImageInRegion(){
-        cloudstackClient.getLaunchPermissionForImageInRegion(regionId, imageId);
-    }
-
-
-    @Override
-    @Test
-    public void testCreateAndListEBSBackedImage() throws Exception {
-        //just a place holder so that super class test doesn't run
-    }
-
-    @Override
-    @Test(dependsOnMethods = "testCreateAndListEBSBackedImage")
-    public void testGetLaunchPermissionForImage() {
-       //just a place holder so that super class test doesn't run
-    }
-
-    @Override
-    @AfterClass(groups = {"integration", "live"})
-    protected void tearDownContext() {
-        for (String imageId : imagesToDeregister)
-            cloudstackClient.deregisterImageInRegion(regionId, imageId);
-
-        for (String snapshotId : snapshotsToDelete)
-            cloudstackEc2Client.getElasticBlockStoreServices().deleteSnapshotInRegion(regionId, snapshotId);
-
-        if (instanceId != null) {
-            cloudstackEc2Client.getInstanceServices().terminateInstancesInRegion(regionId, instanceId);
-        }
-        super.tearDownContext();
-    }
-
-
+      if (instanceId != null) {
+         cloudstackEc2Client.getInstanceServices().terminateInstancesInRegion(regionId, instanceId);
+      }
+      super.tearDownContext();
+   }
 }

--- a/labs/cloudstack-ec2/src/test/java/org/jclouds/cloudstack/ec2/services/CloudStackEC2AvailabilityZoneAndRegionClientLiveTest.java
+++ b/labs/cloudstack-ec2/src/test/java/org/jclouds/cloudstack/ec2/services/CloudStackEC2AvailabilityZoneAndRegionClientLiveTest.java
@@ -22,7 +22,6 @@ import org.jclouds.ec2.services.AvailabilityZoneAndRegionClientLiveTest;
 import org.testng.annotations.Test;
 
 /**
- * 
  * @author Adrian Cole
  */
 @Test(groups = "live", singleThreaded = true, testName = "CloudStackEC2AvailabilityZoneAndRegionClientLiveTest")
@@ -31,9 +30,8 @@ public class CloudStackEC2AvailabilityZoneAndRegionClientLiveTest extends Availa
       provider = "cloudstack-ec2";
    }
 
-    @Override
-    public void testDescribeRegions() {
-        //just a place holder
+   @Override
+   public void testDescribeRegions() {
+      throw new org.testng.SkipException("Regions are not supported in CloudStack");
    }
-
 }

--- a/labs/cloudstack-ec2/src/test/java/org/jclouds/cloudstack/ec2/services/CloudStackEC2ElasticBlockStoreClientLiveTest.java
+++ b/labs/cloudstack-ec2/src/test/java/org/jclouds/cloudstack/ec2/services/CloudStackEC2ElasticBlockStoreClientLiveTest.java
@@ -23,7 +23,12 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import org.jclouds.cloudstack.ec2.CloudStackEC2ApiMetadata;
 import org.jclouds.cloudstack.ec2.CloudStackEC2Client;
-import org.jclouds.ec2.domain.*;
+import org.jclouds.ec2.domain.AvailabilityZoneInfo;
+import org.jclouds.ec2.domain.Image;
+import org.jclouds.ec2.domain.Reservation;
+import org.jclouds.ec2.domain.RunningInstance;
+import org.jclouds.ec2.domain.Snapshot;
+import org.jclouds.ec2.domain.Volume;
 import org.jclouds.ec2.predicates.InstanceStateRunning;
 import org.jclouds.ec2.predicates.SnapshotCompleted;
 import org.jclouds.ec2.predicates.VolumeAvailable;
@@ -51,196 +56,191 @@ import static org.testng.Assert.assertTrue;
  */
 @Test(groups = "live", singleThreaded = true, testName = "CloudStackEC2ElasticBlockStoreClientLiveTest")
 public class CloudStackEC2ElasticBlockStoreClientLiveTest extends ElasticBlockStoreClientLiveTest {
-    private CloudStackEC2Client cloudstackEc2Client;
-    private RetryablePredicate<RunningInstance> runningTester;
-    private ElasticBlockStoreClient cloudstackClient;
-    private String regionId = "AmazonEC2";
-    private String cloudstackDefaultZone;
-    private String imageId;
-    private RunningInstance instance;
-    private String instanceId;
-    private String cloudstackVolumeId;
-    private Snapshot cloudstackSnapshot;
-    private Volume volumeSnapshot;
+   private CloudStackEC2Client cloudstackEc2Client;
+   private RetryablePredicate<RunningInstance> runningTester;
+   private ElasticBlockStoreClient cloudstackClient;
+   private String regionId = "AmazonEC2";
+   private String cloudstackDefaultZone;
+   private String imageId;
+   private RunningInstance instance;
+   private String instanceId;
+   private String cloudstackVolumeId;
+   private Snapshot cloudstackSnapshot;
+   private Volume volumeSnapshot;
 
-    public CloudStackEC2ElasticBlockStoreClientLiveTest() {
-        provider = "cloudstack-ec2";
-    }
+   public CloudStackEC2ElasticBlockStoreClientLiveTest() {
+      provider = "cloudstack-ec2";
+   }
 
-    @Override
-    @BeforeClass(groups = {"integration", "live"})
-    public void setupContext() {
-        initializeContext();
-        cloudstackEc2Client = view.unwrap(CloudStackEC2ApiMetadata.CONTEXT_TOKEN).getApi();
-        runningTester = new RetryablePredicate<RunningInstance>(new InstanceStateRunning(cloudstackEc2Client), 900, 5,
-                TimeUnit.SECONDS);
-        cloudstackClient = cloudstackEc2Client.getElasticBlockStoreServices();
-        Set<AvailabilityZoneInfo> allResults = cloudstackEc2Client.getAvailabilityZoneAndRegionServices().describeAvailabilityZonesInRegion(regionId);
-        allResults.iterator().next();
-        cloudstackDefaultZone = allResults.iterator().next().getZone();
-        Set<? extends Image> allImageResults = cloudstackEc2Client.getAMIServices().describeImagesInRegion(regionId);
-        assertNotNull(allImageResults);
-        assert allImageResults.size() >= 1 : allImageResults.size();
-        Iterator<? extends Image> iterator = allImageResults.iterator();
-        imageId = iterator.next().getId();
-        if (imageId != null) {
-            runInstance();
-        }
+   @Override
+   @BeforeClass(groups = {"integration", "live"})
+   public void setupContext() {
+      initializeContext();
+      cloudstackEc2Client = view.unwrap(CloudStackEC2ApiMetadata.CONTEXT_TOKEN).getApi();
+      runningTester = new RetryablePredicate<RunningInstance>(new InstanceStateRunning(cloudstackEc2Client), 900, 5,
+              TimeUnit.SECONDS);
+      cloudstackClient = cloudstackEc2Client.getElasticBlockStoreServices();
+      Set<AvailabilityZoneInfo> allResults = cloudstackEc2Client.getAvailabilityZoneAndRegionServices()
+              .describeAvailabilityZonesInRegion(regionId);
+      allResults.iterator().next();
+      cloudstackDefaultZone = allResults.iterator().next().getZone();
+      Set<? extends Image> allImageResults = cloudstackEc2Client.getAMIServices().describeImagesInRegion(regionId);
+      assertNotNull(allImageResults);
+      assert allImageResults.size() >= 1 : allImageResults.size();
+      Iterator<? extends Image> iterator = allImageResults.iterator();
+      imageId = iterator.next().getId();
+      if (imageId != null) {
+         runInstance();
+      }
+   }
 
-    }
+   private void runInstance() {
+      Reservation<? extends RunningInstance> runningInstances = cloudstackEc2Client.getInstanceServices()
+              .runInstancesInRegion(
+                      regionId, cloudstackDefaultZone, imageId, 1, 1);
+      instance = getOnlyElement(concat(runningInstances));
+      instanceId = instance.getId();
+      assertTrue(runningTester.apply(instance), instanceId + "didn't achieve the state running!");
+      instance = (RunningInstance) (getOnlyElement(concat(cloudstackEc2Client.getInstanceServices()
+              .describeInstancesInRegion(regionId,
+                      instanceId))));
+   }
 
-    private void runInstance() {
-        Reservation<? extends RunningInstance> runningInstances = cloudstackEc2Client.getInstanceServices().runInstancesInRegion(
-                regionId, cloudstackDefaultZone, imageId, 1, 1);
-        instance = getOnlyElement(concat(runningInstances));
-        instanceId = instance.getId();
-        assertTrue(runningTester.apply(instance), instanceId + "didn't achieve the state running!");
-        instance = (RunningInstance) (getOnlyElement(concat(cloudstackEc2Client.getInstanceServices().describeInstancesInRegion(regionId,
-                instanceId))));
-    }
+   @Test
+   void testDescribeVolumes() {
+      SortedSet<Volume> allResults = Sets.newTreeSet(cloudstackClient.describeVolumesInRegion(regionId));
+      assertNotNull(allResults);
+      if (allResults.size() >= 1) {
+         Volume volume = allResults.last();
+         SortedSet<Volume> result = Sets.newTreeSet(cloudstackClient.describeVolumesInRegion(regionId, volume.getId()));
+         assertNotNull(result);
+         Volume compare = result.last();
+         assertEquals(compare, volume);
+      }
+   }
 
+   @Test
+   void testCreateVolumeInAvailabilityZone() {
+      Volume expected = cloudstackClient.createVolumeInAvailabilityZone(cloudstackDefaultZone, 1);
+      assertNotNull(expected);
+      assertEquals(expected.getAvailabilityZone(), cloudstackDefaultZone);
+      this.cloudstackVolumeId = expected.getId();
+      Set<Volume> result = Sets.newLinkedHashSet(cloudstackClient.describeVolumesInRegion(regionId, expected.getId()));
+      assertNotNull(result);
+      assertEquals(result.size(), 1);
+      Volume volume = result.iterator().next();
+      assertEquals(volume.getId(), expected.getId());
+   }
 
-    @Test
-    void testDescribeVolumes() {
-            SortedSet<Volume> allResults = Sets.newTreeSet(cloudstackClient.describeVolumesInRegion(regionId));
-            assertNotNull(allResults);
-            if (allResults.size() >= 1) {
-                Volume volume = allResults.last();
-                SortedSet<Volume> result = Sets.newTreeSet(cloudstackClient.describeVolumesInRegion(regionId, volume.getId()));
-                assertNotNull(result);
-                Volume compare = result.last();
-                assertEquals(compare, volume);
-            }
-    }
+   @Test(dependsOnMethods = "testAttachVolumeInRegion")
+   void testCreateSnapshotInRegion() {
+      Snapshot snapshot = cloudstackClient.createSnapshotInRegion(regionId, cloudstackVolumeId);
+      Predicate<Snapshot> snapshotted = new RetryablePredicate<Snapshot>(new SnapshotCompleted(cloudstackClient),
+              900, 10,
+              TimeUnit.SECONDS);
+      assert snapshotted.apply(snapshot);
 
-    @Test
-    void testCreateVolumeInAvailabilityZone() {
-        Volume expected = cloudstackClient.createVolumeInAvailabilityZone(cloudstackDefaultZone, 1);
-        assertNotNull(expected);
-        assertEquals(expected.getAvailabilityZone(), cloudstackDefaultZone);
-        this.cloudstackVolumeId = expected.getId();
-        Set<Volume> result = Sets.newLinkedHashSet(cloudstackClient.describeVolumesInRegion(regionId, expected.getId()));
-        assertNotNull(result);
-        assertEquals(result.size(), 1);
-        Volume volume = result.iterator().next();
-        assertEquals(volume.getId(), expected.getId());
-    }
+      Snapshot result = Iterables.getOnlyElement(cloudstackClient.describeSnapshotsInRegion(snapshot.getRegion(),
+              snapshotIds(snapshot.getId())));
 
-    @Test(dependsOnMethods = "testAttachVolumeInRegion")
-    void testCreateSnapshotInRegion() {
-        Snapshot snapshot = cloudstackClient.createSnapshotInRegion(regionId, cloudstackVolumeId);
-        Predicate<Snapshot> snapshotted = new RetryablePredicate<Snapshot>(new SnapshotCompleted(cloudstackClient), 900, 10,
-                TimeUnit.SECONDS);
-        assert snapshotted.apply(snapshot);
+      assertEquals(result.getProgress(), 100);
+      this.cloudstackSnapshot = result;
+   }
 
-        Snapshot result = Iterables.getOnlyElement(cloudstackClient.describeSnapshotsInRegion(snapshot.getRegion(),
-                snapshotIds(snapshot.getId())));
+   @Test(dependsOnMethods = "testCreateSnapshotInRegion")
+   void testCreateVolumeFromSnapshotInAvailabilityZone() {
+      volumeSnapshot = cloudstackClient.createVolumeFromSnapshotInAvailabilityZone(cloudstackDefaultZone,
+              cloudstackSnapshot.getId());
+      assertNotNull(volumeSnapshot);
 
-        assertEquals(result.getProgress(), 100);
-        this.cloudstackSnapshot = result;
-    }
+      Predicate<Volume> availabile = new RetryablePredicate<Volume>(new VolumeAvailable(cloudstackClient), 600, 10,
+              TimeUnit.SECONDS);
+      assert availabile.apply(volumeSnapshot);
 
-    @Test(dependsOnMethods = "testCreateSnapshotInRegion")
-    void testCreateVolumeFromSnapshotInAvailabilityZone() {
-        volumeSnapshot = cloudstackClient.createVolumeFromSnapshotInAvailabilityZone(cloudstackDefaultZone, cloudstackSnapshot.getId());
-        assertNotNull(volumeSnapshot);
+      Volume result = Iterables.getOnlyElement(cloudstackClient.describeVolumesInRegion(regionId,
+              volumeSnapshot.getId()));
 
-        Predicate<Volume> availabile = new RetryablePredicate<Volume>(new VolumeAvailable(cloudstackClient), 600, 10,
-                TimeUnit.SECONDS);
-        assert availabile.apply(volumeSnapshot);
+      assertEquals(volumeSnapshot.getId(), result.getId());
+      // assertEquals(volumeSnapshot.getSnapshotId(), cloudstackSnapshot.getId());
+      // assertEquals(volumeSnapshot.getAvailabilityZone(), defaultZone);
+      //assertEquals(result.getStatus(), Volume.Status.AVAILABLE);
 
-        Volume result = Iterables.getOnlyElement(cloudstackClient.describeVolumesInRegion(regionId, volumeSnapshot.getId()));
+      cloudstackClient.deleteVolumeInRegion(regionId, volumeSnapshot.getId());
+      volumeSnapshot = null;
+   }
 
-        assertEquals(volumeSnapshot.getId(), result.getId());
+   @Test(dependsOnMethods = "testCreateVolumeInAvailabilityZone")
+   void testAttachVolumeInRegion() {
+      cloudstackClient.attachVolumeInRegion(regionId, cloudstackVolumeId, instanceId, "/dev/sdh");
+   }
 
-        // assertEquals(volumeSnapshot.getSnapshotId(), cloudstackSnapshot.getId());
+   @Test(dependsOnMethods = "testCreateSnapshotInRegion")
+   void testDetachVolumeInRegion() {
+      cloudstackClient.detachVolumeInRegion(regionId, cloudstackVolumeId, false);
+   }
 
-        // assertEquals(volumeSnapshot.getAvailabilityZone(), defaultZone);
+   @Test
+   void testDescribeSnapshots() {
+      for (String region : cloudstackEc2Client.getConfiguredRegions()) {
+         SortedSet<Snapshot> allResults = Sets.newTreeSet(cloudstackClient.describeSnapshotsInRegion(region));
+         assertNotNull(allResults);
+         if (allResults.size() >= 1) {
+            Snapshot snapshot = allResults.last();
+            Snapshot result = Iterables.getOnlyElement(cloudstackClient.describeSnapshotsInRegion(region,
+                    snapshotIds(snapshot.getId())));
+            assertNotNull(result);
+            assertEquals(result, snapshot);
+         }
+      }
+   }
 
-        //assertEquals(result.getStatus(), Volume.Status.AVAILABLE);
-
-
-        cloudstackClient.deleteVolumeInRegion(regionId, volumeSnapshot.getId());
-        volumeSnapshot = null;
-    }
-
-    @Test(dependsOnMethods = "testCreateVolumeInAvailabilityZone")
-    void testAttachVolumeInRegion() {
-
-        cloudstackClient.attachVolumeInRegion(regionId, cloudstackVolumeId, instanceId, "/dev/sdh");
-
-    }
-
-    @Test(dependsOnMethods = "testCreateSnapshotInRegion")
-    void testDetachVolumeInRegion() {
-        cloudstackClient.detachVolumeInRegion(regionId, cloudstackVolumeId, false);
-    }
-
-    @Test
-    void testDescribeSnapshots() {
-        for (String region : cloudstackEc2Client.getConfiguredRegions()) {
-            SortedSet<Snapshot> allResults = Sets.newTreeSet(cloudstackClient.describeSnapshotsInRegion(region));
-            assertNotNull(allResults);
-            if (allResults.size() >= 1) {
-                Snapshot snapshot = allResults.last();
-                Snapshot result = Iterables.getOnlyElement(cloudstackClient.describeSnapshotsInRegion(region,
-                        snapshotIds(snapshot.getId())));
-                assertNotNull(result);
-                assertEquals(result, snapshot);
-            }
-        }
-    }
-
-    @Test(dependsOnMethods = "testDetachVolumeInRegion")
-    void testDeleteVolumeInRegion() {
-        cloudstackClient.deleteVolumeInRegion(regionId, cloudstackVolumeId);
-        cloudstackVolumeId = null;
-
-      /*Set<Volume> result = Sets.newLinkedHashSet(cloudstackClient.describeVolumesInRegion(defaultRegion, cloudstackVolumeId));
+   @Test(dependsOnMethods = "testDetachVolumeInRegion")
+   void testDeleteVolumeInRegion() {
+      cloudstackClient.deleteVolumeInRegion(regionId, cloudstackVolumeId);
+      cloudstackVolumeId = null;
+      /*Set<Volume> result = Sets.newLinkedHashSet(cloudstackClient.describeVolumesInRegion(defaultRegion,
+      cloudstackVolumeId));
         assertEquals(result.size(), 1);
         Volume volume = result.iterator().next();
         assertEquals(volume.getStatus(), Volume.Status.DELETING);*/
+   }
 
-    }
+   @Test(dependsOnMethods = "testCreateSnapshotInRegion")
+   public void testGetCreateVolumePermissionForSnapshot() {
+      throw new org.testng.SkipException("Not supported in CloudStack");
+   }
 
-    @Test(dependsOnMethods = "testCreateSnapshotInRegion")
-    public void testGetCreateVolumePermissionForSnapshot() {
-        //cloudstackClient.getCreateVolumePermissionForSnapshotInRegion(cloudstackSnapshot.getRegion(), cloudstackSnapshot.getId());
-    }
+   @Test(dependsOnMethods = "testCreateSnapshotInRegion")
+   void testCreateVolumeFromSnapshotInAvailabilityZoneWithSize() {
+      throw new org.testng.SkipException("Not supported in CloudStack");
+   }
 
-    @Test(dependsOnMethods = "testCreateSnapshotInRegion")
-    void testCreateVolumeFromSnapshotInAvailabilityZoneWithSize() {
-    }
+   @Test(dependsOnMethods = "testCreateVolumeFromSnapshotInAvailabilityZone")
+   void testDeleteSnapshotInRegion() {
+      cloudstackClient.deleteSnapshotInRegion(regionId, cloudstackSnapshot.getId());
+      assert cloudstackClient.describeSnapshotsInRegion(regionId, snapshotIds(cloudstackSnapshot.getId())).size() == 0;
+      cloudstackSnapshot = null;
+   }
 
-    @Test(dependsOnMethods = "testCreateVolumeFromSnapshotInAvailabilityZone")
-    void testDeleteSnapshotInRegion() {
-        cloudstackClient.deleteSnapshotInRegion(regionId, cloudstackSnapshot.getId());
-        assert cloudstackClient.describeSnapshotsInRegion(regionId, snapshotIds(cloudstackSnapshot.getId())).size() == 0;
-        cloudstackSnapshot = null;
-    }
+   @Override
+   @AfterClass(groups = {"integration", "live"})
+   protected void tearDownContext() {
+      if (instanceId != null) {
+         cloudstackEc2Client.getInstanceServices().terminateInstancesInRegion(regionId, instanceId);
+      }
 
-    @Override
-    @AfterClass(groups = {"integration", "live"})
-    protected void tearDownContext() {
-        if (instanceId != null) {
-            cloudstackEc2Client.getInstanceServices().terminateInstancesInRegion(regionId, instanceId);
-        }
+      if (cloudstackVolumeId != null) {
+         cloudstackClient.deleteVolumeInRegion(regionId, cloudstackVolumeId);
+      }
 
-        if(cloudstackVolumeId != null){
-            cloudstackClient.deleteVolumeInRegion(regionId, cloudstackVolumeId);
-        }
+      if (cloudstackSnapshot != null) {
+         cloudstackClient.deleteSnapshotInRegion(regionId, cloudstackSnapshot.getId());
+      }
 
-        if(cloudstackSnapshot != null){
-            cloudstackClient.deleteSnapshotInRegion(regionId, cloudstackSnapshot.getId());
-        }
+      if (volumeSnapshot != null) {
+         cloudstackClient.deleteVolumeInRegion(regionId, volumeSnapshot.getId());
+      }
 
-        if(volumeSnapshot != null){
-            cloudstackClient.deleteVolumeInRegion(regionId, volumeSnapshot.getId());
-        }
-
-        super.tearDownContext();
-    }
-
-
-
+      super.tearDownContext();
+   }
 }

--- a/labs/cloudstack-ec2/src/test/java/org/jclouds/cloudstack/ec2/services/CloudStackEC2ElasticIPAddressClientLiveTest.java
+++ b/labs/cloudstack-ec2/src/test/java/org/jclouds/cloudstack/ec2/services/CloudStackEC2ElasticIPAddressClientLiveTest.java
@@ -21,7 +21,11 @@ package org.jclouds.cloudstack.ec2.services;
 import com.google.common.collect.Sets;
 import org.jclouds.cloudstack.ec2.CloudStackEC2ApiMetadata;
 import org.jclouds.cloudstack.ec2.CloudStackEC2Client;
-import org.jclouds.ec2.domain.*;
+import org.jclouds.ec2.domain.AvailabilityZoneInfo;
+import org.jclouds.ec2.domain.Image;
+import org.jclouds.ec2.domain.PublicIpInstanceIdPair;
+import org.jclouds.ec2.domain.Reservation;
+import org.jclouds.ec2.domain.RunningInstance;
 import org.jclouds.ec2.predicates.InstanceStateRunning;
 import org.jclouds.ec2.services.ElasticIPAddressClient;
 import org.jclouds.ec2.services.ElasticIPAddressClientLiveTest;
@@ -37,109 +41,105 @@ import java.util.concurrent.TimeUnit;
 
 import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 /**
- * 
  * @author Adrian Cole
  */
 @Test(groups = "live", singleThreaded = true, testName = "CloudStackEC2ElasticIPAddressClientLiveTest")
 public class CloudStackEC2ElasticIPAddressClientLiveTest extends ElasticIPAddressClientLiveTest {
-    private CloudStackEC2Client cloudstackEc2Client;
-    private ElasticIPAddressClient cloudstackClient;
-    private RetryablePredicate<RunningInstance> runningTester;
-    private String cloudstackDefaultZone;
-    private String imageId;
-    private String regionId = "AmazonEC2";
-    private RunningInstance instance;
-    private String instanceId;
-    private String publicIp;
+   private CloudStackEC2Client cloudstackEc2Client;
+   private ElasticIPAddressClient cloudstackClient;
+   private RetryablePredicate<RunningInstance> runningTester;
+   private String cloudstackDefaultZone;
+   private String imageId;
+   private String regionId = "AmazonEC2";
+   private RunningInstance instance;
+   private String instanceId;
+   private String publicIp;
 
-    public CloudStackEC2ElasticIPAddressClientLiveTest() {
+   public CloudStackEC2ElasticIPAddressClientLiveTest() {
       provider = "cloudstack-ec2";
    }
 
-    @Override
-    @BeforeClass(groups = {"integration", "live"})
-    public void setupContext() {
-        initializeContext();
-        cloudstackEc2Client = view.unwrap(CloudStackEC2ApiMetadata.CONTEXT_TOKEN).getApi();
-        cloudstackClient = cloudstackEc2Client.getElasticIPAddressServices();
+   @Override
+   @BeforeClass(groups = {"integration", "live"})
+   public void setupContext() {
+      initializeContext();
+      cloudstackEc2Client = view.unwrap(CloudStackEC2ApiMetadata.CONTEXT_TOKEN).getApi();
+      cloudstackClient = cloudstackEc2Client.getElasticIPAddressServices();
+      runningTester = new RetryablePredicate<RunningInstance>(new InstanceStateRunning(cloudstackEc2Client), 900, 5,
+              TimeUnit.SECONDS);
+      Set<AvailabilityZoneInfo> allResults = cloudstackEc2Client.getAvailabilityZoneAndRegionServices()
+              .describeAvailabilityZonesInRegion(regionId);
+      allResults.iterator().next();
+      cloudstackDefaultZone = allResults.iterator().next().getZone();
+      Set<? extends Image> allImageResults = cloudstackEc2Client.getAMIServices().describeImagesInRegion(regionId);
+      assertNotNull(allImageResults);
+      assert allImageResults.size() >= 1 : allImageResults.size();
+      Iterator<? extends Image> iterator = allImageResults.iterator();
+      imageId = iterator.next().getId();
+      if (imageId != null) {
+         runInstance();
+      }
+   }
 
-        runningTester = new RetryablePredicate<RunningInstance>(new InstanceStateRunning(cloudstackEc2Client), 900, 5,
-                TimeUnit.SECONDS);
-        Set<AvailabilityZoneInfo> allResults = cloudstackEc2Client.getAvailabilityZoneAndRegionServices().describeAvailabilityZonesInRegion(regionId);
-        allResults.iterator().next();
-        cloudstackDefaultZone = allResults.iterator().next().getZone();
-        Set<? extends Image> allImageResults = cloudstackEc2Client.getAMIServices().describeImagesInRegion(regionId);
-        assertNotNull(allImageResults);
-        assert allImageResults.size() >= 1 : allImageResults.size();
-        Iterator<? extends Image> iterator = allImageResults.iterator();
-        imageId = iterator.next().getId();
-        if (imageId != null) {
-            runInstance();
-        }
+   private void runInstance() {
+      Reservation<? extends RunningInstance> runningInstances = cloudstackEc2Client.getInstanceServices()
+              .runInstancesInRegion(
+                      regionId, cloudstackDefaultZone, imageId, 1, 1);
+      instance = getOnlyElement(concat(runningInstances));
+      instanceId = instance.getId();
+      assertTrue(runningTester.apply(instance), instanceId + "didn't achieve the state running!");
+      instance = (RunningInstance) (getOnlyElement(concat(cloudstackEc2Client.getInstanceServices()
+              .describeInstancesInRegion(regionId,
+                      instanceId))));
+   }
 
-    }
+   @Test
+   void testDescribeAddresses() {
+      SortedSet<PublicIpInstanceIdPair> allResults = Sets.newTreeSet(cloudstackClient.describeAddressesInRegion
+              (regionId));
+      assertNotNull(allResults);
+      if (allResults.size() >= 1) {
+         PublicIpInstanceIdPair pair = allResults.last();
+         SortedSet<PublicIpInstanceIdPair> result = Sets.newTreeSet(cloudstackClient.describeAddressesInRegion
+                 (regionId, pair
+                 .getPublicIp()));
+         assertNotNull(result);
+         PublicIpInstanceIdPair compare = result.last();
+         assertEquals(compare, pair);
+      }
+   }
 
+   @Test
+   void testAllocateAddressInRegion() {
+      publicIp = cloudstackClient.allocateAddressInRegion(regionId);
+   }
 
-    private void runInstance() {
-        Reservation<? extends RunningInstance> runningInstances = cloudstackEc2Client.getInstanceServices().runInstancesInRegion(
-                regionId, cloudstackDefaultZone, imageId, 1, 1);
-        instance = getOnlyElement(concat(runningInstances));
-        instanceId = instance.getId();
-        assertTrue(runningTester.apply(instance), instanceId + "didn't achieve the state running!");
-        instance = (RunningInstance) (getOnlyElement(concat(cloudstackEc2Client.getInstanceServices().describeInstancesInRegion(regionId,
-                instanceId))));
-    }
+   @Test(dependsOnMethods = "testAllocateAddressInRegion")
+   void testAssociateAddressInRegion() {
+      cloudstackClient.associateAddressInRegion(regionId, publicIp, instanceId);
+   }
 
-    @Test
-    void testDescribeAddresses() {
+   @Test(dependsOnMethods = "testAssociateAddressInRegion")
+   void testDisassociateAddressInRegion() {
+      cloudstackClient.disassociateAddressInRegion(regionId, publicIp);
+   }
 
-        SortedSet<PublicIpInstanceIdPair> allResults = Sets.newTreeSet(cloudstackClient.describeAddressesInRegion(regionId));
-        assertNotNull(allResults);
-        if (allResults.size() >= 1) {
-            PublicIpInstanceIdPair pair = allResults.last();
-            SortedSet<PublicIpInstanceIdPair> result = Sets.newTreeSet(cloudstackClient.describeAddressesInRegion(regionId, pair
-                    .getPublicIp()));
-            assertNotNull(result);
-            PublicIpInstanceIdPair compare = result.last();
-            assertEquals(compare, pair);
-        }
+   @Test(dependsOnMethods = "testDisassociateAddressInRegion")
+   void testReleaseAddressInRegion() {
+      cloudstackClient.releaseAddressInRegion(regionId, publicIp);
+   }
 
-    }
-
-    @Test
-    void testAllocateAddressInRegion() {
-        publicIp = cloudstackClient.allocateAddressInRegion(regionId);
-    }
-
-    @Test(dependsOnMethods = "testAllocateAddressInRegion")
-    void testAssociateAddressInRegion() {
-        cloudstackClient.associateAddressInRegion(regionId, publicIp, instanceId);
-    }
-
-    @Test(dependsOnMethods = "testAssociateAddressInRegion")
-    void testDisassociateAddressInRegion() {
-        cloudstackClient.disassociateAddressInRegion(regionId,publicIp);
-    }
-
-    @Test(dependsOnMethods = "testDisassociateAddressInRegion")
-    void testReleaseAddressInRegion() {
-        cloudstackClient.releaseAddressInRegion(regionId,publicIp);
-    }
-
-    @Override
-    @AfterClass(groups = {"integration", "live"})
-    protected void tearDownContext() {
-        if (instanceId != null) {
-            cloudstackEc2Client.getInstanceServices().terminateInstancesInRegion(regionId, instanceId);
-        }
-
-        super.tearDownContext();
-    }
-
-
-
-
+   @Override
+   @AfterClass(groups = {"integration", "live"})
+   protected void tearDownContext() {
+      if (instanceId != null) {
+         cloudstackEc2Client.getInstanceServices().terminateInstancesInRegion(regionId, instanceId);
+      }
+      super.tearDownContext();
+   }
 }

--- a/labs/cloudstack-ec2/src/test/java/org/jclouds/cloudstack/ec2/services/CloudStackEC2InstanceClientLiveTest.java
+++ b/labs/cloudstack-ec2/src/test/java/org/jclouds/cloudstack/ec2/services/CloudStackEC2InstanceClientLiveTest.java
@@ -40,85 +40,85 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 /**
- * 
  * @author Adrian Cole
  */
 @Test(groups = "live", singleThreaded = true, testName = "CloudStackInstanceClientLiveTest")
 public class CloudStackEC2InstanceClientLiveTest extends InstanceClientLiveTest {
+   private CloudStackEC2Client cloudstackEc2Client;
+   private RetryablePredicate<RunningInstance> runningTester;
+   private CloudStackEC2InstanceClient cloudstackClient;
+   private String cloudstackDefaultZone;
+   private String imageId;
+   private String regionId = "AmazonEC2";
+   private RunningInstance instance;
+   private String instanceId;
 
-    private CloudStackEC2Client cloudstackEc2Client;
-    private RetryablePredicate<RunningInstance> runningTester;
-    private CloudStackEC2InstanceClient cloudstackClient;
-    private String cloudstackDefaultZone;
-    private String imageId;
-    private String regionId = "AmazonEC2";
-    private RunningInstance instance;
-    private String instanceId;
-
-
-    public CloudStackEC2InstanceClientLiveTest() {
+   public CloudStackEC2InstanceClientLiveTest() {
       provider = "cloudstack-ec2";
    }
 
-    @Override
-    @BeforeClass(groups = {"integration", "live"})
-    public void setupContext() {
-        initializeContext();
-        cloudstackEc2Client = view.unwrap(CloudStackEC2ApiMetadata.CONTEXT_TOKEN).getApi();
-        runningTester = new RetryablePredicate<RunningInstance>(new InstanceStateRunning(cloudstackEc2Client), 900, 5,
-                TimeUnit.SECONDS);
-        cloudstackClient = cloudstackEc2Client.getInstanceServices();
-        Set<AvailabilityZoneInfo> allResults = cloudstackEc2Client.getAvailabilityZoneAndRegionServices().describeAvailabilityZonesInRegion(regionId);
-        allResults.iterator().next();
-        cloudstackDefaultZone = allResults.iterator().next().getZone();
-        Set<? extends Image> allImageResults = cloudstackEc2Client.getAMIServices().describeImagesInRegion(regionId);
-        assertNotNull(allImageResults);
-        assert allImageResults.size() >= 1 : allImageResults.size();
-        Iterator<? extends Image> iterator = allImageResults.iterator();
-        imageId = iterator.next().getId();
-    }
+   @Override
+   @BeforeClass(groups = {"integration", "live"})
+   public void setupContext() {
+      initializeContext();
+      cloudstackEc2Client = view.unwrap(CloudStackEC2ApiMetadata.CONTEXT_TOKEN).getApi();
+      runningTester = new RetryablePredicate<RunningInstance>(new InstanceStateRunning(cloudstackEc2Client), 900, 5,
+              TimeUnit.SECONDS);
+      cloudstackClient = cloudstackEc2Client.getInstanceServices();
+      Set<AvailabilityZoneInfo> allResults = cloudstackEc2Client.getAvailabilityZoneAndRegionServices()
+              .describeAvailabilityZonesInRegion(regionId);
+      allResults.iterator().next();
+      cloudstackDefaultZone = allResults.iterator().next().getZone();
+      Set<? extends Image> allImageResults = cloudstackEc2Client.getAMIServices().describeImagesInRegion(regionId);
+      assertNotNull(allImageResults);
+      assert allImageResults.size() >= 1 : allImageResults.size();
+      Iterator<? extends Image> iterator = allImageResults.iterator();
+      imageId = iterator.next().getId();
+   }
 
-    @Test
-    void testDescribeInstances() {
-       Set<? extends Reservation<? extends RunningInstance>> allResults = cloudstackClient.describeInstancesInRegion(regionId);
-       assertNotNull(allResults);
-       assert allResults.size() >= 0 : allResults.size();
-    }
+   @Test
+   void testDescribeInstances() {
+      Set<? extends Reservation<? extends RunningInstance>> allResults = cloudstackClient.describeInstancesInRegion
+              (regionId);
+      assertNotNull(allResults);
+      assert allResults.size() >= 0 : allResults.size();
+   }
 
-    @Test
-    void testRunInstance() {
+   @Test
+   void testRunInstance() {
+      Reservation<? extends RunningInstance> runningInstances = cloudstackEc2Client.getInstanceServices()
+              .runInstancesInRegion(
+              regionId, cloudstackDefaultZone, imageId, 1, 1);
+      instance = getOnlyElement(concat(runningInstances));
+      instanceId = instance.getId();
+      assertTrue(runningTester.apply(instance), instanceId + "didn't achieve the state running!");
+      instance = (RunningInstance) (getOnlyElement(concat(cloudstackEc2Client.getInstanceServices()
+              .describeInstancesInRegion(regionId,
+              instanceId))));
+   }
 
-        Reservation<? extends RunningInstance> runningInstances = cloudstackEc2Client.getInstanceServices().runInstancesInRegion(
-                regionId, cloudstackDefaultZone, imageId, 1, 1);
-        instance = getOnlyElement(concat(runningInstances));
-        instanceId = instance.getId();
-        assertTrue(runningTester.apply(instance), instanceId + "didn't achieve the state running!");
-        instance = (RunningInstance) (getOnlyElement(concat(cloudstackEc2Client.getInstanceServices().describeInstancesInRegion(regionId,
-                instanceId))));
-    }
+   @Test(dependsOnMethods = "testRunInstance")
+   void testRebootInstance() {
+      cloudstackClient.rebootInstancesInRegion(regionId, instanceId);
+   }
 
-    @Test(dependsOnMethods = "testRunInstance")
-    void testRebootInstance() {
-        cloudstackClient.rebootInstancesInRegion(regionId, instanceId);
-    }
+   @Test(dependsOnMethods = "testRunInstance")
+   void testGetInstanceTypeForInstanceInRegion() {
+      cloudstackClient.getInstanceTypeForInstanceInRegion(regionId, instanceId);
+   }
 
-    @Test(dependsOnMethods = "testRunInstance")
-    void testGetInstanceTypeForInstanceInRegion() {
-        cloudstackClient.getInstanceTypeForInstanceInRegion(regionId, instanceId);
-    }
+   @Test(dependsOnMethods = "testRebootInstance")
+   void testStopInstances() {
+      cloudstackClient.stopInstancesInRegion(regionId, false, instanceId);
+   }
 
-    @Test(dependsOnMethods = "testRebootInstance")
-    void testStopInstances() {
-        cloudstackClient.stopInstancesInRegion(regionId, false, instanceId);
-    }
+   @Test(dependsOnMethods = "testStopInstances")
+   void testStartInstances() {
+      cloudstackClient.startInstancesInRegion(regionId, instanceId);
+   }
 
-    @Test(dependsOnMethods = "testStopInstances")
-    void testStartInstances() {
-        cloudstackClient.startInstancesInRegion(regionId, instanceId);
-    }
-
-    @Test(dependsOnMethods = "testStartInstances")
-    void testTerminateInstances() {
-        cloudstackClient.terminateInstancesInRegion(regionId, instanceId);
-    }
+   @Test(dependsOnMethods = "testStartInstances")
+   void testTerminateInstances() {
+      cloudstackClient.terminateInstancesInRegion(regionId, instanceId);
+   }
 }

--- a/labs/cloudstack-ec2/src/test/java/org/jclouds/cloudstack/ec2/services/CloudStackEC2KeyPairClientLiveTest.java
+++ b/labs/cloudstack-ec2/src/test/java/org/jclouds/cloudstack/ec2/services/CloudStackEC2KeyPairClientLiveTest.java
@@ -34,68 +34,66 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
 /**
- * 
  * @author Adrian Cole
  */
 @Test(groups = "live", singleThreaded = true, testName = "CloudStackEC2KeyPairClientLiveTest")
 public class CloudStackEC2KeyPairClientLiveTest extends KeyPairClientLiveTest {
+   private CloudStackEC2Client cloudstackEc2Client;
+   private KeyPairClient cloudstackClient;
+   private String regionId = "AmazonEC2";
 
-    private CloudStackEC2Client cloudstackEc2Client;
-    private KeyPairClient cloudstackClient;
-    private String regionId = "AmazonEC2";
-
-
-    public CloudStackEC2KeyPairClientLiveTest() {
+   public CloudStackEC2KeyPairClientLiveTest() {
       provider = "cloudstack-ec2";
    }
 
-    @Override
-    @BeforeClass(groups = {"integration", "live"})
-    public void setupContext() {
-        initializeContext();
-        cloudstackEc2Client = view.unwrap(CloudStackEC2ApiMetadata.CONTEXT_TOKEN).getApi();
-        cloudstackClient = cloudstackEc2Client.getKeyPairServices();
-    }
+   @Override
+   @BeforeClass(groups = {"integration", "live"})
+   public void setupContext() {
+      initializeContext();
+      cloudstackEc2Client = view.unwrap(CloudStackEC2ApiMetadata.CONTEXT_TOKEN).getApi();
+      cloudstackClient = cloudstackEc2Client.getKeyPairServices();
+   }
 
-    @Test
-    void testDescribeKeyPairs() {
-        SortedSet<KeyPair> allResults = Sets.newTreeSet(cloudstackClient.describeKeyPairsInRegion(regionId));
-        assertNotNull(allResults);
-        if (allResults.size() >= 1) {
-            KeyPair pair = allResults.last();
-            SortedSet<KeyPair> result = Sets.newTreeSet(cloudstackClient.describeKeyPairsInRegion(regionId, pair.getKeyName()));
-            assertNotNull(result);
-            KeyPair compare = result.last();
-            assertEquals(compare, pair);
-        }
-    }
+   @Test
+   void testDescribeKeyPairs() {
+      SortedSet<KeyPair> allResults = Sets.newTreeSet(cloudstackClient.describeKeyPairsInRegion(regionId));
+      assertNotNull(allResults);
+      if (allResults.size() >= 1) {
+         KeyPair pair = allResults.last();
+         SortedSet<KeyPair> result = Sets.newTreeSet(cloudstackClient.describeKeyPairsInRegion(regionId,
+                 pair.getKeyName()));
+         assertNotNull(result);
+         KeyPair compare = result.last();
+         assertEquals(compare, pair);
+      }
+   }
 
-    public static final String PREFIX = System.getProperty("user.name") + "-cloudstack-ec2";
+   public static final String PREFIX = System.getProperty("user.name") + "-cloudstack-ec2";
 
-    @Test
-    void testCreateKeyPair() {
-        String keyName = PREFIX + "1";
-        cleanUpKeyPair(keyName);
+   @Test
+   void testCreateKeyPair() {
+      String keyName = PREFIX + "1";
+      cleanUpKeyPair(keyName);
 
-        KeyPair result = cloudstackClient.createKeyPairInRegion(null, keyName);
-        assertNotNull(result);
-        assertNotNull(result.getKeyMaterial());
-        assertNotNull(result.getSha1OfPrivateKey());
-        assertEquals(result.getKeyName(), keyName);
+      KeyPair result = cloudstackClient.createKeyPairInRegion(null, keyName);
+      assertNotNull(result);
+      assertNotNull(result.getKeyMaterial());
+      assertNotNull(result.getSha1OfPrivateKey());
+      assertEquals(result.getKeyName(), keyName);
 
-        Set<KeyPair> twoResults = Sets.newLinkedHashSet(cloudstackClient.describeKeyPairsInRegion(null, keyName));
-        assertNotNull(twoResults);
-        assertEquals(twoResults.size(), 1);
-        KeyPair listPair = twoResults.iterator().next();
-        assertEquals(listPair.getKeyName(), result.getKeyName());
-        assertEquals(listPair.getSha1OfPrivateKey(), result.getSha1OfPrivateKey());
-        cleanUpKeyPair(keyName);
-    }
+      Set<KeyPair> twoResults = Sets.newLinkedHashSet(cloudstackClient.describeKeyPairsInRegion(null, keyName));
+      assertNotNull(twoResults);
+      assertEquals(twoResults.size(), 1);
+      KeyPair listPair = twoResults.iterator().next();
+      assertEquals(listPair.getKeyName(), result.getKeyName());
+      assertEquals(listPair.getSha1OfPrivateKey(), result.getSha1OfPrivateKey());
+      cleanUpKeyPair(keyName);
+   }
 
-    private void cleanUpKeyPair(String keyName) {
-        try {
-            cloudstackClient.deleteKeyPairInRegion(null, keyName);
-        } catch (Exception e) {
-        }
-    }
+   private void cleanUpKeyPair(String keyName) {
+      try {
+         cloudstackClient.deleteKeyPairInRegion(null, keyName);
+      } catch (Exception e) {
+      }
+   }
 }

--- a/labs/cloudstack-ec2/src/test/java/org/jclouds/cloudstack/ec2/services/CloudStackEC2SecurityGroupClientLiveTest.java
+++ b/labs/cloudstack-ec2/src/test/java/org/jclouds/cloudstack/ec2/services/CloudStackEC2SecurityGroupClientLiveTest.java
@@ -34,53 +34,48 @@ import static org.testng.Assert.assertNotNull;
  */
 @Test(groups = "live", singleThreaded = true, testName = "CloudStackEC2SecurityGroupClientLiveTest")
 public class CloudStackEC2SecurityGroupClientLiveTest extends SecurityGroupClientLiveTest {
-    private String regionId = "AmazonEC2";
+   private String regionId = "AmazonEC2";
 
-    public CloudStackEC2SecurityGroupClientLiveTest() {
-        provider = "cloudstack-ec2";
-    }
+   public CloudStackEC2SecurityGroupClientLiveTest() {
+      provider = "cloudstack-ec2";
+   }
 
-    public static final String PREFIX = System.getProperty("user.name") + "-cloudstack-ec2";
+   public static final String PREFIX = System.getProperty("user.name") + "-cloudstack-ec2";
 
-    @Test
-    void testDescribe() {
+   @Test
+   void testDescribe() {
+      Set<SecurityGroup> allResults = client.describeSecurityGroupsInRegion(regionId);
+      assertNotNull(allResults);
+      if (allResults.size() >= 1) {
+         SecurityGroup group = Iterables.getLast(allResults);
+         Set<SecurityGroup> result = client.describeSecurityGroupsInRegion(regionId, group.getName());
+         assertNotNull(result);
+         SecurityGroup compare = Iterables.getLast(result);
+         assertEquals(compare, group);
+      }
+   }
 
-        Set<SecurityGroup> allResults = client.describeSecurityGroupsInRegion(regionId);
-        assertNotNull(allResults);
-        if (allResults.size() >= 1) {
-            SecurityGroup group = Iterables.getLast(allResults);
-            Set<SecurityGroup> result = client.describeSecurityGroupsInRegion(regionId, group.getName());
-            assertNotNull(result);
-            SecurityGroup compare = Iterables.getLast(result);
-            assertEquals(compare, group);
-        }
-    }
+   @Test
+   void testCreateSecurityGroup() {
+      String groupName = PREFIX + "1";
+      cleanupAndSleep(groupName);
+      try {
+         String groupDescription = PREFIX + "1";
+         client.createSecurityGroupInRegion(null, groupName, groupDescription);
+         verifySecurityGroup(groupName, groupDescription);
+      } finally {
+         client.deleteSecurityGroupInRegion(null, groupName);
+      }
+   }
 
-    @Test
-    void testCreateSecurityGroup() {
-        String groupName = PREFIX + "1";
-
-        cleanupAndSleep(groupName);
-        try {
-            String groupDescription = PREFIX + "1";
-            client.createSecurityGroupInRegion(null, groupName, groupDescription);
-            verifySecurityGroup(groupName, groupDescription);
-        } finally {
-            client.deleteSecurityGroupInRegion(null, groupName);
-        }
-    }
-
-    private void verifySecurityGroup(String groupName, String description) {
-        Set<SecurityGroup> oneResult = client.describeSecurityGroupsInRegion(null);
-        assertNotNull(oneResult);
-        assertEquals(oneResult.size(), 2);
-        Iterator<SecurityGroup> sresult = oneResult.iterator();
-        sresult.next();
-        SecurityGroup listPair = sresult.next();
-        assertEquals(listPair.getName(), groupName);
-        assertEquals(listPair.getDescription(), description);
-    }
-
-
-
+   private void verifySecurityGroup(String groupName, String description) {
+      Set<SecurityGroup> oneResult = client.describeSecurityGroupsInRegion(null);
+      assertNotNull(oneResult);
+      assertEquals(oneResult.size(), 2);
+      Iterator<SecurityGroup> sresult = oneResult.iterator();
+      sresult.next();
+      SecurityGroup listPair = sresult.next();
+      assertEquals(listPair.getName(), groupName);
+      assertEquals(listPair.getDescription(), description);
+   }
 }


### PR DESCRIPTION
This PR contains initial commit changes for CloudStack EC2 Query API . Following changes are made 
1. Parser related changes as new element introduced are causing errors
2. Region Related change as CloudStack doesn't support regions
3. Client Related changes as some API calls takes more time in CloudStack like first instance takes time for creation (increased socket and connection timeout values for this)
