### PR TITLE
Added network service type in Abiquo

### DIFF
--- a/labs/abiquo/pom.xml
+++ b/labs/abiquo/pom.xml
@@ -15,7 +15,8 @@
     <packaging>bundle</packaging>
     
     <properties>
-        <abiquo.version>2.1.1</abiquo.version>
+        <abiquomodel.version>2.2.0</abiquomodel.version>
+        <abiquoam.version>2.1.2</abiquoam.version>
         <test.abiquo.endpoint>http://localhost/api</test.abiquo.endpoint>
         <test.abiquo.identity>FIXME</test.abiquo.identity>
         <test.abiquo.credential>FIXME</test.abiquo.credential>
@@ -49,7 +50,7 @@
         <dependency>
             <groupId>com.abiquo</groupId>
             <artifactId>api-model-transport</artifactId>
-            <version>${abiquo.version}</version>
+            <version>${abiquomodel.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.ws.rs</groupId>
@@ -64,7 +65,7 @@
         <dependency>
             <groupId>com.abiquo</groupId>
             <artifactId>am-model</artifactId>
-            <version>${abiquo.version}</version>
+            <version>${abiquoam.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.ws.rs</groupId>

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/AbiquoApiMetadata.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/AbiquoApiMetadata.java
@@ -47,6 +47,8 @@ public class AbiquoApiMetadata extends BaseRestApiMetadata {
 
    /** The token describing the rest api context. */
    public static final TypeToken<RestContext<AbiquoApi, AbiquoAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<AbiquoApi, AbiquoAsyncApi>>() {
+
+      private static final long serialVersionUID = -2098594161943130770L;
    };
 
    public AbiquoApiMetadata() {

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/DomainWithTasksWrapper.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/DomainWithTasksWrapper.java
@@ -30,10 +30,11 @@ import org.jclouds.abiquo.domain.task.AsyncTask;
 import org.jclouds.rest.RestContext;
 
 import com.abiquo.model.transport.SingleResourceTransportDto;
+import com.abiquo.server.core.task.TaskDto;
 import com.abiquo.server.core.task.TasksDto;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import com.google.common.primitives.Longs;
 
@@ -65,7 +66,7 @@ public abstract class DomainWithTasksWrapper<T extends SingleResourceTransportDt
    }
 
    public List<AsyncTask> listTasks(final Predicate<AsyncTask> filter) {
-      return Lists.newLinkedList(filter(listTasks(), filter));
+      return ImmutableList.copyOf(filter(listTasks(), filter));
    }
 
    public AsyncTask findTask(final Predicate<AsyncTask> filter) {

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/DomainWrapper.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/DomainWrapper.java
@@ -20,10 +20,12 @@
 package org.jclouds.abiquo.domain;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.transform;
 
 import java.lang.reflect.Constructor;
 import java.net.URI;
+import java.util.Collection;
 import java.util.List;
 
 import org.jclouds.abiquo.AbiquoApi;
@@ -40,6 +42,7 @@ import com.abiquo.model.transport.SingleResourceTransportDto;
 import com.abiquo.model.transport.WrapperDto;
 import com.abiquo.server.core.task.TaskDto;
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 /**
@@ -119,7 +122,7 @@ public abstract class DomainWrapper<T extends SingleResourceTransportDto> {
          return null;
       }
 
-      return Lists.newLinkedList(transform(targets, new Function<T, W>() {
+      return ImmutableList.copyOf(transform(targets, new Function<T, W>() {
          @Override
          public W apply(final T input) {
             return wrap(context, wrapperClass, input);
@@ -132,7 +135,7 @@ public abstract class DomainWrapper<T extends SingleResourceTransportDto> {
     */
    public static <T extends SingleResourceTransportDto, W extends DomainWrapper<T>> List<T> unwrap(
          final Iterable<W> targets) {
-      return Lists.newLinkedList(transform(targets, new Function<W, T>() {
+      return ImmutableList.copyOf(transform(targets, new Function<W, T>() {
          @Override
          public T apply(final W input) {
             return input.unwrap();
@@ -165,11 +168,12 @@ public abstract class DomainWrapper<T extends SingleResourceTransportDto> {
     */
    public static <T extends SingleResourceTransportDto> Iterable<T> join(
          final Iterable<? extends WrapperDto<T>> collection) {
-      List<T> dtos = Lists.newLinkedList();
-      for (WrapperDto<T> wrapper : collection) {
-         dtos.addAll(wrapper.getCollection());
-      }
-      return dtos;
+      return concat(transform(collection, new Function<WrapperDto<T>, Collection<T>>() {
+         @Override
+         public Collection<T> apply(WrapperDto<T> input) {
+            return input.getCollection();
+         }
+      }));
    }
 
    /**

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/cloud/Conversion.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/cloud/Conversion.java
@@ -23,8 +23,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Date;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWithTasksWrapper;
 import org.jclouds.abiquo.domain.task.AsyncTask;
 import org.jclouds.abiquo.reference.ValidationErrors;

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/cloud/VirtualAppliance.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/cloud/VirtualAppliance.java
@@ -44,8 +44,8 @@ import com.abiquo.server.core.cloud.VirtualMachineWithNodeExtendedDto;
 import com.abiquo.server.core.cloud.VirtualMachinesWithNodeExtendedDto;
 import com.abiquo.server.core.enterprise.EnterpriseDto;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 
 /**
  * Represents a virtual appliance.
@@ -178,7 +178,7 @@ public class VirtualAppliance extends DomainWrapper<VirtualApplianceDto> {
     *         given filter.
     */
    public List<VirtualMachine> listVirtualMachines(final Predicate<VirtualMachine> filter) {
-      return Lists.newLinkedList(filter(listVirtualMachines(), filter));
+      return ImmutableList.copyOf(filter(listVirtualMachines(), filter));
    }
 
    /**

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/cloud/VirtualDatacenter.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/cloud/VirtualDatacenter.java
@@ -60,8 +60,8 @@ import com.abiquo.server.core.infrastructure.storage.TiersDto;
 import com.abiquo.server.core.infrastructure.storage.VolumeManagementDto;
 import com.abiquo.server.core.infrastructure.storage.VolumesManagementDto;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 
 /**
  * Represents a virtual datacenter.
@@ -194,7 +194,7 @@ public class VirtualDatacenter extends DomainWithLimitsWrapper<VirtualDatacenter
     *      # VirtualApplianceResource-RetrievethelistofVirtualAppliances</a>
     */
    public List<VirtualAppliance> listVirtualAppliances(final Predicate<VirtualAppliance> filter) {
-      return Lists.newLinkedList(filter(listVirtualAppliances(), filter));
+      return ImmutableList.copyOf(filter(listVirtualAppliances(), filter));
    }
 
    /**
@@ -256,7 +256,7 @@ public class VirtualDatacenter extends DomainWithLimitsWrapper<VirtualDatacenter
     *      Resource# VirtualDatacenterResource-Retrieveenabledtiers</a>
     */
    public List<Tier> listStorageTiers(final Predicate<Tier> filter) {
-      return Lists.newLinkedList(filter(listStorageTiers(), filter));
+      return ImmutableList.copyOf(filter(listStorageTiers(), filter));
    }
 
    /**
@@ -317,7 +317,7 @@ public class VirtualDatacenter extends DomainWithLimitsWrapper<VirtualDatacenter
     *      VolumeResource- Retrievethelistofvolumes</a>
     */
    public List<Volume> listVolumes(final Predicate<Volume> filter) {
-      return Lists.newLinkedList(filter(listVolumes(), filter));
+      return ImmutableList.copyOf(filter(listVolumes(), filter));
    }
 
    /**
@@ -354,7 +354,7 @@ public class VirtualDatacenter extends DomainWithLimitsWrapper<VirtualDatacenter
    }
 
    public List<HardDisk> listHardDisks(final Predicate<HardDisk> filter) {
-      return Lists.newLinkedList(filter(listHardDisks(), filter));
+      return ImmutableList.copyOf(filter(listHardDisks(), filter));
    }
 
    public HardDisk findHardDisk(final Predicate<HardDisk> filter) {
@@ -392,7 +392,7 @@ public class VirtualDatacenter extends DomainWithLimitsWrapper<VirtualDatacenter
    }
 
    public List<PrivateNetwork> listPrivateNetworks(final Predicate<Network<PrivateIp>> filter) {
-      return Lists.newLinkedList(filter(listPrivateNetworks(), filter));
+      return ImmutableList.copyOf(filter(listPrivateNetworks(), filter));
    }
 
    public PrivateNetwork findPrivateNetwork(final Predicate<Network<PrivateIp>> filter) {
@@ -420,7 +420,7 @@ public class VirtualDatacenter extends DomainWithLimitsWrapper<VirtualDatacenter
    }
 
    public List<VirtualMachineTemplate> listAvailableTemplates(final Predicate<VirtualMachineTemplate> filter) {
-      return Lists.newLinkedList(filter(listAvailableTemplates(), filter));
+      return ImmutableList.copyOf(filter(listAvailableTemplates(), filter));
    }
 
    public VirtualMachineTemplate findAvailableTemplate(final Predicate<VirtualMachineTemplate> filter) {
@@ -463,7 +463,7 @@ public class VirtualDatacenter extends DomainWithLimitsWrapper<VirtualDatacenter
    }
 
    public List<PublicIp> listAvailablePublicIps(final Predicate<PublicIp> filter) {
-      return Lists.newLinkedList(filter(listAvailablePublicIps(), filter));
+      return ImmutableList.copyOf(filter(listAvailablePublicIps(), filter));
    }
 
    public PublicIp findAvailablePublicIp(final Predicate<PublicIp> filter) {
@@ -487,7 +487,7 @@ public class VirtualDatacenter extends DomainWithLimitsWrapper<VirtualDatacenter
    }
 
    public List<PublicIp> listPurchasedPublicIps(final Predicate<PublicIp> filter) {
-      return Lists.newLinkedList(filter(listPurchasedPublicIps(), filter));
+      return ImmutableList.copyOf(filter(listPurchasedPublicIps(), filter));
    }
 
    public PublicIp findPurchasedPublicIp(final Predicate<PublicIp> filter) {

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/cloud/VirtualMachine.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/cloud/VirtualMachine.java
@@ -67,6 +67,7 @@ import com.abiquo.server.core.infrastructure.storage.VolumesManagementDto;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.inject.TypeLiteral;
@@ -304,7 +305,7 @@ public class VirtualMachine extends DomainWithTasksWrapper<VirtualMachineWithNod
    }
 
    public List<HardDisk> listAttachedHardDisks(final Predicate<HardDisk> filter) {
-      return Lists.newLinkedList(filter(listAttachedHardDisks(), filter));
+      return ImmutableList.copyOf(filter(listAttachedHardDisks(), filter));
    }
 
    public HardDisk findAttachedHardDisk(final Predicate<HardDisk> filter) {
@@ -318,7 +319,7 @@ public class VirtualMachine extends DomainWithTasksWrapper<VirtualMachineWithNod
    }
 
    public List<Volume> listAttachedVolumes(final Predicate<Volume> filter) {
-      return Lists.newLinkedList(filter(listAttachedVolumes(), filter));
+      return ImmutableList.copyOf(filter(listAttachedVolumes(), filter));
    }
 
    public Volume findAttachedVolume(final Predicate<Volume> filter) {
@@ -328,11 +329,11 @@ public class VirtualMachine extends DomainWithTasksWrapper<VirtualMachineWithNod
    public List<Ip<?, ?>> listAttachedNics() {
       // The strategy will refresh the vm. There is no need to do it here
       ListAttachedNics strategy = context.getUtils().getInjector().getInstance(ListAttachedNics.class);
-      return Lists.newLinkedList(strategy.execute(this));
+      return ImmutableList.copyOf(strategy.execute(this));
    }
 
    public List<Ip<?, ?>> listAttachedNics(final Predicate<Ip<?, ?>> filter) {
-      return Lists.newLinkedList(filter(listAttachedNics(), filter));
+      return ImmutableList.copyOf(filter(listAttachedNics(), filter));
    }
 
    public Ip<?, ?> findAttachedNic(final Predicate<Ip<?, ?>> filter) {
@@ -392,7 +393,7 @@ public class VirtualMachine extends DomainWithTasksWrapper<VirtualMachineWithNod
    }
 
    public AsyncTask attachHardDisks(final HardDisk... hardDisks) {
-      List<HardDisk> expected = listAttachedHardDisks();
+      List<HardDisk> expected = Lists.newArrayList(listAttachedHardDisks());
       expected.addAll(Arrays.asList(hardDisks));
 
       HardDisk[] disks = new HardDisk[expected.size()];
@@ -405,7 +406,7 @@ public class VirtualMachine extends DomainWithTasksWrapper<VirtualMachineWithNod
    }
 
    public AsyncTask detachHardDisks(final HardDisk... hardDisks) {
-      List<HardDisk> expected = listAttachedHardDisks();
+      List<HardDisk> expected = Lists.newArrayList(listAttachedHardDisks());
       Iterables.removeIf(expected, hardDiskIdIn(hardDisks));
 
       HardDisk[] disks = new HardDisk[expected.size()];
@@ -419,7 +420,7 @@ public class VirtualMachine extends DomainWithTasksWrapper<VirtualMachineWithNod
    }
 
    public AsyncTask attachVolumes(final Volume... volumes) {
-      List<Volume> expected = listAttachedVolumes();
+      List<Volume> expected = Lists.newArrayList(listAttachedVolumes());
       expected.addAll(Arrays.asList(volumes));
 
       Volume[] vols = new Volume[expected.size()];
@@ -432,7 +433,7 @@ public class VirtualMachine extends DomainWithTasksWrapper<VirtualMachineWithNod
    }
 
    public AsyncTask detachVolumes(final Volume... volumes) {
-      List<Volume> expected = listAttachedVolumes();
+      List<Volume> expected = Lists.newArrayList(listAttachedVolumes());
       Iterables.removeIf(expected, volumeIdIn(volumes));
 
       Volume[] vols = new Volume[expected.size()];

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/cloud/VirtualMachineTemplate.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/cloud/VirtualMachineTemplate.java
@@ -56,8 +56,8 @@ import com.abiquo.server.core.appslibrary.VirtualMachineTemplatePersistentDto;
 import com.abiquo.server.core.infrastructure.storage.VolumeManagementDto;
 import com.abiquo.server.core.pricing.CostCodeDto;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.inject.TypeLiteral;
 
 /**
@@ -239,7 +239,7 @@ public class VirtualMachineTemplate extends DomainWrapper<VirtualMachineTemplate
     *         matching the given filter.
     */
    public List<Conversion> listConversions(final Predicate<Conversion> filter) {
-      return Lists.newLinkedList(filter(listConversions(), filter));
+      return ImmutableList.copyOf(filter(listConversions(), filter));
    }
 
    /**

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/cloud/Volume.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/cloud/Volume.java
@@ -21,8 +21,8 @@ package org.jclouds.abiquo.domain.cloud;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWrapper;
 import org.jclouds.abiquo.domain.infrastructure.Tier;
 import org.jclouds.abiquo.domain.task.AsyncTask;

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/enterprise/Enterprise.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/enterprise/Enterprise.java
@@ -65,18 +65,19 @@ import com.abiquo.server.core.infrastructure.DatacentersDto;
 import com.abiquo.server.core.infrastructure.MachinesDto;
 import com.abiquo.server.core.infrastructure.network.VLANNetworksDto;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.inject.TypeLiteral;
 
 /**
- * Adds high level functionality to {@link EnterpriseDto}.
+ * Represents a tenant.
+ * <p>
+ * Each tenant has a set of available locations, and a set of compute,
+ * networking and storage resources that can be consumed in the assigned
+ * locations.
  * 
  * @author Ignasi Barrera
  * @author Francesc Montserrat
- * @see API: <a
- *      href="http://community.abiquo.com/display/ABI20/EnterpriseResource">
- *      http://community.abiquo.com/display/ABI20/EnterpriseResource</a>
  */
 public class Enterprise extends DomainWithLimitsWrapper<EnterpriseDto> {
    /** The default value for the reservation restricted flag. */
@@ -159,7 +160,7 @@ public class Enterprise extends DomainWithLimitsWrapper<EnterpriseDto> {
     * @return Filtered list of virtual datacenters in this enterprise.
     */
    public List<VirtualDatacenter> listVirtualDatacenters(final Predicate<VirtualDatacenter> filter) {
-      return Lists.newLinkedList(filter(listVirtualDatacenters(), filter));
+      return ImmutableList.copyOf(filter(listVirtualDatacenters(), filter));
    }
 
    /**
@@ -209,7 +210,7 @@ public class Enterprise extends DomainWithLimitsWrapper<EnterpriseDto> {
     * @return Filtered list of template definition lists of the enterprise.
     */
    public List<TemplateDefinitionList> listTemplateDefinitionLists(final Predicate<TemplateDefinitionList> filter) {
-      return Lists.newLinkedList(filter(listTemplateDefinitionLists(), filter));
+      return ImmutableList.copyOf(filter(listTemplateDefinitionLists(), filter));
    }
 
    /**
@@ -275,7 +276,7 @@ public class Enterprise extends DomainWithLimitsWrapper<EnterpriseDto> {
     * @return Filtered list of datacenter limits by enterprise.
     */
    public List<Limits> listLimits(final Predicate<Limits> filter) {
-      return Lists.newLinkedList(filter(listLimits(), filter));
+      return ImmutableList.copyOf(filter(listLimits(), filter));
    }
 
    /**
@@ -338,7 +339,7 @@ public class Enterprise extends DomainWithLimitsWrapper<EnterpriseDto> {
     * @return Filtered list of users of this enterprise.
     */
    public List<User> listUsers(final Predicate<User> filter) {
-      return Lists.newLinkedList(filter(listUsers(), filter));
+      return ImmutableList.copyOf(filter(listUsers(), filter));
    }
 
    /**
@@ -394,7 +395,7 @@ public class Enterprise extends DomainWithLimitsWrapper<EnterpriseDto> {
     * @return Filtered list of roles by this enterprise.
     */
    public List<Role> listRoles(final Predicate<Role> filter) {
-      return Lists.newLinkedList(filter(listRoles(), filter));
+      return ImmutableList.copyOf(filter(listRoles(), filter));
    }
 
    /**
@@ -418,7 +419,7 @@ public class Enterprise extends DomainWithLimitsWrapper<EnterpriseDto> {
 
    public List<VirtualMachineTemplate> listTemplatesInRepository(final Datacenter datacenter,
          final Predicate<VirtualMachineTemplate> filter) {
-      return Lists.newLinkedList(filter(listTemplatesInRepository(datacenter), filter));
+      return ImmutableList.copyOf(filter(listTemplatesInRepository(datacenter), filter));
    }
 
    public VirtualMachineTemplate findTemplateInRepository(final Datacenter datacenter,
@@ -435,13 +436,13 @@ public class Enterprise extends DomainWithLimitsWrapper<EnterpriseDto> {
    public List<VirtualMachineTemplate> listTemplates() {
       ListVirtualMachineTemplates strategy = context.getUtils().getInjector()
             .getInstance(ListVirtualMachineTemplates.class);
-      return Lists.newLinkedList(strategy.execute(this));
+      return ImmutableList.copyOf(strategy.execute(this));
    }
 
    public List<VirtualMachineTemplate> listTemplates(final Predicate<VirtualMachineTemplate> filter) {
       ListVirtualMachineTemplates strategy = context.getUtils().getInjector()
             .getInstance(ListVirtualMachineTemplates.class);
-      return Lists.newLinkedList(strategy.execute(this, filter));
+      return ImmutableList.copyOf(strategy.execute(this, filter));
    }
 
    public VirtualMachineTemplate findTemplate(final Predicate<VirtualMachineTemplate> filter) {
@@ -456,7 +457,7 @@ public class Enterprise extends DomainWithLimitsWrapper<EnterpriseDto> {
    }
 
    public List<Datacenter> listAllowedDatacenters(final Predicate<Datacenter> filter) {
-      return Lists.newLinkedList(filter(listAllowedDatacenters(), filter));
+      return ImmutableList.copyOf(filter(listAllowedDatacenters(), filter));
    }
 
    public Datacenter findAllowedDatacenter(final Predicate<Datacenter> filter) {
@@ -485,7 +486,7 @@ public class Enterprise extends DomainWithLimitsWrapper<EnterpriseDto> {
    @EnterpriseEdition
    public List<ExternalNetwork> listExternalNetworks(final Datacenter datacenter,
          final Predicate<Network<ExternalIp>> filter) {
-      return Lists.newLinkedList(filter(listExternalNetworks(datacenter), filter));
+      return ImmutableList.copyOf(filter(listExternalNetworks(datacenter), filter));
    }
 
    @EnterpriseEdition
@@ -511,7 +512,7 @@ public class Enterprise extends DomainWithLimitsWrapper<EnterpriseDto> {
    @EnterpriseEdition
    public List<UnmanagedNetwork> listUnmanagedNetworks(final Datacenter datacenter,
          final Predicate<Network<UnmanagedIp>> filter) {
-      return Lists.newLinkedList(filter(listUnmanagedNetworks(datacenter), filter));
+      return ImmutableList.copyOf(filter(listUnmanagedNetworks(datacenter), filter));
    }
 
    @EnterpriseEdition
@@ -548,7 +549,7 @@ public class Enterprise extends DomainWithLimitsWrapper<EnterpriseDto> {
     * @return Filtered list of virtual appliances by this enterprise.
     */
    public List<VirtualAppliance> listVirtualAppliances(final Predicate<VirtualAppliance> filter) {
-      return Lists.newLinkedList(filter(listVirtualAppliances(), filter));
+      return ImmutableList.copyOf(filter(listVirtualAppliances(), filter));
    }
 
    /**
@@ -595,7 +596,7 @@ public class Enterprise extends DomainWithLimitsWrapper<EnterpriseDto> {
     * @return Filtered list of virtual machines by this enterprise.
     */
    public List<VirtualMachine> listVirtualMachines(final Predicate<VirtualMachine> filter) {
-      return Lists.newLinkedList(filter(listVirtualMachines(), filter));
+      return ImmutableList.copyOf(filter(listVirtualMachines(), filter));
    }
 
    /**
@@ -621,7 +622,7 @@ public class Enterprise extends DomainWithLimitsWrapper<EnterpriseDto> {
    }
 
    public List<VirtualMachine> listReservedMachines(final Predicate<VirtualMachine> filter) {
-      return Lists.newLinkedList(filter(listVirtualMachines(), filter));
+      return ImmutableList.copyOf(filter(listVirtualMachines(), filter));
    }
 
    public VirtualMachine findReservedMachine(final Predicate<VirtualMachine> filter) {

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/enterprise/EnterpriseProperties.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/enterprise/EnterpriseProperties.java
@@ -21,8 +21,8 @@ package org.jclouds.abiquo.domain.enterprise;
 
 import java.util.Map;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWrapper;
 import org.jclouds.abiquo.reference.annotations.EnterpriseEdition;
 import org.jclouds.abiquo.reference.rest.ParentLinkName;

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/enterprise/Limits.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/enterprise/Limits.java
@@ -19,8 +19,8 @@
 
 package org.jclouds.abiquo.domain.enterprise;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWithLimitsWrapper;
 import org.jclouds.abiquo.domain.builder.LimitsBuilder;
 import org.jclouds.rest.RestContext;

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/enterprise/Role.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/enterprise/Role.java
@@ -24,8 +24,8 @@ import static com.google.common.collect.Iterables.filter;
 
 import java.util.List;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWrapper;
 import org.jclouds.abiquo.domain.config.Privilege;
 import org.jclouds.abiquo.reference.ValidationErrors;
@@ -36,8 +36,8 @@ import com.abiquo.model.rest.RESTLink;
 import com.abiquo.server.core.enterprise.PrivilegesDto;
 import com.abiquo.server.core.enterprise.RoleDto;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 
 /**
  * Adds high level functionality to {@link RoleDto}.
@@ -144,7 +144,7 @@ public class Role extends DomainWrapper<RoleDto> {
    }
 
    public List<Privilege> listPrivileges(final Predicate<Privilege> filter) {
-      return Lists.newLinkedList(filter(listPrivileges(), filter));
+      return ImmutableList.copyOf(filter(listPrivileges(), filter));
    }
 
    public Privilege findPrivileges(final Predicate<Privilege> filter) {

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/enterprise/TemplateDefinitionList.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/enterprise/TemplateDefinitionList.java
@@ -23,8 +23,8 @@ import static com.google.common.collect.Iterables.filter;
 
 import java.util.List;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWrapper;
 import org.jclouds.abiquo.domain.infrastructure.Datacenter;
 import org.jclouds.rest.RestContext;
@@ -32,7 +32,7 @@ import org.jclouds.rest.RestContext;
 import com.abiquo.am.model.TemplatesStateDto;
 import com.abiquo.server.core.appslibrary.TemplateDefinitionListDto;
 import com.google.common.base.Predicate;
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Adds high level functionality to {@link TemplateDefinitionListDto}. A
@@ -140,7 +140,7 @@ public class TemplateDefinitionList extends DomainWrapper<TemplateDefinitionList
     *      Retrievealistofthestatusofalltemplatestatuslist</a>
     */
    public List<TemplateState> listStatus(final Predicate<TemplateState> filter, final Datacenter datacenter) {
-      return Lists.newLinkedList(filter(listStatus(datacenter), filter));
+      return ImmutableList.copyOf(filter(listStatus(datacenter), filter));
    }
 
    // Builder

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/enterprise/TemplateState.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/enterprise/TemplateState.java
@@ -19,8 +19,8 @@
 
 package org.jclouds.abiquo.domain.enterprise;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWrapper;
 import org.jclouds.rest.RestContext;
 

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/enterprise/User.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/enterprise/User.java
@@ -25,8 +25,8 @@ import static com.google.common.collect.Iterables.filter;
 import java.util.List;
 import java.util.StringTokenizer;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWrapper;
 import org.jclouds.abiquo.domain.cloud.VirtualDatacenter;
 import org.jclouds.abiquo.domain.cloud.VirtualMachine;
@@ -41,6 +41,7 @@ import com.abiquo.server.core.enterprise.RoleDto;
 import com.abiquo.server.core.enterprise.UserDto;
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
@@ -128,11 +129,11 @@ public class User extends DomainWrapper<UserDto> {
 
       ListVirtualDatacenters listVirtualDatacenters = context.getUtils().getInjector()
             .getInstance(ListVirtualDatacenters.class);
-      return Lists.newArrayList(listVirtualDatacenters.execute(ids));
+      return ImmutableList.copyOf(listVirtualDatacenters.execute(ids));
    }
 
    public List<VirtualDatacenter> listPermittedVirtualDatacenters(final Predicate<VirtualDatacenter> filter) {
-      return Lists.newLinkedList(filter(listPermittedVirtualDatacenters(), filter));
+      return ImmutableList.copyOf(filter(listPermittedVirtualDatacenters(), filter));
    }
 
    public VirtualDatacenter findPermittedVirtualDatacenter(final Predicate<VirtualDatacenter> filter) {
@@ -195,7 +196,7 @@ public class User extends DomainWrapper<UserDto> {
    }
 
    public List<VirtualMachine> listMachines(final Predicate<VirtualMachine> filter) {
-      return Lists.newLinkedList(filter(listMachines(), filter));
+      return ImmutableList.copyOf(filter(listMachines(), filter));
    }
 
    public VirtualMachine findMachine(final Predicate<VirtualMachine> filter) {

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/exception/AbiquoException.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/exception/AbiquoException.java
@@ -30,7 +30,7 @@ import javax.ws.rs.core.Response.Status;
 
 import com.abiquo.model.transport.error.ErrorDto;
 import com.abiquo.model.transport.error.ErrorsDto;
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Abiquo API exception.
@@ -39,6 +39,8 @@ import com.google.common.collect.Lists;
  * @author Ignasi Barrera
  */
 public class AbiquoException extends RuntimeException {
+
+   private static final long serialVersionUID = 3627304442037389536L;
 
    /** The HTTP status. */
    private Status httpStatus;
@@ -70,7 +72,7 @@ public class AbiquoException extends RuntimeException {
     * Find all errors with the given code.
     */
    public List<ErrorDto> findErrors(final String code) {
-      return Lists.newLinkedList(filter(errors.getCollection(), code(code)));
+      return ImmutableList.copyOf(filter(errors.getCollection(), code(code)));
    }
 
    /**

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/exception/BuilderException.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/exception/BuilderException.java
@@ -26,6 +26,8 @@ package org.jclouds.abiquo.domain.exception;
  */
 public class BuilderException extends RuntimeException {
 
+   private static final long serialVersionUID = 540948631643049450L;
+
    /**
     * Creates a {@link BuilderException} with the given message.
     * 

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/exception/WrapperException.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/exception/WrapperException.java
@@ -30,6 +30,8 @@ import com.abiquo.model.transport.SingleResourceTransportDto;
  */
 public class WrapperException extends RuntimeException {
 
+   private static final long serialVersionUID = 3756802225851609583L;
+
    private Class<? extends DomainWrapper<?>> wrapperClass;
 
    private SingleResourceTransportDto target;

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/AbstractPhysicalMachine.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/AbstractPhysicalMachine.java
@@ -22,12 +22,12 @@ package org.jclouds.abiquo.domain.infrastructure;
 import static com.google.common.collect.Iterables.find;
 
 import java.util.List;
-import java.util.StringTokenizer;
 
 import org.jclouds.abiquo.AbiquoApi;
 import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWrapper;
 import org.jclouds.abiquo.predicates.infrastructure.DatastorePredicates;
+import org.jclouds.abiquo.predicates.infrastructure.NetworkInterfacePredicates;
 import org.jclouds.rest.RestContext;
 
 import com.abiquo.model.enumerator.HypervisorType;
@@ -37,8 +37,6 @@ import com.abiquo.server.core.infrastructure.DatastoresDto;
 import com.abiquo.server.core.infrastructure.MachineDto;
 import com.abiquo.server.core.infrastructure.MachineIpmiStateDto;
 import com.abiquo.server.core.infrastructure.MachineStateDto;
-import com.google.common.base.Predicates;
-import com.google.common.collect.Lists;
 
 /**
  * Adds high level functionality to {@link MachineDto}. This class defines
@@ -58,15 +56,11 @@ public abstract class AbstractPhysicalMachine extends DomainWrapper<MachineDto> 
    /** The default virtual cpu used in MB. */
    protected static final int DEFAULT_VCPU_USED = 1;
 
-   /** List of available virtual switches provided by discover operation **/
-   protected List<String> virtualSwitches;
-
    /**
     * Constructor to be used only by the builder.
     */
    protected AbstractPhysicalMachine(final RestContext<AbiquoApi, AbiquoAsyncApi> context, final MachineDto target) {
       super(context, target);
-      extractVirtualSwitches();
    }
 
    public void delete() {
@@ -98,6 +92,14 @@ public abstract class AbstractPhysicalMachine extends DomainWrapper<MachineDto> 
 
    public Datastore findDatastore(final String name) {
       return find(getDatastores(), DatastorePredicates.name(name), null);
+   }
+
+   public List<NetworkInterface> getNetworkInterfaces() {
+      return wrap(context, NetworkInterface.class, target.getNetworkInterfaces().getCollection());
+   }
+
+   public NetworkInterface findNetworkInterface(final String name) {
+      return find(getNetworkInterfaces(), NetworkInterfacePredicates.name(name), null);
    }
 
    // Delegate methods
@@ -168,10 +170,6 @@ public abstract class AbstractPhysicalMachine extends DomainWrapper<MachineDto> 
 
    public Integer getVirtualRamUsedInMb() {
       return target.getVirtualRamUsedInMb();
-   }
-
-   public String getVirtualSwitch() {
-      return target.getVirtualSwitch();
    }
 
    public void setDatastores(final List<Datastore> datastores) {
@@ -248,42 +246,14 @@ public abstract class AbstractPhysicalMachine extends DomainWrapper<MachineDto> 
       target.setVirtualRamUsedInMb(virtualRamUsedInMb);
    }
 
-   public void setVirtualSwitch(final String virtualSwitch) {
-      target.setVirtualSwitch(virtualSwitch);
-   }
-
    public String getDescription() {
       return target.getDescription();
    }
 
    // Aux operations
 
-   /**
-    * Converts the tokenized String provided by the node collector API to a list
-    * of Strings and stores it at the attribute switches.
-    */
-   protected void extractVirtualSwitches() {
-      StringTokenizer st = new StringTokenizer(getVirtualSwitch(), "/");
-      this.virtualSwitches = Lists.newArrayList();
-
-      while (st.hasMoreTokens()) {
-         this.virtualSwitches.add(st.nextToken());
-      }
-
-      if (virtualSwitches.size() > 0) {
-         this.setVirtualSwitch(virtualSwitches.get(0));
-      }
-   }
-
-   /**
-    * Returns the virtual switches available. One of them needs to be selected.
-    */
-   public List<String> getAvailableVirtualSwitches() {
-      return virtualSwitches;
-   }
-
-   public String findAvailableVirtualSwitch(final String vswitch) {
-      return find(virtualSwitches, Predicates.equalTo(vswitch));
+   public NetworkInterface findAvailableVirtualSwitch(final String virtualswitch) {
+      return find(getNetworkInterfaces(), NetworkInterfacePredicates.name(virtualswitch));
    }
 
    @Override
@@ -293,9 +263,8 @@ public abstract class AbstractPhysicalMachine extends DomainWrapper<MachineDto> 
             + getIpService() + ", name=" + getName() + ", password=" + getPassword() + ", port=" + getPort()
             + ", state=" + getState() + ", type=" + getType() + ", user=" + getUser() + ", virtualCpuCores="
             + getVirtualCpuCores() + ", virtualCpusUsed=" + getVirtualCpusUsed() + ", getVirtualRamInMb()="
-            + getVirtualRamInMb() + ", virtualRamUsedInMb=" + getVirtualRamUsedInMb() + ", virtualSwitch="
-            + getVirtualSwitch() + ", description=" + getDescription() + ", availableVirtualSwitches="
-            + getAvailableVirtualSwitches() + "]";
+            + getVirtualRamInMb() + ", virtualRamUsedInMb=" + getVirtualRamUsedInMb() + ", description="
+            + getDescription() + "]";
    }
 
 }

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/Blade.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/Blade.java
@@ -21,8 +21,8 @@ package org.jclouds.abiquo.domain.infrastructure;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.reference.ValidationErrors;
 import org.jclouds.abiquo.reference.rest.ParentLinkName;
 import org.jclouds.abiquo.rest.internal.ExtendedUtils;

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/BladeLocatorLed.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/BladeLocatorLed.java
@@ -19,8 +19,8 @@
 
 package org.jclouds.abiquo.domain.infrastructure;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWrapper;
 import org.jclouds.abiquo.reference.annotations.EnterpriseEdition;
 import org.jclouds.rest.RestContext;

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/Datastore.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/Datastore.java
@@ -19,8 +19,8 @@
 
 package org.jclouds.abiquo.domain.infrastructure;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWrapper;
 import org.jclouds.rest.RestContext;
 

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/Fsm.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/Fsm.java
@@ -19,8 +19,8 @@
 
 package org.jclouds.abiquo.domain.infrastructure;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWrapper;
 import org.jclouds.abiquo.reference.annotations.EnterpriseEdition;
 import org.jclouds.rest.RestContext;

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/LogicServer.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/LogicServer.java
@@ -21,8 +21,8 @@ package org.jclouds.abiquo.domain.infrastructure;
 
 import java.util.List;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWrapper;
 import org.jclouds.abiquo.reference.annotations.EnterpriseEdition;
 import org.jclouds.rest.RestContext;

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/ManagedRack.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/ManagedRack.java
@@ -24,8 +24,8 @@ import static com.google.common.collect.Iterables.filter;
 
 import java.util.List;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWrapper;
 import org.jclouds.abiquo.reference.ValidationErrors;
 import org.jclouds.abiquo.reference.annotations.EnterpriseEdition;
@@ -36,10 +36,11 @@ import com.abiquo.server.core.infrastructure.FsmsDto;
 import com.abiquo.server.core.infrastructure.LogicServersDto;
 import com.abiquo.server.core.infrastructure.MachinesDto;
 import com.abiquo.server.core.infrastructure.OrganizationsDto;
+import com.abiquo.server.core.infrastructure.RackDto;
 import com.abiquo.server.core.infrastructure.UcsRackDto;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 
 /**
  * Adds high level functionality to {@link RackDto}.
@@ -158,7 +159,7 @@ public class ManagedRack extends DomainWrapper<UcsRackDto> {
     *      MachineResource- RetrievealistofMachines</a>
     */
    public List<Blade> listMachines(final Predicate<Blade> filter) {
-      return Lists.newLinkedList(filter(listMachines(), filter));
+      return ImmutableList.copyOf(filter(listMachines(), filter));
    }
 
    /**
@@ -200,7 +201,7 @@ public class ManagedRack extends DomainWrapper<UcsRackDto> {
     *      - RetrievealistofallservicesprofilesinaUCSrack</a>
     */
    public List<LogicServer> listServiceProfiles(final Predicate<LogicServer> filter) {
-      return Lists.newLinkedList(filter(listServiceProfiles(), filter));
+      return ImmutableList.copyOf(filter(listServiceProfiles(), filter));
    }
 
    /**
@@ -242,7 +243,7 @@ public class ManagedRack extends DomainWrapper<UcsRackDto> {
     *      RetrievealistofallServicesProfilesTemplatesinaUCSRack</a>
     */
    public List<LogicServer> listServiceProfileTemplates(final Predicate<LogicServer> filter) {
-      return Lists.newLinkedList(filter(listServiceProfileTemplates(), filter));
+      return ImmutableList.copyOf(filter(listServiceProfileTemplates(), filter));
    }
 
    /**
@@ -291,7 +292,7 @@ public class ManagedRack extends DomainWrapper<UcsRackDto> {
     *      RetrieveallorganizationsfromaUCS</a>
     */
    public List<Organization> listOrganizations(final Predicate<Organization> filter) {
-      return Lists.newLinkedList(filter(listOrganizations(), filter));
+      return ImmutableList.copyOf(filter(listOrganizations(), filter));
    }
 
    /**

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/NetworkInterface.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/NetworkInterface.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.abiquo.domain.infrastructure;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
+import org.jclouds.abiquo.domain.DomainWrapper;
+import org.jclouds.abiquo.domain.network.NetworkServiceType;
+import org.jclouds.abiquo.rest.internal.ExtendedUtils;
+import org.jclouds.http.HttpResponse;
+import org.jclouds.http.functions.ParseXMLWithJAXB;
+import org.jclouds.rest.RestContext;
+
+import com.abiquo.model.rest.RESTLink;
+import com.abiquo.server.core.infrastructure.network.NetworkInterfaceDto;
+import com.abiquo.server.core.infrastructure.network.NetworkServiceTypeDto;
+import com.google.inject.TypeLiteral;
+
+/**
+ * Represents a physical attached NIC.
+ * 
+ * Allows to specify the {@link NetworkServiceType} for the network interface.
+ * This way all network interfaces have the information of the kind of network
+ * they are attached to.
+ * 
+ * @author Jaume Devesa
+ */
+public class NetworkInterface extends DomainWrapper<NetworkInterfaceDto> {
+   /**
+    * Constructor to be used only by the builder. This resource cannot be
+    * created.
+    */
+   protected NetworkInterface(final RestContext<AbiquoApi, AbiquoAsyncApi> context, final NetworkInterfaceDto target) {
+      super(context, target);
+   }
+
+   public String getName() {
+      return target.getName();
+   }
+
+   public String getMac() {
+      return target.getMac();
+   }
+
+   public void setNetworkServiceType(final NetworkServiceType type) {
+      checkNotNull(type, "network service type cannot be null");
+      target.setNetworkServiceTypeLink(type.unwrap().getEditLink().getHref());
+   }
+
+   public NetworkServiceType getNetworkServiceType() {
+      RESTLink link = target.getNetworkServiceTypeLink();
+
+      ExtendedUtils utils = (ExtendedUtils) context.getUtils();
+      HttpResponse response = utils.getAbiquoHttpClient().get(link);
+
+      ParseXMLWithJAXB<NetworkServiceTypeDto> parser = new ParseXMLWithJAXB<NetworkServiceTypeDto>(utils.getXml(),
+            TypeLiteral.get(NetworkServiceTypeDto.class));
+
+      return wrap(context, NetworkServiceType.class, parser.apply(response));
+   }
+}

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/Organization.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/Organization.java
@@ -19,8 +19,8 @@
 
 package org.jclouds.abiquo.domain.infrastructure;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWrapper;
 import org.jclouds.abiquo.reference.annotations.EnterpriseEdition;
 import org.jclouds.rest.RestContext;

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/Rack.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/Rack.java
@@ -24,8 +24,8 @@ import static com.google.common.collect.Iterables.filter;
 
 import java.util.List;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWrapper;
 import org.jclouds.abiquo.reference.ValidationErrors;
 import org.jclouds.abiquo.reference.rest.ParentLinkName;
@@ -35,8 +35,8 @@ import com.abiquo.server.core.infrastructure.MachineDto;
 import com.abiquo.server.core.infrastructure.MachinesDto;
 import com.abiquo.server.core.infrastructure.RackDto;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 
 /**
  * Adds high level functionality to {@link RackDto}. Represents unmanaged racks
@@ -151,7 +151,7 @@ public class Rack extends DomainWrapper<RackDto> {
     *      MachineResource- RetrievealistofMachines</a>
     */
    public List<Machine> listMachines(final Predicate<Machine> filter) {
-      return Lists.newLinkedList(filter(listMachines(), filter));
+      return ImmutableList.copyOf(filter(listMachines(), filter));
    }
 
    /**

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/RemoteService.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/RemoteService.java
@@ -21,8 +21,8 @@ package org.jclouds.abiquo.domain.infrastructure;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWrapper;
 import org.jclouds.abiquo.reference.ValidationErrors;
 import org.jclouds.abiquo.reference.rest.ParentLinkName;

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/StorageDevice.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/StorageDevice.java
@@ -24,8 +24,8 @@ import static com.google.common.collect.Iterables.filter;
 
 import java.util.List;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWrapper;
 import org.jclouds.abiquo.domain.infrastructure.options.StoragePoolOptions;
 import org.jclouds.abiquo.reference.ValidationErrors;
@@ -39,8 +39,8 @@ import com.abiquo.server.core.infrastructure.storage.StoragePoolDto;
 import com.abiquo.server.core.infrastructure.storage.StoragePoolsDto;
 import com.abiquo.server.core.infrastructure.storage.TiersDto;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 
 /**
  * Adds high level functionality to {@link StorageDeviceDto}. The Storage Device
@@ -157,7 +157,7 @@ public class StorageDevice extends DomainWrapper<StorageDeviceDto> {
     * @return Filtered synchronized list of storage pools in this device.
     */
    public List<StoragePool> listRemoteStoragePools(final Predicate<StoragePool> filter) {
-      return Lists.newLinkedList(filter(listRemoteStoragePools(), filter));
+      return ImmutableList.copyOf(filter(listRemoteStoragePools(), filter));
    }
 
    /**
@@ -206,7 +206,7 @@ public class StorageDevice extends DomainWrapper<StorageDeviceDto> {
     * @return Filtered unsynchronized list of storage pools in this device.
     */
    public List<StoragePool> listStoragePools(final Predicate<StoragePool> filter) {
-      return Lists.newLinkedList(filter(listStoragePools(), filter));
+      return ImmutableList.copyOf(filter(listStoragePools(), filter));
    }
 
    /**
@@ -280,7 +280,7 @@ public class StorageDevice extends DomainWrapper<StorageDeviceDto> {
     * @return Filtered list of tiers in the datacenter using this device.
     */
    public List<Tier> listTiersFromDatacenter(final Predicate<Tier> filter) {
-      return Lists.newLinkedList(filter(listTiersFromDatacenter(), filter));
+      return ImmutableList.copyOf(filter(listTiersFromDatacenter(), filter));
    }
 
    /**

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/StorageDeviceMetadata.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/StorageDeviceMetadata.java
@@ -19,8 +19,8 @@
 
 package org.jclouds.abiquo.domain.infrastructure;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWrapper;
 import org.jclouds.rest.RestContext;
 

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/StoragePool.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/StoragePool.java
@@ -21,8 +21,8 @@ package org.jclouds.abiquo.domain.infrastructure;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWrapper;
 import org.jclouds.abiquo.domain.config.Privilege;
 import org.jclouds.abiquo.domain.infrastructure.options.StoragePoolOptions;

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/Tier.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/Tier.java
@@ -23,8 +23,8 @@ import static com.google.common.collect.Iterables.filter;
 
 import java.util.List;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWrapper;
 import org.jclouds.abiquo.reference.annotations.EnterpriseEdition;
 import org.jclouds.abiquo.reference.rest.ParentLinkName;
@@ -34,8 +34,8 @@ import com.abiquo.server.core.infrastructure.DatacenterDto;
 import com.abiquo.server.core.infrastructure.storage.StoragePoolsDto;
 import com.abiquo.server.core.infrastructure.storage.TierDto;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 
 /**
  * Adds high level functionality to {@link TierDto}. The Tier Resource offers
@@ -101,7 +101,7 @@ public class Tier extends DomainWrapper<TierDto> {
     * @return Filtered list of storage pools in this tier.
     */
    public List<StoragePool> listStoragePools(final Predicate<StoragePool> filter) {
-      return Lists.newLinkedList(filter(listStoragePools(), filter));
+      return ImmutableList.copyOf(filter(listStoragePools(), filter));
    }
 
    /**

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/network/AbstractPublicIp.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/network/AbstractPublicIp.java
@@ -19,8 +19,8 @@
 
 package org.jclouds.abiquo.domain.network;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.rest.RestContext;
 
 import com.abiquo.server.core.infrastructure.network.AbstractInfrastructureIpDto;

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/network/ExternalIp.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/network/ExternalIp.java
@@ -21,8 +21,8 @@ package org.jclouds.abiquo.domain.network;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.reference.ValidationErrors;
 import org.jclouds.abiquo.reference.rest.ParentLinkName;
 import org.jclouds.abiquo.rest.internal.ExtendedUtils;

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/network/Ip.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/network/Ip.java
@@ -19,8 +19,8 @@
 
 package org.jclouds.abiquo.domain.network;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWrapper;
 import org.jclouds.rest.RestContext;
 

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/network/Network.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/network/Network.java
@@ -21,11 +21,12 @@ package org.jclouds.abiquo.domain.network;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.filter;
+import static com.google.common.collect.Iterables.transform;
 
 import java.util.List;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWrapper;
 import org.jclouds.abiquo.domain.network.options.IpOptions;
 import org.jclouds.abiquo.predicates.network.IpPredicates;
@@ -34,9 +35,10 @@ import org.jclouds.rest.RestContext;
 
 import com.abiquo.model.enumerator.NetworkType;
 import com.abiquo.server.core.infrastructure.network.VLANNetworkDto;
+import com.google.common.base.Function;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 
 /**
  * Adds generic high level functionality to {@link VLANNetworkDto}.
@@ -70,7 +72,7 @@ public abstract class Network<T extends Ip<?, ?>> extends DomainWrapper<VLANNetw
    }
 
    public List<T> listIps(final Predicate<T> filter) {
-      return Lists.newLinkedList(filter(listIps(), filter));
+      return ImmutableList.copyOf(filter(listIps(), filter));
    }
 
    public T findIp(final Predicate<T> filter) {
@@ -320,10 +322,11 @@ public abstract class Network<T extends Ip<?, ?>> extends DomainWrapper<VLANNetw
 
    public static List<Network<?>> wrapNetworks(final RestContext<AbiquoApi, AbiquoAsyncApi> context,
          final List<VLANNetworkDto> dtos) {
-      List<Network<?>> networks = Lists.newLinkedList();
-      for (VLANNetworkDto dto : dtos) {
-         networks.add(wrapNetwork(context, dto));
-      }
-      return networks;
+      return ImmutableList.copyOf(transform(dtos, new Function<VLANNetworkDto, Network<?>>() {
+         @Override
+         public Network<?> apply(VLANNetworkDto input) {
+            return wrapNetwork(context, input);
+         }
+      }));
    }
 }

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/network/NetworkServiceType.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/network/NetworkServiceType.java
@@ -1,0 +1,135 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.abiquo.domain.network;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
+import org.jclouds.abiquo.domain.DomainWrapper;
+import org.jclouds.abiquo.domain.infrastructure.Datacenter;
+import org.jclouds.abiquo.reference.ValidationErrors;
+import org.jclouds.rest.RestContext;
+
+import com.abiquo.server.core.infrastructure.network.NetworkServiceTypeDto;
+
+/**
+ * Network Service Type defines a network service.
+ * 
+ * The network Service Type is used to select the network interface of the
+ * target host where a NIC in the virtual machine will be attached.
+ * 
+ * They are scoped at {@link Datacenter} level: two {@link NetworkServiceType}
+ * can have the same name if they belong to a different {@link Datacenter}
+ * 
+ * @author Jaume Devesa
+ */
+public class NetworkServiceType extends DomainWrapper<NetworkServiceTypeDto> {
+   public static Builder builder(final RestContext<AbiquoApi, AbiquoAsyncApi> context, final Datacenter datacenter) {
+      return new Builder(context, datacenter);
+   }
+
+   /**
+    * Helper class to build {@link NetworkServiceType} in a controlled way.
+    * 
+    * @author Jaume Devesa
+    */
+   public static class Builder {
+      private RestContext<AbiquoApi, AbiquoAsyncApi> context;
+
+      private Datacenter datacenter;
+
+      private String name;
+
+      public Builder(final RestContext<AbiquoApi, AbiquoAsyncApi> context, final Datacenter datacenter) {
+         super();
+         checkNotNull(datacenter, ValidationErrors.NULL_RESOURCE + Datacenter.class);
+         this.datacenter = datacenter;
+         this.context = context;
+      }
+
+      public NetworkServiceType build() {
+         NetworkServiceTypeDto dto = new NetworkServiceTypeDto();
+         dto.setName(this.name);
+
+         NetworkServiceType nst = new NetworkServiceType(context, dto);
+         nst.datacenter = this.datacenter;
+         return nst;
+      }
+
+      public Builder name(final String name) {
+         this.name = checkNotNull(name, ValidationErrors.MISSING_REQUIRED_FIELD + name);
+         return this;
+      }
+   }
+
+   /** The datacenter where the NetworkServiceType belongs. */
+   private Datacenter datacenter;
+
+   /** Constructor will only be used by the builder. */
+   protected NetworkServiceType(final RestContext<AbiquoApi, AbiquoAsyncApi> context, final NetworkServiceTypeDto target) {
+      super(context, target);
+   }
+
+   /**
+    * Delete the Network Service Type.
+    */
+   public void delete() {
+      context.getApi().getInfrastructureApi().deleteNetworkServiceType(target);
+      target = null;
+   }
+
+   /**
+    * Create a new Network Service Type
+    */
+   public void save() {
+      target = context.getApi().getInfrastructureApi().createNetworkServiceType(datacenter.unwrap(), target);
+   }
+
+   /**
+    * Update Network Service Type information in the server with the data from
+    * this NST.
+    */
+   public void update() {
+      target = context.getApi().getInfrastructureApi().updateNetworkServiceType(target);
+   }
+
+   public Integer getId() {
+      return target.getId();
+   }
+
+   public String getName() {
+      return target.getName();
+   }
+
+   public Boolean isDefaultNST() {
+      return target.isDefaultNST();
+   }
+
+   public void setName(final String name) {
+      target.setName(name);
+   }
+
+   @Override
+   public String toString() {
+      return "NetworkServiceType [id=" + getId() + ", name=" + getName() + ", isDefault=" + isDefaultNST() + "]";
+   }
+
+}

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/network/Nic.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/network/Nic.java
@@ -19,8 +19,8 @@
 
 package org.jclouds.abiquo.domain.network;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWrapper;
 import org.jclouds.rest.RestContext;
 

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/network/PrivateIp.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/network/PrivateIp.java
@@ -21,8 +21,8 @@ package org.jclouds.abiquo.domain.network;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.reference.ValidationErrors;
 import org.jclouds.abiquo.reference.rest.ParentLinkName;
 import org.jclouds.abiquo.rest.internal.ExtendedUtils;

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/network/PrivateNetwork.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/network/PrivateNetwork.java
@@ -21,8 +21,8 @@ package org.jclouds.abiquo.domain.network;
 
 import java.util.List;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.cloud.VirtualDatacenter;
 import org.jclouds.abiquo.domain.network.options.IpOptions;
 import org.jclouds.rest.RestContext;

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/network/PublicIp.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/network/PublicIp.java
@@ -21,8 +21,8 @@ package org.jclouds.abiquo.domain.network;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.reference.ValidationErrors;
 import org.jclouds.abiquo.reference.rest.ParentLinkName;
 import org.jclouds.abiquo.rest.internal.ExtendedUtils;

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/network/UnmanagedIp.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/network/UnmanagedIp.java
@@ -21,8 +21,8 @@ package org.jclouds.abiquo.domain.network;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.reference.ValidationErrors;
 import org.jclouds.abiquo.reference.rest.ParentLinkName;
 import org.jclouds.abiquo.rest.internal.ExtendedUtils;

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/util/LinkUtils.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/util/LinkUtils.java
@@ -27,7 +27,7 @@ import org.jclouds.abiquo.predicates.LinkPredicates;
 
 import com.abiquo.model.rest.RESTLink;
 import com.abiquo.model.transport.SingleResourceTransportDto;
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Utility method to work with {@link RESTLink} objects.
@@ -55,6 +55,6 @@ public class LinkUtils {
     * @return A list with all links that point to a NIC.
     */
    public static List<RESTLink> filterNicLinks(final List<RESTLink> links) {
-      return Lists.newLinkedList(filter(links, LinkPredicates.isNic()));
+      return ImmutableList.copyOf(filter(links, LinkPredicates.isNic()));
    }
 }

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/features/InfrastructureApi.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/features/InfrastructureApi.java
@@ -58,6 +58,8 @@ import com.abiquo.server.core.infrastructure.UcsRackDto;
 import com.abiquo.server.core.infrastructure.UcsRacksDto;
 import com.abiquo.server.core.infrastructure.network.ExternalIpDto;
 import com.abiquo.server.core.infrastructure.network.ExternalIpsDto;
+import com.abiquo.server.core.infrastructure.network.NetworkServiceTypeDto;
+import com.abiquo.server.core.infrastructure.network.NetworkServiceTypesDto;
 import com.abiquo.server.core.infrastructure.network.PublicIpDto;
 import com.abiquo.server.core.infrastructure.network.PublicIpsDto;
 import com.abiquo.server.core.infrastructure.network.UnmanagedIpDto;
@@ -1205,4 +1207,53 @@ public interface InfrastructureApi {
     * @since 2.3
     */
    UnmanagedIpDto getUnmanagedIp(VLANNetworkDto network, Integer ipId);
+
+   /**
+    * List all the Network Service types definied into a datacenter.
+    * 
+    * @param datacenter
+    *           The datacenter
+    * @return The list of Network Service Types in the datacenter.
+    */
+   NetworkServiceTypesDto listNetworkServiceTypes(DatacenterDto datacenter);
+
+   /**
+    * Create a new Network Service Type Dto.
+    * 
+    * @param datacenter
+    *           the datacenter where the network service type will belong to
+    * @param nst
+    *           {@link NetworkServiceTypeDto} instance to create
+    * @return the created {@link NetworkServiceTypeDto}
+    */
+   NetworkServiceTypeDto createNetworkServiceType(DatacenterDto datacenter, NetworkServiceTypeDto nst);
+
+   /**
+    * Get a single instance of a {@link NetworkServiceTypeDto}
+    * 
+    * @param datacenter
+    *           datacenter where search into
+    * @param nstId
+    *           identifier of the {@link NetworkServiceTypeDto}
+    * @return the found entity
+    */
+   NetworkServiceTypeDto getNetworkServiceType(DatacenterDto datacenter, Integer nstId);
+
+   /**
+    * Update the value of a {@link NetworkServiceTypeDto}
+    * 
+    * @param nstDto
+    *           the instance to update with the new values.
+    * @return the updated entity.
+    */
+   NetworkServiceTypeDto updateNetworkServiceType(NetworkServiceTypeDto nstDto);
+
+   /**
+    * Remove a {@link NetworkServiceTypeDto} entity.
+    * 
+    * @param nstDto
+    *           the entity to delete
+    */
+   void deleteNetworkServiceType(NetworkServiceTypeDto nstDto);
+
 }

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/features/InfrastructureAsyncApi.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/features/InfrastructureAsyncApi.java
@@ -89,6 +89,8 @@ import com.abiquo.server.core.infrastructure.UcsRackDto;
 import com.abiquo.server.core.infrastructure.UcsRacksDto;
 import com.abiquo.server.core.infrastructure.network.ExternalIpDto;
 import com.abiquo.server.core.infrastructure.network.ExternalIpsDto;
+import com.abiquo.server.core.infrastructure.network.NetworkServiceTypeDto;
+import com.abiquo.server.core.infrastructure.network.NetworkServiceTypesDto;
 import com.abiquo.server.core.infrastructure.network.PublicIpDto;
 import com.abiquo.server.core.infrastructure.network.PublicIpsDto;
 import com.abiquo.server.core.infrastructure.network.UnmanagedIpDto;
@@ -1078,4 +1080,62 @@ public interface InfrastructureAsyncApi {
    ListenableFuture<UnmanagedIpDto> getUnmanagedIp(
          @EndpointLink("ips") @BinderParam(BindToPath.class) VLANNetworkDto network,
          @BinderParam(AppendToPath.class) Integer ipId);
+
+   /***************************** NETWORK SERVICE TYPES *******************************************/
+
+   /**
+    * @see InfrastructureApi#listNetworkServiceTypes(DatacenterDto)
+    */
+   @GET
+   @Consumes(NetworkServiceTypesDto.BASE_MEDIA_TYPE)
+   @JAXBResponseParser
+   ListenableFuture<NetworkServiceTypesDto> listNetworkServiceTypes(
+         @EndpointLink("networkservicetypes") @BinderParam(BindToPath.class) DatacenterDto datacenter);
+
+   /**
+    * @see InfrastructureApi#createNetworkServiceType(DatacenterDto,
+    *      NetworkServiceTypeDto)
+    */
+   @POST
+   @Produces(NetworkServiceTypeDto.BASE_MEDIA_TYPE)
+   @Consumes(NetworkServiceTypeDto.BASE_MEDIA_TYPE)
+   @JAXBResponseParser
+   ListenableFuture<NetworkServiceTypeDto> createNetworkServiceType(
+         @EndpointLink("networkservicetypes") @BinderParam(BindToPath.class) DatacenterDto datacenter,
+         @BinderParam(BindToXMLPayload.class) NetworkServiceTypeDto nst);
+
+   /**
+    * @see InfrastructureApi#getNetworkServiceType(DatacenterDto, Integer)
+    */
+   @GET
+   @Consumes(NetworkServiceTypeDto.BASE_MEDIA_TYPE)
+   @JAXBResponseParser
+   @ExceptionParser(ReturnNullOnNotFoundOr404.class)
+   ListenableFuture<NetworkServiceTypeDto> getNetworkServiceType(
+         @EndpointLink("networkservicetypes") @BinderParam(BindToPath.class) DatacenterDto datacenter,
+         @BinderParam(AppendToPath.class) Integer nstId);
+
+   /**
+    * Update the value of a {@link NetworkServiceTypeDto}
+    * 
+    * @param nstDto
+    *           the instance to update with the new values.
+    * @return the updated entity.
+    */
+   @PUT
+   @Produces(NetworkServiceTypeDto.BASE_MEDIA_TYPE)
+   @Consumes(NetworkServiceTypeDto.BASE_MEDIA_TYPE)
+   @JAXBResponseParser
+   ListenableFuture<NetworkServiceTypeDto> updateNetworkServiceType(
+         @EndpointLink("edit") @BinderParam(BindToXMLPayloadAndPath.class) NetworkServiceTypeDto nstDto);
+
+   /**
+    * Remove a {@link NetworkServiceTypeDto} entity.
+    * 
+    * @param nstDto
+    *           the entity to delete
+    */
+   @DELETE
+   ListenableFuture<Void> deleteNetworkServiceType(
+         @EndpointLink("edit") @BinderParam(BindToPath.class) NetworkServiceTypeDto nstDto);
 }

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/predicates/infrastructure/NetworkInterfacePredicates.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/predicates/infrastructure/NetworkInterfacePredicates.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.abiquo.predicates.infrastructure;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Arrays;
+
+import org.jclouds.abiquo.domain.infrastructure.NetworkInterface;
+
+import com.google.common.base.Predicate;
+
+/**
+ * Container for {@link NetworkInterface} filters.
+ * 
+ * @author Jaume Devesa
+ */
+public class NetworkInterfacePredicates {
+   public static Predicate<NetworkInterface> name(final String... names) {
+      checkNotNull(names, "names must be defined");
+
+      return new Predicate<NetworkInterface>() {
+         @Override
+         public boolean apply(final NetworkInterface ni) {
+            return Arrays.asList(names).contains(ni.getName());
+         }
+      };
+   }
+
+}

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/predicates/network/NetworkServiceTypePredicates.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/predicates/network/NetworkServiceTypePredicates.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.abiquo.predicates.network;
+
+import org.jclouds.abiquo.domain.network.NetworkServiceType;
+
+import com.google.common.base.Predicate;
+
+/**
+ * Container for {@link NetworkServiceType} filters.
+ * 
+ * @author Jaume Devesa
+ */
+public class NetworkServiceTypePredicates {
+   public static Predicate<NetworkServiceType> isDefault() {
+      return new Predicate<NetworkServiceType>() {
+         @Override
+         public boolean apply(final NetworkServiceType ni) {
+            return ni.isDefaultNST();
+         }
+      };
+   }
+}

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/binders/BindToPathTest.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/binders/BindToPathTest.java
@@ -152,6 +152,8 @@ public class BindToPathTest {
 
    static class TestDto extends SingleResourceTransportDto {
 
+      private static final long serialVersionUID = 5381713583837345158L;
+
       public TestDto() {
          addLink(new RESTLink("edit", "http://linkuri"));
       }

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/InfrastructureResources.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/InfrastructureResources.java
@@ -77,7 +77,6 @@ public class InfrastructureResources {
       machine.setVirtualCpuCores(3);
       machine.setDescription("A hawaian machine");
       machine.setVirtualRamInMb(512);
-      machine.setVirtualSwitch("192.168.1.10");
       return machine;
    }
 

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/admin/RoleLiveApiTest.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/admin/RoleLiveApiTest.java
@@ -39,6 +39,7 @@ import org.testng.annotations.Test;
 
 import com.abiquo.server.core.enterprise.PrivilegeDto;
 import com.abiquo.server.core.enterprise.RoleDto;
+import com.google.common.collect.Lists;
 
 /**
  * Live integration tests for the {@link Role} domain class.
@@ -88,7 +89,7 @@ public class RoleLiveApiTest extends BaseAbiquoApiLiveApiTest {
    public void testAddPrivilege() {
       PrivilegeDto dto = env.configApi.getPrivilege(8);
       Privilege privilege = DomainWrapper.wrap(env.context.getApiContext(), Privilege.class, dto);
-      List<Privilege> privileges = env.role.listPrivileges();
+      List<Privilege> privileges = Lists.newArrayList(env.role.listPrivileges());
       privileges.add(privilege);
 
       env.role.setPrivileges(privileges);

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/cloud/VirtualMachineNetworkingLiveApiTest.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/cloud/VirtualMachineNetworkingLiveApiTest.java
@@ -117,7 +117,7 @@ public class VirtualMachineNetworkingLiveApiTest extends BaseAbiquoApiLiveApiTes
 
    @Test(dependsOnMethods = "testAttachPublicIp")
    public void testAttachPrivateIp() {
-      List<Ip<?, ?>> nics = env.virtualMachine.listAttachedNics();
+      List<Ip<?, ?>> nics = Lists.newArrayList(env.virtualMachine.listAttachedNics());
       nics.add(privateIp);
 
       AsyncTask task = env.virtualMachine.setNics(nics);
@@ -131,7 +131,7 @@ public class VirtualMachineNetworkingLiveApiTest extends BaseAbiquoApiLiveApiTes
 
    @Test(dependsOnMethods = "testAttachPrivateIp")
    public void testAttachExternalIp() {
-      List<Ip<?, ?>> nics = env.virtualMachine.listAttachedNics();
+      List<Ip<?, ?>> nics = Lists.newArrayList(env.virtualMachine.listAttachedNics());
       nics.add(externalIp);
 
       AsyncTask task = env.virtualMachine.setNics(nics);

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/infrastructure/BladeLiveUcsTest.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/infrastructure/BladeLiveUcsTest.java
@@ -24,6 +24,7 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 import org.jclouds.abiquo.internal.BaseAbiquoApiLiveApiTest;
+import org.jclouds.abiquo.util.Config;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -39,8 +40,8 @@ public class BladeLiveUcsTest extends BaseAbiquoApiLiveApiTest {
    Blade blade;
 
    public void testFindAvailableVirtualSwitch() {
-      String vswitch = blade.getAvailableVirtualSwitches().get(0);
-      String found = blade.findAvailableVirtualSwitch(vswitch);
+      String vswitch = Config.get("abiquo.hypervisor.vswitch");
+      NetworkInterface found = env.machine.findAvailableVirtualSwitch(vswitch);
       assertEquals(found, vswitch);
    }
 

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/infrastructure/MachineLiveApiTest.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/infrastructure/MachineLiveApiTest.java
@@ -113,9 +113,9 @@ public class MachineLiveApiTest extends BaseAbiquoApiLiveApiTest {
    }
 
    public void testFindAvailableVirtualSwitch() {
-      String vswitch = env.machine.getAvailableVirtualSwitches().get(0);
-      String found = env.machine.findAvailableVirtualSwitch(vswitch);
-      assertEquals(found, vswitch);
+      String vswitch = Config.get("abiquo.hypervisor.vswitch");
+      NetworkInterface found = env.machine.findAvailableVirtualSwitch(vswitch);
+      assertEquals(found.getName(), vswitch);
    }
 
    public void testGetRack() {

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/infrastructure/NetworkServiceTypeLiveApiTest.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/infrastructure/NetworkServiceTypeLiveApiTest.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.abiquo.domain.infrastructure;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import org.jclouds.abiquo.domain.network.NetworkServiceType;
+import org.jclouds.abiquo.internal.BaseAbiquoApiLiveApiTest;
+import org.testng.annotations.Test;
+
+/**
+ * Live integration tests for the {@link NetworkServiceType} domain class.
+ * 
+ * @author Jaume Devesa
+ */
+@Test(groups = "api", testName = "NetworkServiceTypeLiveApiTest")
+public class NetworkServiceTypeLiveApiTest extends BaseAbiquoApiLiveApiTest {
+
+   private NetworkServiceType nst = null;
+
+   @Test
+   public void testCreate() {
+      nst = NetworkServiceType.builder(env.context.getApiContext(), env.datacenter).name("Storage Network").build();
+      nst.save();
+
+      assertNotNull(nst.getId());
+      NetworkServiceType copy = env.datacenter.getNetworkServiceType(nst.getId());
+      assertEquals(copy.getName(), nst.getName());
+
+   }
+
+   @Test(dependsOnMethods = "testCreate")
+   public void testUpdate() {
+      nst.setName("Storage Network Updated");
+      nst.update();
+
+      NetworkServiceType copy = env.datacenter.getNetworkServiceType(nst.getId());
+      assertEquals(copy.getName(), nst.getName());
+   }
+
+   @Test(dependsOnMethods = "testUpdate")
+   public void testDelete() {
+      Integer deleteId = nst.getId();
+      nst.delete();
+
+      // Assert it is deleted
+      assertNull(env.datacenter.getNetworkServiceType(deleteId));
+
+   }
+}

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/environment/CloudTestEnvironment.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/environment/CloudTestEnvironment.java
@@ -42,6 +42,7 @@ import org.jclouds.abiquo.features.CloudApi;
 import org.jclouds.abiquo.features.services.EventService;
 import org.jclouds.abiquo.predicates.enterprise.EnterprisePredicates;
 import org.jclouds.abiquo.predicates.network.NetworkPredicates;
+import org.testng.collections.Lists;
 
 import com.google.common.collect.Ordering;
 import com.google.common.primitives.Longs;
@@ -160,15 +161,17 @@ public class CloudTestEnvironment extends InfrastructureTestEnvironment {
       List<VirtualMachineTemplate> templates = virtualDatacenter.listAvailableTemplates();
       assertFalse(templates.isEmpty());
 
+      List<VirtualMachineTemplate> sorted = Lists.newArrayList(templates);
+
       // Sort by size to use the smallest one
-      Collections.sort(templates, new Ordering<VirtualMachineTemplate>() {
+      Collections.sort(sorted, new Ordering<VirtualMachineTemplate>() {
          @Override
          public int compare(final VirtualMachineTemplate left, final VirtualMachineTemplate right) {
             return Longs.compare(left.getDiskFileSize(), right.getDiskFileSize());
          }
       });
 
-      template = templates.get(0);
+      template = sorted.get(0);
 
       virtualMachine = VirtualMachine.builder(context.getApiContext(), virtualAppliance, template).cpu(2)
             .nameLabel(PREFIX + "VM Aloha").ram(128).build();

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/environment/InfrastructureTestEnvironment.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/environment/InfrastructureTestEnvironment.java
@@ -43,6 +43,7 @@ import org.jclouds.abiquo.domain.infrastructure.Datacenter;
 import org.jclouds.abiquo.domain.infrastructure.Datastore;
 import org.jclouds.abiquo.domain.infrastructure.Machine;
 import org.jclouds.abiquo.domain.infrastructure.ManagedRack;
+import org.jclouds.abiquo.domain.infrastructure.NetworkInterface;
 import org.jclouds.abiquo.domain.infrastructure.Rack;
 import org.jclouds.abiquo.domain.infrastructure.RemoteService;
 import org.jclouds.abiquo.domain.infrastructure.StorageDevice;
@@ -50,6 +51,7 @@ import org.jclouds.abiquo.domain.infrastructure.StorageDeviceMetadata;
 import org.jclouds.abiquo.domain.infrastructure.StoragePool;
 import org.jclouds.abiquo.domain.infrastructure.Tier;
 import org.jclouds.abiquo.domain.network.ExternalNetwork;
+import org.jclouds.abiquo.domain.network.NetworkServiceType;
 import org.jclouds.abiquo.domain.network.PublicNetwork;
 import org.jclouds.abiquo.domain.network.UnmanagedNetwork;
 import org.jclouds.abiquo.features.AdminApi;
@@ -213,8 +215,9 @@ public class InfrastructureTestEnvironment implements TestEnvironment {
 
       machine = datacenter.discoverSingleMachine(ip, type, user, pass);
 
-      String vswitch = machine.findAvailableVirtualSwitch(Config.get("abiquo.hypervisor.vswitch"));
-      machine.setVirtualSwitch(vswitch);
+      NetworkServiceType nst = datacenter.defaultNetworkServiceType();
+      NetworkInterface vswitch = machine.findAvailableVirtualSwitch(Config.get("abiquo.hypervisor.vswitch"));
+      vswitch.setNetworkServiceType(nst);
 
       Datastore datastore = machine.findDatastore(Config.get("abiquo.hypervisor.datastore"));
       datastore.setEnabled(true);

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/features/InfrastructureApiExpectTest.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/features/InfrastructureApiExpectTest.java
@@ -1,0 +1,201 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.abiquo.features;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import java.net.URI;
+
+import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.http.HttpResponse;
+import org.testng.annotations.Test;
+
+import com.abiquo.model.rest.RESTLink;
+import com.abiquo.server.core.infrastructure.DatacenterDto;
+import com.abiquo.server.core.infrastructure.network.NetworkServiceTypeDto;
+import com.abiquo.server.core.infrastructure.network.NetworkServiceTypesDto;
+
+/**
+ * xpect tests for the {@link InfrastructureApi} class.
+ * 
+ * @author Ignasi Barrera
+ */
+@Test(groups = "unit", testName = "InfrastructureApiExpectTest")
+public class InfrastructureApiExpectTest extends BaseAbiquoRestApiExpectTest<InfrastructureApi> {
+
+   public void testListNetworkServiceTypesReturns2xx() {
+      InfrastructureApi api = requestSendsResponse(
+            HttpRequest.builder() //
+                  .method("GET") //
+                  .endpoint(URI.create("http://localhost/api/admin/datacenters/1/networkservicetypes")) //
+                  .addHeader("Authorization", basicAuth) //
+                  .addHeader("Accept", normalize(NetworkServiceTypesDto.MEDIA_TYPE)) //
+                  .build(),
+            HttpResponse
+                  .builder()
+                  .statusCode(200)
+                  .payload(
+                        payloadFromResourceWithContentType("/payloads/nst-list.xml",
+                              normalize(NetworkServiceTypesDto.MEDIA_TYPE))) //
+                  .build());
+
+      DatacenterDto datacenter = new DatacenterDto();
+      datacenter.addLink(new RESTLink("networkservicetypes",
+            "http://localhost/api/admin/datacenters/1/networkservicetypes"));
+
+      NetworkServiceTypesDto nsts = api.listNetworkServiceTypes(datacenter);
+      assertEquals(nsts.getCollection().size(), 2);
+      assertEquals(nsts.getCollection().get(0).getName(), "Service Network");
+      assertEquals(nsts.getCollection().get(1).getName(), "Storage Network");
+   }
+
+   public void testGetNetworkServiceTypeReturns2xx() {
+      InfrastructureApi api = requestSendsResponse(
+            HttpRequest.builder() //
+                  .method("GET") //
+                  .endpoint(URI.create("http://localhost/api/admin/datacenters/1/networkservicetypes/1")) //
+                  .addHeader("Authorization", basicAuth) //
+                  .addHeader("Accept", normalize(NetworkServiceTypeDto.MEDIA_TYPE)) //
+                  .build(),
+            HttpResponse
+                  .builder()
+                  .statusCode(200)
+                  .payload(
+                        payloadFromResourceWithContentType("/payloads/nst-edit.xml",
+                              normalize(NetworkServiceTypeDto.MEDIA_TYPE))) //
+                  .build());
+
+      DatacenterDto datacenter = new DatacenterDto();
+      datacenter.addLink(new RESTLink("networkservicetypes",
+            "http://localhost/api/admin/datacenters/1/networkservicetypes"));
+
+      NetworkServiceTypeDto created = api.getNetworkServiceType(datacenter, 1);
+      assertNotNull(created.getId());
+      assertEquals(created.getName(), "Service Network");
+      assertEquals(created.isDefaultNST(), true);
+   }
+
+   public void testGetNetworkServiceTypeReturns4xx() {
+      InfrastructureApi api = requestSendsResponse(HttpRequest.builder() //
+            .method("GET") //
+            .endpoint(URI.create("http://localhost/api/admin/datacenters/1/networkservicetypes/1")) //
+            .addHeader("Authorization", basicAuth) //
+            .addHeader("Accept", normalize(NetworkServiceTypeDto.MEDIA_TYPE)) //
+            .build(), //
+            HttpResponse.builder().statusCode(404).build());
+
+      DatacenterDto datacenter = new DatacenterDto();
+      datacenter.addLink(new RESTLink("networkservicetypes",
+            "http://localhost/api/admin/datacenters/1/networkservicetypes"));
+
+      assertNull(api.getNetworkServiceType(datacenter, 1));
+   }
+
+   public void testCreateNetworkServiceTypeReturns2xx() {
+      InfrastructureApi api = requestSendsResponse(
+            HttpRequest.builder() //
+                  .method("POST") //
+                  .endpoint(URI.create("http://localhost/api/admin/datacenters/1/networkservicetypes")) //
+                  .addHeader("Authorization", basicAuth) //
+                  .addHeader("Accept", normalize(NetworkServiceTypeDto.MEDIA_TYPE))
+                  //
+                  .payload(
+                        payloadFromResourceWithContentType("/payloads/nst-create.xml",
+                              normalize(NetworkServiceTypeDto.MEDIA_TYPE))) //
+                  .build(),
+            HttpResponse
+                  .builder()
+                  .statusCode(201)
+                  .payload(
+                        payloadFromResourceWithContentType("/payloads/nst-edit.xml",
+                              normalize(NetworkServiceTypeDto.MEDIA_TYPE))) //
+                  .build());
+
+      DatacenterDto datacenter = new DatacenterDto();
+      datacenter.addLink(new RESTLink("networkservicetypes",
+            "http://localhost/api/admin/datacenters/1/networkservicetypes"));
+
+      NetworkServiceTypeDto nst = new NetworkServiceTypeDto();
+      nst.setName("Service Network");
+      nst.setDefaultNST(true);
+
+      NetworkServiceTypeDto created = api.createNetworkServiceType(datacenter, nst);
+      assertNotNull(created.getId());
+      assertEquals(created.getName(), "Service Network");
+      assertEquals(created.isDefaultNST(), true);
+   }
+
+   public void testUpdateNetworkServiceTypeReturns2xx() {
+      InfrastructureApi api = requestSendsResponse(
+            HttpRequest.builder() //
+                  .method("PUT") //
+                  .endpoint(URI.create("http://localhost/api/admin/datacenters/1/networkservicetypes/1")) //
+                  .addHeader("Authorization", basicAuth) //
+                  .addHeader("Accept", normalize(NetworkServiceTypeDto.MEDIA_TYPE))
+                  //
+                  .payload(
+                        payloadFromResourceWithContentType("/payloads/nst-edit.xml",
+                              normalize(NetworkServiceTypeDto.MEDIA_TYPE))) //
+                  .build(),
+            HttpResponse
+                  .builder()
+                  .statusCode(200)
+                  .payload(
+                        payloadFromResourceWithContentType("/payloads/nst-edit.xml",
+                              normalize(NetworkServiceTypeDto.MEDIA_TYPE))) //
+                  .build());
+
+      NetworkServiceTypeDto nst = new NetworkServiceTypeDto();
+      RESTLink editLink = new RESTLink("edit", "http://localhost/api/admin/datacenters/1/networkservicetypes/1");
+      editLink.setType(NetworkServiceTypeDto.BASE_MEDIA_TYPE);
+      nst.addLink(editLink);
+      nst.setId(1);
+      nst.setDefaultNST(true);
+      nst.setName("Service Network");
+
+      NetworkServiceTypeDto created = api.updateNetworkServiceType(nst);
+      assertNotNull(created.getId());
+      assertEquals(created.getName(), "Service Network");
+   }
+
+   public void testDeleteNetworkServiceTypeReturns2xx() {
+      InfrastructureApi api = requestSendsResponse(HttpRequest.builder() //
+            .method("DELETE") //
+            .endpoint(URI.create("http://localhost/api/admin/datacenters/1/networkservicetypes/1")) //
+            .addHeader("Authorization", basicAuth) //
+            .build(), //
+            HttpResponse.builder().statusCode(204).build());
+
+      NetworkServiceTypeDto nst = new NetworkServiceTypeDto();
+      RESTLink editLink = new RESTLink("edit", "http://localhost/api/admin/datacenters/1/networkservicetypes/1");
+      editLink.setType(NetworkServiceTypeDto.BASE_MEDIA_TYPE);
+      nst.addLink(editLink);
+
+      api.deleteNetworkServiceType(nst);
+   }
+
+   @Override
+   protected InfrastructureApi clientFrom(AbiquoApi api) {
+      return api.getInfrastructureApi();
+   }
+
+}

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/strategy/cloud/ListAttachedNicsLiveApiTest.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/strategy/cloud/ListAttachedNicsLiveApiTest.java
@@ -23,7 +23,6 @@ import static com.google.common.collect.Iterables.size;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
 
 import org.jclouds.abiquo.domain.network.ExternalIp;
 import org.jclouds.abiquo.domain.network.Ip;
@@ -32,7 +31,6 @@ import org.jclouds.abiquo.domain.network.PublicIp;
 import org.jclouds.abiquo.domain.network.UnmanagedNetwork;
 import org.jclouds.abiquo.predicates.network.IpPredicates;
 import org.jclouds.abiquo.strategy.BaseAbiquoStrategyLiveApiTest;
-import org.jclouds.abiquo.strategy.cloud.ListAttachedNics;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;

--- a/labs/abiquo/src/test/resources/filters/filters.properties
+++ b/labs/abiquo/src/test/resources/filters/filters.properties
@@ -2,15 +2,15 @@
 # This is the Tarantino IT hypervisor.
 # Should be replaced with a dedicated ESX asap!
 
-#abiquo.hypervisor.pass=tarantino
-#abiquo.hypervisor.address=10.60.1.132
-#abiquo.hypervisor.datastore=nfs-ds
+abiquo.hypervisor.pass=tarantino
+abiquo.hypervisor.address=10.60.1.132
+abiquo.hypervisor.datastore=nfs-ds
 abiquo.hypervisor.type=VMX_04
-abiquo.hypervisor.address=10.60.20.62
-abiquo.hypervisor.pass=temporal
+#abiquo.hypervisor.address=10.60.20.62
+#abiquo.hypervisor.pass=temporal
 abiquo.hypervisor.user=root
 abiquo.hypervisor.vswitch=vSwitch0
-abiquo.hypervisor.datastore=datastore1
+#abiquo.hypervisor.datastore=datastore1
 
 # Storage configuration
 abiquo.storage.type=LVM

--- a/labs/abiquo/src/test/resources/payloads/nst-create.xml
+++ b/labs/abiquo/src/test/resources/payloads/nst-create.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<networkservicetype>
+    <defaultNST>true</defaultNST>
+    <name>Service Network</name>
+</networkservicetype>

--- a/labs/abiquo/src/test/resources/payloads/nst-edit.xml
+++ b/labs/abiquo/src/test/resources/payloads/nst-edit.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<networkservicetype>
+    <link href="http://localhost/api/admin/datacenters/1/networkservicetypes/1" type="application/vnd.abiquo.networkservicetype+xml" rel="edit"/>
+    <defaultNST>true</defaultNST>
+    <id>1</id>
+    <name>Service Network</name>
+</networkservicetype>

--- a/labs/abiquo/src/test/resources/payloads/nst-list.xml
+++ b/labs/abiquo/src/test/resources/payloads/nst-list.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<networkservicestypes>
+    <networkservicetype>
+        <link rel="edit" type="application/vnd.abiquo.networkservicetype+xml" href="http://localhost:80/api/admin/datacenters/1/networkservicetypes/3"/>
+        <defaultNST>true</defaultNST>
+        <id>1</id>
+        <name>Service Network</name>
+    </networkservicetype>
+    <networkservicetype>
+        <link rel="edit" type="application/vnd.abiquo.networkservicetype+xml" href="http://localhost:80/api/admin/datacenters/1/networkservicetypes/2"/>
+        <defaultNST>false</defaultNST>
+        <id>2</id>
+        <name>Storage Network</name>
+    </networkservicetype>
+</networkservicestypes>


### PR DESCRIPTION
Until Abiquo 2.2, all the NICs of the virtual machines were attached to the same physical Network Interface in the target host, because only one virtual switch could be enabled.

Starting from Abiquo 2.3, managed hosts can assign their virtual switches to different Network Service Types. This way hosts can have multiple virtual switches configured to work with Abiquo, and the guests can be configured to get their network interfaces attached to the appropriate network in the target host.
