### PR TITLE
Fixed intermittent and changing test failures in NovaErrorHandlerTest.

### DIFF
--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/handlers/NovaErrorHandlerTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/handlers/NovaErrorHandlerTest.java
@@ -45,7 +45,7 @@ import com.google.gson.Gson;
  * 
  * @author Adrian Cole, Steve Loughran
  */
-@Test(groups = { "unit" })
+@Test(groups = "unit", testName = "NovaErrorHandlerTest", singleThreaded = true)
 public class NovaErrorHandlerTest {
    
    private HttpCommand command;


### PR DESCRIPTION
Recently while trying to submit a pull request I was running into intermittent errors in NovaErrorHandlerTest, both locally and with CloudBees. When run from Eclipse it works fine but doing a "mvn clean install" causes the random problems. The root of the problem appears to be the shared state in the test.

If I add "singleThreaded = true" to the test, it runs fine any which way. 
