### PR TITLE
Fixed Cloud Files break

### DIFF
--- a/apis/cloudfiles/src/test/java/org/jclouds/cloudfiles/blobstore/CloudFilesBlobSignerExpectTest.java
+++ b/apis/cloudfiles/src/test/java/org/jclouds/cloudfiles/blobstore/CloudFilesBlobSignerExpectTest.java
@@ -22,6 +22,8 @@ import static org.jclouds.openstack.swift.reference.SwiftHeaders.ACCOUNT_TEMPORA
 
 import java.util.Map;
 
+import javax.ws.rs.core.MediaType;
+
 import org.jclouds.apis.ApiMetadata;
 import org.jclouds.blobstore.internal.BaseBlobSignerExpectTest;
 import org.jclouds.cloudfiles.CloudFilesApiMetadata;
@@ -112,6 +114,7 @@ public class CloudFilesBlobSignerExpectTest extends BaseBlobSignerExpectTest {
 
       HttpRequest temporaryKeyRequest = HttpRequest.builder().method("HEAD")
             .endpoint("https://storage101.lon3.clouddrive.com/v1/MossoCloudFS_83a9d536-2e25-4166-bd3b-a503a934f953/")
+            .addHeader("Accept", MediaType.WILDCARD)
             .addHeader("X-Auth-Token", authToken).build();
 
       HttpResponse temporaryKeyResponse = HttpResponse.builder().statusCode(200)

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/CommonSwiftAsyncClient.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/CommonSwiftAsyncClient.java
@@ -91,8 +91,9 @@ public interface CommonSwiftAsyncClient {
     * @see CommonSwiftClient#getAccountStatistics
     */
    @HEAD
-   @ResponseParser(ParseAccountMetadataResponseFromHeaders.class)
    @Path("/")
+   @Consumes(MediaType.WILDCARD)
+   @ResponseParser(ParseAccountMetadataResponseFromHeaders.class)
    ListenableFuture<AccountMetadata> getAccountStatistics();
 
    /**
@@ -109,9 +110,10 @@ public interface CommonSwiftAsyncClient {
     */
    @Beta
    @HEAD
+   @Path("/{container}")
+   @Consumes(MediaType.WILDCARD)
    @ResponseParser(ParseContainerMetadataFromHeaders.class)
    @ExceptionParser(ReturnNullOnContainerNotFound.class)
-   @Path("/{container}")
    ListenableFuture<ContainerMetadata> getContainerMetadata(@PathParam("container") String container);
 
    /**
@@ -179,6 +181,7 @@ public interface CommonSwiftAsyncClient {
     */
    @HEAD
    @Path("/{container}")
+   @Consumes(MediaType.WILDCARD)
    @ExceptionParser(ReturnFalseOnContainerNotFound.class)
    ListenableFuture<Boolean> containerExists(@PathParam("container") String container);
 
@@ -221,6 +224,7 @@ public interface CommonSwiftAsyncClient {
    @ResponseParser(ParseObjectInfoFromHeaders.class)
    @ExceptionParser(ReturnNullOnKeyNotFound.class)
    @Path("/{container}/{name}")
+   @Consumes(MediaType.WILDCARD)
    ListenableFuture<MutableObjectInfoWithMetadata> getObjectInfo(@PathParam("container") String container,
                                                                  @PathParam("name") String name);
 
@@ -230,6 +234,7 @@ public interface CommonSwiftAsyncClient {
    @HEAD
    @ExceptionParser(ReturnFalseOnKeyNotFound.class)
    @Path("/{container}/{name}")
+   @Consumes(MediaType.WILDCARD)
    ListenableFuture<Boolean> objectExists(@PathParam("container") String container, 
                                           @PathParam("name") String name);
 

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/extensions/TemporaryUrlKeyAsyncApi.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/extensions/TemporaryUrlKeyAsyncApi.java
@@ -28,10 +28,12 @@ import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.ResponseParser;
 import org.jclouds.rest.annotations.SkipEncoding;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.HEAD;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
 
 /**
  * @author Andrei Savu
@@ -47,6 +49,7 @@ public interface TemporaryUrlKeyAsyncApi {
     */
    @HEAD
    @Path("/")
+   @Consumes(MediaType.WILDCARD)
    @ResponseParser(ParseTemporaryUrlKeyFromHeaders.class)
    ListenableFuture<String> getTemporaryUrlKey();
 

--- a/apis/swift/src/test/java/org/jclouds/openstack/swift/SwiftClientExpectTest.java
+++ b/apis/swift/src/test/java/org/jclouds/openstack/swift/SwiftClientExpectTest.java
@@ -21,6 +21,8 @@ package org.jclouds.openstack.swift;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+import javax.ws.rs.core.MediaType;
+
 import org.jclouds.http.HttpRequest;
 import org.jclouds.http.HttpResponse;
 import org.jclouds.http.HttpResponseException;
@@ -43,6 +45,7 @@ public class SwiftClientExpectTest extends BaseSwiftExpectTest<SwiftClient> {
       HttpRequest headContainer = HttpRequest.builder()
             .method("HEAD")
             .endpoint(swiftEndpointWithHostReplaced + "/foo")
+            .addHeader("Accept", MediaType.WILDCARD)
             .addHeader("X-Auth-Token", authToken).build();
 
       HttpResponse headContainerResponse = HttpResponse.builder().statusCode(200).build();
@@ -58,6 +61,7 @@ public class SwiftClientExpectTest extends BaseSwiftExpectTest<SwiftClient> {
       HttpRequest headContainer = HttpRequest.builder()
             .method("HEAD")
             .endpoint(swiftEndpointWithHostReplaced + "/foo")
+            .addHeader("Accept", MediaType.WILDCARD)
             .addHeader("X-Auth-Token", authToken).build();
 
       HttpResponse headContainerResponse = HttpResponse.builder().statusCode(404).build();

--- a/apis/swift/src/test/java/org/jclouds/openstack/swift/blobstore/SwiftBlobSignerExpectTest.java
+++ b/apis/swift/src/test/java/org/jclouds/openstack/swift/blobstore/SwiftBlobSignerExpectTest.java
@@ -22,6 +22,8 @@ import static org.jclouds.openstack.swift.reference.SwiftHeaders.ACCOUNT_TEMPORA
 
 import java.util.Map;
 
+import javax.ws.rs.core.MediaType;
+
 import org.jclouds.apis.ApiMetadata;
 import org.jclouds.blobstore.internal.BaseBlobSignerExpectTest;
 import org.jclouds.http.HttpRequest;
@@ -60,7 +62,8 @@ public class SwiftBlobSignerExpectTest extends BaseBlobSignerExpectTest {
    @Override
    protected HttpRequest getBlobWithTime() {
       return HttpRequest.builder().method("GET")
-            .endpoint("http://storage/container/name?temp_url_sig=2abd47f6b1c159fe9a45c873aaade8eeeb36a2e1&temp_url_expires=123456792").build();
+            .endpoint("http://storage/container/name?temp_url_sig=2abd47f6b1c159fe9a45c873aaade8eeeb36a2e1&temp_url_expires=123456792")
+            .build();
    }
 
    @Override
@@ -81,7 +84,8 @@ public class SwiftBlobSignerExpectTest extends BaseBlobSignerExpectTest {
    @Override
    protected HttpRequest putBlobWithTime() {
       return HttpRequest.builder().method("PUT")
-            .endpoint("http://storage/container/name?temp_url_sig=e894c60fa1284cc575cf22d7786bab07b8c33610&temp_url_expires=123456792").build();
+            .endpoint("http://storage/container/name?temp_url_sig=e894c60fa1284cc575cf22d7786bab07b8c33610&temp_url_expires=123456792")
+            .build();
    }
 
    @Override
@@ -107,6 +111,7 @@ public class SwiftBlobSignerExpectTest extends BaseBlobSignerExpectTest {
 
       HttpRequest temporaryKeyRequest = HttpRequest.builder().method("HEAD")
             .endpoint("http://storage/")
+            .addHeader("Accept", MediaType.WILDCARD)
             .addHeader("X-Auth-Token", "testtoken").build();
 
       HttpResponse temporaryKeyResponse = HttpResponse.builder().statusCode(200)

--- a/apis/swift/src/test/java/org/jclouds/openstack/swift/blobstore/SwiftKeystoneBlobSignerExpectTest.java
+++ b/apis/swift/src/test/java/org/jclouds/openstack/swift/blobstore/SwiftKeystoneBlobSignerExpectTest.java
@@ -22,6 +22,8 @@ import static org.jclouds.openstack.swift.reference.SwiftHeaders.ACCOUNT_TEMPORA
 
 import java.util.Map;
 
+import javax.ws.rs.core.MediaType;
+
 import org.jclouds.apis.ApiMetadata;
 import org.jclouds.blobstore.internal.BaseBlobSignerExpectTest;
 import org.jclouds.http.HttpRequest;
@@ -110,6 +112,7 @@ public class SwiftKeystoneBlobSignerExpectTest extends BaseBlobSignerExpectTest 
             .builder()
             .method("HEAD")
             .endpoint("https://objects.jclouds.org/v1.0/40806637803162/")
+            .addHeader("Accept", MediaType.WILDCARD)
             .addHeader("X-Auth-Token", "Auth_4f173437e4b013bee56d1007").build();
 
       HttpResponse temporaryKeyResponse = HttpResponse.builder().statusCode(200)

--- a/apis/swift/src/test/java/org/jclouds/openstack/swift/keystone/AccessKeyAndSecretKeyAndTenantIdAuthenticationExpectTest.java
+++ b/apis/swift/src/test/java/org/jclouds/openstack/swift/keystone/AccessKeyAndSecretKeyAndTenantIdAuthenticationExpectTest.java
@@ -22,6 +22,8 @@ import static org.testng.Assert.assertEquals;
 
 import java.util.Properties;
 
+import javax.ws.rs.core.MediaType;
+
 import org.jclouds.http.HttpRequest;
 import org.jclouds.http.HttpResponse;
 import org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties;
@@ -56,6 +58,7 @@ public class AccessKeyAndSecretKeyAndTenantIdAuthenticationExpectTest extends Ba
       HttpRequest containerExists = HttpRequest.builder()
                                                .method("HEAD")
                                                .endpoint("https://objects.jclouds.org/v1.0/40806637803162/container")
+                                               .addHeader("Accept", MediaType.WILDCARD)
                                                .addHeader("X-Auth-Token", authToken).build();
 
       HttpResponse containerExistsResponse = HttpResponse.builder().statusCode(200).build();

--- a/apis/swift/src/test/java/org/jclouds/openstack/swift/keystone/AccessKeyAndSecretKeyAndTenantNamePropertyAuthenticationExpectTest.java
+++ b/apis/swift/src/test/java/org/jclouds/openstack/swift/keystone/AccessKeyAndSecretKeyAndTenantNamePropertyAuthenticationExpectTest.java
@@ -22,6 +22,8 @@ import static org.testng.Assert.assertEquals;
 
 import java.util.Properties;
 
+import javax.ws.rs.core.MediaType;
+
 import org.jclouds.http.HttpRequest;
 import org.jclouds.http.HttpResponse;
 import org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties;
@@ -56,6 +58,7 @@ public class AccessKeyAndSecretKeyAndTenantNamePropertyAuthenticationExpectTest 
       HttpRequest containerExists = HttpRequest.builder()
                                                .method("HEAD")
                                                .endpoint("https://objects.jclouds.org/v1.0/40806637803162/container")
+                                               .addHeader("Accept", MediaType.WILDCARD)
                                                .addHeader("X-Auth-Token", authToken).build();
 
       HttpResponse containerExistsResponse = HttpResponse.builder().statusCode(200).build();

--- a/apis/swift/src/test/java/org/jclouds/openstack/swift/keystone/AccessKeyAndSecretKeyAuthenticationExpectTest.java
+++ b/apis/swift/src/test/java/org/jclouds/openstack/swift/keystone/AccessKeyAndSecretKeyAuthenticationExpectTest.java
@@ -22,6 +22,8 @@ import static org.testng.Assert.assertEquals;
 
 import java.util.Properties;
 
+import javax.ws.rs.core.MediaType;
+
 import org.jclouds.http.HttpRequest;
 import org.jclouds.http.HttpResponse;
 import org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties;
@@ -51,6 +53,7 @@ public class AccessKeyAndSecretKeyAuthenticationExpectTest extends BaseSwiftKeys
       HttpRequest containerExists = HttpRequest.builder()
                                                .method("HEAD")
                                                .endpoint("https://objects.jclouds.org/v1.0/40806637803162/container")
+                                               .addHeader("Accept", MediaType.WILDCARD)
                                                .addHeader("X-Auth-Token", authToken).build();
 
       HttpResponse containerExistsResponse = HttpResponse.builder().statusCode(200).build();

--- a/apis/swift/src/test/java/org/jclouds/openstack/swift/keystone/PasswordAuthenticationExpectTest.java
+++ b/apis/swift/src/test/java/org/jclouds/openstack/swift/keystone/PasswordAuthenticationExpectTest.java
@@ -22,6 +22,8 @@ import static org.testng.Assert.assertEquals;
 
 import java.util.Properties;
 
+import javax.ws.rs.core.MediaType;
+
 import org.jclouds.http.HttpRequest;
 import org.jclouds.http.HttpResponse;
 import org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties;
@@ -54,6 +56,7 @@ public class PasswordAuthenticationExpectTest extends BaseSwiftKeystoneExpectTes
       HttpRequest containerExists = HttpRequest.builder()
                                                .method("HEAD")
                                                .endpoint("https://objects.jclouds.org/v1.0/40806637803162/container")
+                                               .addHeader("Accept", MediaType.WILDCARD)
                                                .addHeader("X-Auth-Token", authToken).build();
 
       HttpResponse containerExistsResponse = HttpResponse.builder().statusCode(200).build();

--- a/apis/swift/src/test/java/org/jclouds/openstack/swift/keystone/PasswordAuthenticationWithTenantNameExpectTest.java
+++ b/apis/swift/src/test/java/org/jclouds/openstack/swift/keystone/PasswordAuthenticationWithTenantNameExpectTest.java
@@ -22,6 +22,8 @@ import static org.testng.Assert.assertEquals;
 
 import java.util.Properties;
 
+import javax.ws.rs.core.MediaType;
+
 import org.jclouds.http.HttpRequest;
 import org.jclouds.http.HttpResponse;
 import org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties;
@@ -51,6 +53,7 @@ public class PasswordAuthenticationWithTenantNameExpectTest extends BaseSwiftKey
       HttpRequest containerExists = HttpRequest.builder()
                                                .method("HEAD")
                                                .endpoint("https://objects.jclouds.org/v1.0/40806637803162/container")
+                                               .addHeader("Accept", MediaType.WILDCARD)
                                                .addHeader("X-Auth-Token", authToken).build();
 
       HttpResponse containerExistsResponse = HttpResponse.builder().statusCode(200).build();

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobSignerLiveTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobSignerLiveTest.java
@@ -22,15 +22,15 @@ import static org.jclouds.blobstore.options.GetOptions.Builder.range;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
 import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.http.HttpRequest;
 import org.jclouds.rest.AuthorizationException;
 import org.jclouds.util.Strings2;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
-
-import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Tests integrated functionality of all signature commands.
@@ -89,7 +89,7 @@ public class BaseBlobSignerLiveTest extends BaseBlobStoreIntegrationTest {
          view.getBlobStore().putBlob(container, blob);
          assertConsistencyAwareContainerSize(container, 1);
          HttpRequest request = view.getSigner().signGetBlob(container, name, 3 /* seconds */);
-
+         
          assertEquals(request.getFilters().size(), 0);
          assertEquals(Strings2.toString(view.utils().http().invoke(request).getPayload()), text);
 


### PR DESCRIPTION
Fixed issue where an Accept header is required when doing HEAD requests to Cloud Files.

Live tests can be run now. There are still a handful of preexisting timing and putting fails but at least the majority are running.
