### PR TITLE
Update for ServerLove pre-installed images

### DIFF
--- a/providers/serverlove-z1-man/src/main/resources/serverlove-z1-man/preinstalled_images.json
+++ b/providers/serverlove-z1-man/src/main/resources/serverlove-z1-man/preinstalled_images.json
@@ -8,6 +8,14 @@
       "loginUser": "root"
   },
   {
+      "uuid": "bcd758d4-cfc8-4d42-a707-c4bebe47900b",
+      "description": "CentOS Linux 6.2",
+      "osFamily": "CENTOS",
+      "osVersion": "6.2",
+      "size": "3",
+      "loginUser": "root"
+  },
+  {
       "uuid": "aca2fa0b-40bc-4e06-ad99-f1467690d5de",
       "description": "Debian Linux 6.0",
       "osFamily": "DEBIAN",
@@ -24,18 +32,50 @@
       "loginUser": "root"
   },
   {
-      "uuid": "85623ca1-9c2a-4398-a771-9a43c347e86b",
-      "description": "Windows Web Server 2008 R2",
+      "uuid": "80f7b359-b25f-48ea-b208-cc1f39d8bf07",
+      "description": "Ubuntu 12.04 LTS",
+      "osFamily": "UBUNTU",
+      "osVersion": "12.04",
+      "size": "1",
+      "loginUser": "root"
+  },
+  {
+      "uuid": "41993a02-0b22-4e49-bb47-0aa8975217e4",
+      "description": "Windows Server 2008 R2 Standard",
       "osFamily": "WINDOWS",
       "osVersion": "2008 R2",
       "size": "13",
       "loginUser": "Administrator"
   },
   {
-      "uuid": "41993a02-0b22-4e49-bb47-0aa8975217e4",
-      "description": "Windows Server 2008 Standard R2",
+      "uuid": "7a488d27-7b79-472c-8fbc-84dca822027e",
+      "description": "Windows Server 2008 R2 Standard SP1 with SQL Server 2008 R2 Web Edition",
       "osFamily": "WINDOWS",
-      "osVersion": "2008 R2",
+      "osVersion": "2008 R2 SP1 SQL",
+      "size": "13",
+      "loginUser": "Administrator"
+  },
+  {
+      "uuid": "a90a65b0-9452-4ac8-acfa-3e607c77cc9c",
+      "description": "Windows Server 2012 Standard",
+      "osFamily": "WINDOWS",
+      "osVersion": "2012",
+      "size": "13",
+      "loginUser": "Administrator"
+  },
+  {
+      "uuid": "85623ca1-9c2a-4398-a771-9a43c347e86b",
+      "description": "Windows Web Server 2008 R2",
+      "osFamily": "WINDOWS",
+      "osVersion": "2008 R2 Web",
+      "size": "13",
+      "loginUser": "Administrator"
+  },
+  {
+      "uuid": "9183de46-ca66-43aa-aa8a-8d172acca51d",
+      "description": "Windows Web Server 2008 R2 SP1 with SQL Server 2008 R2 Web Edition",
+      "osFamily": "WINDOWS",
+      "osVersion": "2008 R2 SP1 Web SQL",
       "size": "13",
       "loginUser": "Administrator"
   }

--- a/providers/serverlove-z1-man/src/test/java/org/jclouds/serverlove/compute/ServerloveManchesterTemplateBuilderLiveTest.java
+++ b/providers/serverlove-z1-man/src/test/java/org/jclouds/serverlove/compute/ServerloveManchesterTemplateBuilderLiveTest.java
@@ -52,13 +52,13 @@ public class ServerloveManchesterTemplateBuilderLiveTest extends BaseTemplateBui
          public boolean apply(OsFamilyVersion64Bit input) {
             switch (input.family) {
             case UBUNTU:
-               return (input.version.equals("") || input.version.equals("10.04")) && input.is64Bit;
+               return (input.version.equals("") || input.version.equals("10.04") || input.version.equals("12.04")) && input.is64Bit;
             case DEBIAN:
                return (input.version.equals("") || input.version.equals("6.0")) && input.is64Bit;
             case CENTOS:
-               return (input.version.equals("") || input.version.equals("5.7")) && input.is64Bit;
+               return (input.version.equals("") || input.version.equals("5.7") || input.version.equals("6.2")) && input.is64Bit;
             case WINDOWS:
-               return (input.version.equals("") || input.version.equals("2008 R2")) && input.is64Bit;
+               return (input.version.equals("") || input.version.equals("2008 R2") || input.version.equals("2008 R2 SP1 SQL") || input.version.equals("2012") || input.version.equals("2008 R2 Web") || input.version.equals("2008 R2 SP1 Web SQL")) && input.is64Bit;
             default:
                return false;
             }


### PR DESCRIPTION
Pre-installed images (for the ServerLove provider) are not up to date (e.g. Ubuntu 12.04 LTS is not amongst the provider listed images).

For the Windows images, I'm unsure if the osVersion field matches expectations and so this could perhaps do with some additional checking?
