### PR TITLE
added named annotations corresponding to IAM actions

### DIFF
--- a/apis/cloudwatch/src/main/java/org/jclouds/cloudwatch/CloudWatchAsyncApi.java
+++ b/apis/cloudwatch/src/main/java/org/jclouds/cloudwatch/CloudWatchAsyncApi.java
@@ -21,6 +21,7 @@ package org.jclouds.cloudwatch;
 import java.util.Date;
 import java.util.Set;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -69,6 +70,7 @@ public interface CloudWatchAsyncApi {
    /**
     * @see MetricAsyncApi#getMetricStatistics
     */
+   @Named("cloudwatch:GetMetricStatistics")
    @Deprecated
    @POST
    @Path("/")

--- a/apis/cloudwatch/src/main/java/org/jclouds/cloudwatch/features/MetricAsyncApi.java
+++ b/apis/cloudwatch/src/main/java/org/jclouds/cloudwatch/features/MetricAsyncApi.java
@@ -18,6 +18,7 @@
  */
 package org.jclouds.cloudwatch.features;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -62,6 +63,7 @@ public interface MetricAsyncApi {
    /**
     * @see MetricApi#list()
     */
+   @Named("cloudwatch:ListMetrics")
    @POST
    @Path("/")
    @XMLResponseParser(ListMetricsResponseHandler.class)
@@ -73,6 +75,7 @@ public interface MetricAsyncApi {
    /**
     * @see MetricApi#list(ListMetricsOptions)
     */
+   @Named("cloudwatch:ListMetrics")
    @POST
    @Path("/")
    @XMLResponseParser(ListMetricsResponseHandler.class)
@@ -83,6 +86,7 @@ public interface MetricAsyncApi {
    /**
     * @see MetricApi#getMetricStatistics(GetMetricStatistics)
     */
+   @Named("cloudwatch:GetMetricStatistics")
    @POST
    @Path("/")
    @XMLResponseParser(GetMetricStatisticsResponseHandlerV2.class)
@@ -93,6 +97,7 @@ public interface MetricAsyncApi {
    /**
     * @see MetricApi#getMetricStatistics(GetMetricStatistics, GetMetricStatisticsOptions)
     */
+   @Named("cloudwatch:GetMetricStatistics")
    @POST
    @Path("/")
    @XMLResponseParser(GetMetricStatisticsResponseHandlerV2.class)
@@ -104,6 +109,7 @@ public interface MetricAsyncApi {
    /**
     * @see MetricApi#putMetricsInNamespace(Iterable, String)
     */
+   @Named("cloudwatch:PutMetricData")
    @POST
    @Path("/")
    @FormParams(keys = "Action", values = "PutMetricData")

--- a/apis/ec2/src/main/java/org/jclouds/ec2/features/TagAsyncApi.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/features/TagAsyncApi.java
@@ -22,6 +22,7 @@ import static org.jclouds.aws.reference.FormParameters.ACTION;
 
 import java.util.Map;
 
+import javax.inject.Named;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 
@@ -64,6 +65,7 @@ public interface TagAsyncApi {
     * @see <a
     *      href="http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-CreateTags.html">docs</a>
     */
+   @Named("ec2:CreateTags")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreateTags")
@@ -75,6 +77,7 @@ public interface TagAsyncApi {
     * @see <a
     *      href="http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-CreateTags.html">docs</a>
     */
+   @Named("ec2:CreateTags")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreateTags")
@@ -86,6 +89,7 @@ public interface TagAsyncApi {
     * @see <a
     *      href="http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeTags.html">docs</a>
     */
+   @Named("ec2:DescribeTags")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeTags")
@@ -98,6 +102,7 @@ public interface TagAsyncApi {
     * @see <a
     *      href="http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeTags.html">docs</a>
     */
+   @Named("ec2:DescribeTags")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeTags")
@@ -111,6 +116,7 @@ public interface TagAsyncApi {
     * @see <a
     *      href="http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DeleteTags.html">docs</a>
     */
+   @Named("ec2:DeleteTags")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeleteTags")
@@ -123,6 +129,7 @@ public interface TagAsyncApi {
     * @see <a
     *      href="http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DeleteTags.html">docs</a>
     */
+   @Named("ec2:DeleteTags")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeleteTags")

--- a/apis/ec2/src/main/java/org/jclouds/ec2/features/WindowsAsyncApi.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/features/WindowsAsyncApi.java
@@ -20,6 +20,7 @@ package org.jclouds.ec2.features;
 
 import static org.jclouds.aws.reference.FormParameters.ACTION;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -55,6 +56,7 @@ public interface WindowsAsyncApi {
    /**
     * @see WindowsApi#getPasswordDataForInstance
     */
+   @Named("ec2:GetPasswordData")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "GetPasswordData")

--- a/apis/ec2/src/main/java/org/jclouds/ec2/services/AMIAsyncClient.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/services/AMIAsyncClient.java
@@ -23,6 +23,7 @@ import static org.jclouds.aws.reference.FormParameters.ACTION;
 import java.util.Map;
 import java.util.Set;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -67,6 +68,7 @@ public interface AMIAsyncClient {
    /**
     * @see AMIClient#describeImagesInRegion
     */
+   @Named("ec2:DescribeImages")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeImages")
@@ -79,6 +81,7 @@ public interface AMIAsyncClient {
    /**
     * @see AMIClient#createImageInRegion
     */
+   @Named("ec2:CreateImage")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreateImage")
@@ -90,6 +93,7 @@ public interface AMIAsyncClient {
    /**
     * @see AMIClient#deregisterImageInRegion
     */
+   @Named("ec2:DeregisterImage")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeregisterImage")
@@ -100,6 +104,7 @@ public interface AMIAsyncClient {
    /**
     * @see AMIClient#registerImageFromManifestInRegion
     */
+   @Named("ec2:RegisterImage")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "RegisterImage")
@@ -112,6 +117,7 @@ public interface AMIAsyncClient {
    /**
     * @see AMIClient#registerUnixImageBackedByEbsInRegion
     */
+   @Named("ec2:RegisterImage")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "RootDeviceName", "BlockDeviceMapping.0.DeviceName" }, values = { "RegisterImage",
@@ -126,6 +132,7 @@ public interface AMIAsyncClient {
    /**
     * @see AMIClient#resetLaunchPermissionsOnImageInRegion
     */
+   @Named("ec2:ResetImageAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "ResetImageAttribute", "launchPermission" })
@@ -136,6 +143,7 @@ public interface AMIAsyncClient {
    /**
     * @see AMIClient#addLaunchPermissionsToImageInRegion
     */
+   @Named("ec2:ModifyImageAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "OperationType", "Attribute" }, values = { "ModifyImageAttribute", "add",
@@ -149,6 +157,7 @@ public interface AMIAsyncClient {
    /**
     * @see AMIClient#removeLaunchPermissionsToImageInRegion
     */
+   @Named("ec2:ModifyImageAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "OperationType", "Attribute" }, values = { "ModifyImageAttribute", "remove",
@@ -162,6 +171,7 @@ public interface AMIAsyncClient {
    /**
     * @see AMIClient#getLaunchPermissionForImageInRegion
     */
+   @Named("ec2:DescribeImageAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeImageAttribute", "launchPermission" })
@@ -173,6 +183,7 @@ public interface AMIAsyncClient {
    /**
     * @see AMIClient#getBlockDeviceMappingsForImageInRegion
     */
+   @Named("ec2:DescribeImageAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeImageAttribute", "blockDeviceMapping" })

--- a/apis/ec2/src/main/java/org/jclouds/ec2/services/AvailabilityZoneAndRegionAsyncClient.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/services/AvailabilityZoneAndRegionAsyncClient.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.Set;
 
+import javax.inject.Named;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 
@@ -58,6 +59,7 @@ public interface AvailabilityZoneAndRegionAsyncClient {
    /**
     * @see AvailabilityZoneAndRegionClient#describeAvailabilityZonesInRegion
     */
+   @Named("ec2:DescribeAvailabilityZones")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeAvailabilityZones")
@@ -70,6 +72,7 @@ public interface AvailabilityZoneAndRegionAsyncClient {
    /**
     * @see AvailabilityZoneAndRegionClient#describeRegions
     */
+   @Named("ec2:DescribeRegions")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeRegions")

--- a/apis/ec2/src/main/java/org/jclouds/ec2/services/ElasticBlockStoreAsyncClient.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/services/ElasticBlockStoreAsyncClient.java
@@ -22,6 +22,7 @@ import static org.jclouds.aws.reference.FormParameters.ACTION;
 
 import java.util.Set;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -71,6 +72,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#createVolumeFromSnapshotInAvailabilityZone
     */
+   @Named("ec2:CreateVolume")   
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreateVolume")
@@ -82,6 +84,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#createVolumeFromSnapshotInAvailabilityZone
     */
+   @Named("ec2:CreateVolume")   
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreateVolume")
@@ -93,6 +96,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#createVolumeInAvailabilityZone
     */
+   @Named("ec2:CreateVolume")   
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreateVolume")
@@ -105,6 +109,7 @@ public interface ElasticBlockStoreAsyncClient {
     * @see ElasticBlockStoreClient#describeVolumesInRegion
     */
    @POST
+   @Named("ec2:DescribeVolumes")   
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeVolumes")
    @XMLResponseParser(DescribeVolumesResponseHandler.class)
@@ -115,6 +120,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#deleteVolumeInRegion
     */
+   @Named("ec2:DeleteVolume")   
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeleteVolume")
@@ -124,6 +130,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#detachVolumeInRegion
     */
+   @Named("ec2:DetachVolume")   
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DetachVolume")
@@ -134,6 +141,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#attachVolumeInRegion
     */
+   @Named("ec2:AttachVolume")   
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "AttachVolume")
@@ -146,6 +154,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#createSnapshotInRegion
     */
+   @Named("ec2:CreateSnapshot")   
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreateSnapshot")
@@ -157,6 +166,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#describeSnapshotsInRegion
     */
+   @Named("ec2:DescribeSnapshots")   
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeSnapshots")
@@ -169,6 +179,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#deleteSnapshotInRegion
     */
+   @Named("ec2:DeleteSnapshot")   
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeleteSnapshot")
@@ -179,6 +190,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#addCreateVolumePermissionsToSnapshotInRegion
     */
+   @Named("ec2:ModifySnapshotAttribute")   
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "OperationType", "Attribute" }, values = { "ModifySnapshotAttribute", "add",
@@ -192,6 +204,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#removeCreateVolumePermissionsFromSnapshotInRegion
     */
+   @Named("ec2:ModifySnapshotAttribute")   
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "OperationType", "Attribute" }, values = { "ModifySnapshotAttribute", "remove",
@@ -205,6 +218,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#getCreateVolumePermissionForSnapshotInRegion
     */
+   @Named("ec2:DescribeSnapshotAttribute")   
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeSnapshotAttribute", "createVolumePermission" })
@@ -216,6 +230,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#resetCreateVolumePermissionsOnSnapshotInRegion
     */
+   @Named("ec2:ResetSnapshotAttribute")   
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "ResetSnapshotAttribute", "createVolumePermission" })

--- a/apis/ec2/src/main/java/org/jclouds/ec2/services/ElasticIPAddressAsyncClient.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/services/ElasticIPAddressAsyncClient.java
@@ -22,6 +22,7 @@ import static org.jclouds.aws.reference.FormParameters.ACTION;
 
 import java.util.Set;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -57,6 +58,7 @@ public interface ElasticIPAddressAsyncClient {
    /**
     * @see BaseEC2Client#allocateAddressInRegion
     */
+   @Named("ec2:AllocateAddress")
    @POST
    @Path("/")
    @XMLResponseParser(AllocateAddressResponseHandler.class)
@@ -67,6 +69,7 @@ public interface ElasticIPAddressAsyncClient {
    /**
     * @see BaseEC2Client#associateAddressInRegion
     */
+   @Named("ec2:AssociateAddress")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "AssociateAddress")
@@ -77,6 +80,7 @@ public interface ElasticIPAddressAsyncClient {
    /**
     * @see BaseEC2Client#disassociateAddressInRegion
     */
+   @Named("ec2:DisassociateAddress")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DisassociateAddress")
@@ -87,6 +91,7 @@ public interface ElasticIPAddressAsyncClient {
    /**
     * @see BaseEC2Client#releaseAddressInRegion
     */
+   @Named("ec2:ReleaseAddress")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ReleaseAddress")
@@ -97,6 +102,7 @@ public interface ElasticIPAddressAsyncClient {
    /**
     * @see BaseEC2Client#describeAddressesInRegion
     */
+   @Named("ec2:DescribeAddresses")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeAddresses")

--- a/apis/ec2/src/main/java/org/jclouds/ec2/services/InstanceAsyncClient.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/services/InstanceAsyncClient.java
@@ -23,6 +23,7 @@ import static org.jclouds.aws.reference.FormParameters.ACTION;
 import java.util.Map;
 import java.util.Set;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -75,6 +76,7 @@ public interface InstanceAsyncClient {
    /**
     * @see InstanceClient#describeInstancesInRegion
     */
+   @Named("ec2:DescribeInstances")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeInstances")
@@ -87,6 +89,7 @@ public interface InstanceAsyncClient {
    /**
     * @see InstanceClient#runInstancesInRegion
     */
+   @Named("ec2:RunInstances")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "RunInstances")
@@ -100,6 +103,7 @@ public interface InstanceAsyncClient {
    /**
     * @see InstanceClient#rebootInstancesInRegion
     */
+   @Named("ec2:RebootInstances")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "RebootInstances")
@@ -110,6 +114,7 @@ public interface InstanceAsyncClient {
    /**
     * @see InstanceClient#terminateInstancesInRegion
     */
+   @Named("ec2:TerminateInstances")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "TerminateInstances")
@@ -122,6 +127,7 @@ public interface InstanceAsyncClient {
    /**
     * @see InstanceClient#stopInstancesInRegion
     */
+   @Named("ec2:StopInstances")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "StopInstances")
@@ -134,6 +140,7 @@ public interface InstanceAsyncClient {
    /**
     * @see InstanceClient#startInstancesInRegion
     */
+   @Named("ec2:StartInstances")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "StartInstances")
@@ -145,6 +152,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#getUserDataForInstanceInRegion
     */
+   @Named("ec2:DescribeInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeInstanceAttribute", "userData" })
@@ -156,6 +164,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#getRootDeviceNameForInstanceInRegion
     */
+   @Named("ec2:DescribeInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeInstanceAttribute", "rootDeviceName" })
@@ -167,6 +176,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#getRamdiskForInstanceInRegion
     */
+   @Named("ec2:DescribeInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeInstanceAttribute", "ramdisk" })
@@ -178,6 +188,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#getKernelForInstanceInRegion
     */
+   @Named("ec2:DescribeInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeInstanceAttribute", "kernel" })
@@ -189,6 +200,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#isApiTerminationDisabledForInstanceInRegion
     */
+   @Named("ec2:DescribeInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeInstanceAttribute", "disableApiTermination" })
@@ -200,6 +212,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#getInstanceTypeForInstanceInRegion
     */
+   @Named("ec2:DescribeInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeInstanceAttribute", "instanceType" })
@@ -211,6 +224,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#getInstanceInitiatedShutdownBehaviorForInstanceInRegion
     */
+   @Named("ec2:DescribeInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeInstanceAttribute",
@@ -223,6 +237,7 @@ public interface InstanceAsyncClient {
    /**
     * @see InstanceClient#getBlockDeviceMappingForInstanceInRegion
     */
+   @Named("ec2:DescribeInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeInstanceAttribute", "blockDeviceMapping" })
@@ -234,6 +249,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#resetRamdiskForInstanceInRegion
     */
+   @Named("ec2:ResetInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "ResetInstanceAttribute", "ramdisk" })
@@ -244,6 +260,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#resetKernelForInstanceInRegion
     */
+   @Named("ec2:ResetInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "ResetInstanceAttribute", "kernel" })
@@ -254,6 +271,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#setUserDataForInstanceInRegion
     */
+   @Named("ec2:ModifyInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "ModifyInstanceAttribute", "userData" })
@@ -265,6 +283,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#setRamdiskForInstanceInRegion
     */
+   @Named("ec2:ModifyInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "ModifyInstanceAttribute", "ramdisk" })
@@ -275,6 +294,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#setKernelForInstanceInRegion
     */
+   @Named("ec2:ModifyInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "ModifyInstanceAttribute", "kernel" })
@@ -285,6 +305,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#setApiTerminationDisabledForInstanceInRegion
     */
+   @Named("ec2:ModifyInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "ModifyInstanceAttribute", "disableApiTermination" })
@@ -295,6 +316,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#setInstanceTypeForInstanceInRegion
     */
+   @Named("ec2:ModifyInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "ModifyInstanceAttribute", "instanceType" })
@@ -305,6 +327,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#setInstanceInitiatedShutdownBehaviorForInstanceInRegion
     */
+   @Named("ec2:ModifyInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "ModifyInstanceAttribute",
@@ -317,6 +340,7 @@ public interface InstanceAsyncClient {
    /**
     * @see InstanceClient#setBlockDeviceMappingForInstanceInRegion
     */
+   @Named("ec2:ModifyInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION }, values = { "ModifyInstanceAttribute" })
@@ -328,6 +352,7 @@ public interface InstanceAsyncClient {
    /**
     * @see InstanceClient#getConsoleOutputForInstanceInRegion(String, String)
     */
+   @Named("ec2:GetConsoleOutput")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION }, values = { "GetConsoleOutput" })

--- a/apis/ec2/src/main/java/org/jclouds/ec2/services/KeyPairAsyncClient.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/services/KeyPairAsyncClient.java
@@ -22,6 +22,7 @@ import static org.jclouds.aws.reference.FormParameters.ACTION;
 
 import java.util.Set;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -57,6 +58,7 @@ public interface KeyPairAsyncClient {
    /**
     * @see KeyPairClient#createKeyPairInRegion
     */
+   @Named("ec2:CreateKeyPair")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreateKeyPair")
@@ -68,6 +70,7 @@ public interface KeyPairAsyncClient {
    /**
     * @see KeyPairClient#describeKeyPairsInRegion
     */
+   @Named("ec2:DescribeKeyPairs")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeKeyPairs")
@@ -80,6 +83,7 @@ public interface KeyPairAsyncClient {
    /**
     * @see KeyPairClient#deleteKeyPairInRegion
     */
+   @Named("ec2:DeleteKeyPair")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeleteKeyPair")

--- a/apis/ec2/src/main/java/org/jclouds/ec2/services/SecurityGroupAsyncClient.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/services/SecurityGroupAsyncClient.java
@@ -22,6 +22,7 @@ import static org.jclouds.aws.reference.FormParameters.ACTION;
 
 import java.util.Set;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -60,6 +61,7 @@ public interface SecurityGroupAsyncClient {
    /**
     * @see SecurityGroupClient#createSecurityGroupInRegion
     */
+   @Named("ec2:CreateSecurityGroup")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreateSecurityGroup")
@@ -70,6 +72,7 @@ public interface SecurityGroupAsyncClient {
    /**
     * @see SecurityGroupClient#deleteSecurityGroupInRegion
     */
+   @Named("ec2:DeleteSecurityGroup")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeleteSecurityGroup")
@@ -80,6 +83,7 @@ public interface SecurityGroupAsyncClient {
    /**
     * @see SecurityGroupClient#describeSecurityGroupsInRegion
     */
+   @Named("ec2:DescribeSecurityGroups")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeSecurityGroups")
@@ -93,6 +97,7 @@ public interface SecurityGroupAsyncClient {
     * @see SecurityGroupClient#authorizeSecurityGroupIngressInRegion(@ org.jclouds.javax.annotation.Nullable Region,
     *      String,UserIdGroupPair)
     */
+   @Named("ec2:AuthorizeSecurityGroupIngress")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "AuthorizeSecurityGroupIngress")
@@ -105,6 +110,7 @@ public interface SecurityGroupAsyncClient {
     * @see SecurityGroupClient#authorizeSecurityGroupIngressInRegion(@ org.jclouds.javax.annotation.Nullable Region,
     *      String,IpProtocol,int,int,String)
     */
+   @Named("ec2:AuthorizeSecurityGroupIngress")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "AuthorizeSecurityGroupIngress")
@@ -117,6 +123,7 @@ public interface SecurityGroupAsyncClient {
     * @see SecurityGroupClient#revokeSecurityGroupIngressInRegion(@Nullable Region,
     *      String,UserIdGroupPair)
     */
+   @Named("ec2:RevokeSecurityGroupIngress")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "RevokeSecurityGroupIngress")
@@ -129,6 +136,7 @@ public interface SecurityGroupAsyncClient {
     * @see SecurityGroupClient#revokeSecurityGroupIngressInRegion(@ org.jclouds.javax.annotation.Nullable Region,
     *      String,IpProtocol,int,int,String)
     */
+   @Named("ec2:RevokeSecurityGroupIngress")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "RevokeSecurityGroupIngress")

--- a/apis/ec2/src/main/java/org/jclouds/ec2/services/WindowsAsyncClient.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/services/WindowsAsyncClient.java
@@ -22,6 +22,7 @@ import static org.jclouds.aws.reference.FormParameters.ACTION;
 
 import java.util.Set;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -61,6 +62,7 @@ public interface WindowsAsyncClient {
    /**
     * @see WindowsClient#bundleInstanceInRegion
     */
+   @Named("ec2:BundleInstance")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "BundleInstance")
@@ -75,6 +77,7 @@ public interface WindowsAsyncClient {
    /**
     * @see WindowsClient#cancelBundleTaskInRegion
     */
+   @Named("ec2:CancelBundleTask")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CancelBundleTask")
@@ -86,6 +89,7 @@ public interface WindowsAsyncClient {
    /**
     * @see BundleTaskClient#describeBundleTasksInRegion
     */
+   @Named("ec2:DescribeBundleTasks")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeBundleTasks")
@@ -98,6 +102,7 @@ public interface WindowsAsyncClient {
    /**
     * @see WindowsClient#getPasswordDataInRegion
     */
+   @Named("ec2:GetPasswordData")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "GetPasswordData")

--- a/apis/s3/src/main/java/org/jclouds/s3/S3AsyncClient.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/S3AsyncClient.java
@@ -22,6 +22,7 @@ import static org.jclouds.blobstore.attr.BlobScopes.CONTAINER;
 
 import java.util.Set;
 
+import javax.inject.Named;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.HEAD;
@@ -119,6 +120,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#getObject
     */
+   @Named("s3:GetObject")
    @GET
    @Path("/{key}")
    @ExceptionParser(ReturnNullOnKeyNotFound.class)
@@ -130,6 +132,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#headObject
     */
+   @Named("s3:GetObject")
    @HEAD
    @Path("/{key}")
    @ExceptionParser(ReturnNullOnKeyNotFound.class)
@@ -141,6 +144,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#objectExists
     */
+   @Named("s3:GetObject")
    @HEAD
    @Path("/{key}")
    @ExceptionParser(ReturnFalseOnKeyNotFound.class)
@@ -151,6 +155,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#deleteObject
     */
+   @Named("s3:DeleteObject")
    @DELETE
    @Path("/{key}")
    @ExceptionParser(ReturnVoidOnNotFoundOr404.class)
@@ -161,6 +166,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#putObject
     */
+   @Named("s3:PutObject")
    @PUT
    @Path("/{key}")
    @ResponseParser(ParseETagHeader.class)
@@ -172,6 +178,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#putBucketInRegion
     */
+   @Named("s3:CreateBucket")
    @PUT
    @Path("/")
    @Endpoint(Bucket.class)
@@ -184,6 +191,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#deleteBucketIfEmpty
     */
+   @Named("s3:DeleteBucket")
    @DELETE
    @Path("/")
    @ExceptionParser(ReturnTrueOn404OrNotFoundFalseOnIllegalState.class)
@@ -193,6 +201,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#bucketExists
     */
+   @Named("s3:ListBucket")
    @HEAD
    @Path("/")
    @QueryParams(keys = "max-keys", values = "0")
@@ -204,6 +213,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#getBucketLocation
     */
+   @Named("s3:GetBucketLocation")
    @GET
    @QueryParams(keys = "location")
    @Path("/")
@@ -215,6 +225,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#getBucketPayer
     */
+   @Named("s3:GetBucketRequestPayment")
    @GET
    @QueryParams(keys = "requestPayment")
    @Path("/")
@@ -225,6 +236,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#setBucketPayer
     */
+   @Named("s3:PutBucketRequestPayment")
    @PUT
    @QueryParams(keys = "requestPayment")
    @Path("/")
@@ -235,6 +247,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#listBucket
     */
+   @Named("s3:ListBucket")
    @GET
    @Path("/")
    @XMLResponseParser(ListBucketHandler.class)
@@ -245,6 +258,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#listOwnedBuckets
     */
+   @Named("s3:ListAllMyBuckets")
    @GET
    @XMLResponseParser(ListAllMyBucketsHandler.class)
    @Path("/")
@@ -254,6 +268,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#copyObject
     */
+   @Named("s3:PutObject")
    @PUT
    @Path("/{destinationObject}")
    @Headers(keys = "x-amz-copy-source", values = "/{sourceBucket}/{sourceObject}")
@@ -267,6 +282,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#getBucketACL
     */
+   @Named("s3:GetBucketAcl")
    @GET
    @QueryParams(keys = "acl")
    @XMLResponseParser(AccessControlListHandler.class)
@@ -278,6 +294,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#putBucketACL
     */
+   @Named("s3:PutBucketAcl")
    @PUT
    @Path("/")
    @QueryParams(keys = "acl")
@@ -288,6 +305,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#getObjectACL
     */
+   @Named("s3:GetObjectAcl")
    @GET
    @QueryParams(keys = "acl")
    @Path("/{key}")
@@ -300,6 +318,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#putObjectACL
     */
+   @Named("s3:PutObjectAcl")
    @PUT
    @QueryParams(keys = "acl")
    @Path("/{key}")
@@ -310,6 +329,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#getBucketLogging
     */
+   @Named("s3:GetBucketLogging")
    @GET
    @QueryParams(keys = "logging")
    @XMLResponseParser(BucketLoggingHandler.class)
@@ -321,6 +341,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#enableBucketLogging
     */
+   @Named("s3:PutBucketLogging")
    @PUT
    @Path("/")
    @QueryParams(keys = "logging")
@@ -331,6 +352,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#putBucketLogging
     */
+   @Named("s3:PutBucketLogging")
    @PUT
    @Path("/")
    @QueryParams(keys = "logging")

--- a/apis/sqs/src/main/java/org/jclouds/sqs/features/MessageAsyncApi.java
+++ b/apis/sqs/src/main/java/org/jclouds/sqs/features/MessageAsyncApi.java
@@ -23,6 +23,7 @@ import static org.jclouds.sqs.reference.SQSParameters.VERSION;
 
 import java.util.Map;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -73,6 +74,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#delete(String)
     */
+   @Named("sqs:DeleteMessage")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeleteMessage")
@@ -82,6 +84,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#delete(Map)
     */
+   @Named("sqs:DeleteMessageBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeleteMessageBatch")
@@ -92,6 +95,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#delete(Iterable)
     */
+   @Named("sqs:DeleteMessageBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeleteMessageBatch")
@@ -102,6 +106,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#changeVisibility(String, int)
     */
+   @Named("sqs:ChangeMessageVisibility")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ChangeMessageVisibility")
@@ -111,6 +116,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#changeVisibility(Table)
     */
+   @Named("sqs:ChangeMessageVisibilityBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ChangeMessageVisibilityBatch")
@@ -121,6 +127,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#changeVisibility(Map)
     */
+   @Named("sqs:ChangeMessageVisibilityBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ChangeMessageVisibilityBatch")
@@ -131,6 +138,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#changeVisibility(Map, int)
     */
+   @Named("sqs:ChangeMessageVisibilityBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ChangeMessageVisibilityBatch")
@@ -143,6 +151,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#changeVisibility(Iterable, int)
     */
+   @Named("sqs:ChangeMessageVisibilityBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ChangeMessageVisibilityBatch")
@@ -155,6 +164,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#send(String)
     */
+   @Named("sqs:SendMessage")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "SendMessage")
@@ -164,6 +174,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#send(String, SendMessageOptions)
     */
+   @Named("sqs:SendMessage")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "SendMessage")
@@ -173,6 +184,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#sendWithDelays(Table)
     */
+   @Named("sqs:SendMessageBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "SendMessageBatch")
@@ -184,6 +196,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#sendWithDelays(Map)
     */
+   @Named("sqs:SendMessageBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "SendMessageBatch")
@@ -195,6 +208,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#sendWithDelay(Map, int)
     */
+   @Named("sqs:SendMessageBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "SendMessageBatch")
@@ -207,6 +221,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#sendWithDelay(Iterable, int)
     */
+   @Named("sqs:SendMessageBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "SendMessageBatch")
@@ -218,6 +233,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#send(Map)
     */
+   @Named("sqs:SendMessageBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "SendMessageBatch")
@@ -228,6 +244,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#send(Iterable)
     */
+   @Named("sqs:SendMessageBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "SendMessageBatch")
@@ -238,6 +255,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#receive()
     */
+   @Named("sqs:ReceiveMessage")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ReceiveMessage")
@@ -247,6 +265,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#receive(ReceiveMessageOptions)
     */
+   @Named("sqs:ReceiveMessage")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ReceiveMessage")
@@ -256,6 +275,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#receive(int)
     */
+   @Named("sqs:ReceiveMessage")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ReceiveMessage")
@@ -265,6 +285,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#receive(int, ReceiveMessageOptions)
     */
+   @Named("sqs:ReceiveMessage")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ReceiveMessage")

--- a/apis/sqs/src/main/java/org/jclouds/sqs/features/PermissionAsyncApi.java
+++ b/apis/sqs/src/main/java/org/jclouds/sqs/features/PermissionAsyncApi.java
@@ -21,6 +21,7 @@ package org.jclouds.sqs.features;
 import static org.jclouds.sqs.reference.SQSParameters.ACTION;
 import static org.jclouds.sqs.reference.SQSParameters.VERSION;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -48,6 +49,7 @@ public interface PermissionAsyncApi {
    /**
     * @see PermissionApi#addPermissionToAccount
     */
+   @Named("sqs:AddPermission")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "AddPermission")
@@ -57,6 +59,7 @@ public interface PermissionAsyncApi {
    /**
     * @see PermissionApi#remove
     */
+   @Named("sqs:RemovePermission")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "RemovePermission")

--- a/apis/sqs/src/main/java/org/jclouds/sqs/features/QueueAsyncApi.java
+++ b/apis/sqs/src/main/java/org/jclouds/sqs/features/QueueAsyncApi.java
@@ -24,6 +24,7 @@ import static org.jclouds.sqs.reference.SQSParameters.VERSION;
 import java.net.URI;
 import java.util.Map;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -68,6 +69,7 @@ public interface QueueAsyncApi {
    /**
     * @see QueueApi#list
     */
+   @Named("sqs:ListQueues")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ListQueues")
@@ -77,6 +79,7 @@ public interface QueueAsyncApi {
    /**
     * @see QueueApi#list(ListQueuesOptions)
     */
+   @Named("sqs:ListQueues")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ListQueues")
@@ -86,6 +89,7 @@ public interface QueueAsyncApi {
    /**
     * @see QueueApi#get(String)
     */
+   @Named("sqs:GetQueueUrl")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "GetQueueUrl")
@@ -96,6 +100,7 @@ public interface QueueAsyncApi {
    /**
     * @see QueueApi#getInAccount
     */
+   @Named("sqs:GetQueueUrl")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "GetQueueUrl")
@@ -107,6 +112,7 @@ public interface QueueAsyncApi {
    /**
     * @see QueueApi#create
     */
+   @Named("sqs:CreateQueue")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreateQueue")
@@ -116,6 +122,7 @@ public interface QueueAsyncApi {
    /**
     * @see QueueApi#create
     */
+   @Named("sqs:CreateQueue")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreateQueue")
@@ -125,6 +132,7 @@ public interface QueueAsyncApi {
    /**
     * @see QueueApi#delete
     */
+   @Named("sqs:DeleteQueue")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeleteQueue")
@@ -134,6 +142,7 @@ public interface QueueAsyncApi {
    /**
     * @see QueueApi#getAttributes(URI)
     */
+   @Named("sqs:GetQueueAttributes")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "AttributeName.1" }, values = { "GetQueueAttributes", "All" })
@@ -145,6 +154,7 @@ public interface QueueAsyncApi {
    /**
     * @see QueueApi#getAttributes(URI, Iterable)
     */
+   @Named("sqs:GetQueueAttributes")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "GetQueueAttributes")
@@ -155,6 +165,7 @@ public interface QueueAsyncApi {
    /**
     * @see QueueApi#getAttribute
     */
+   @Named("sqs:GetQueueAttributes")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "GetQueueAttributes")
@@ -164,6 +175,7 @@ public interface QueueAsyncApi {
    /**
     * @see QueueApi#setAttribute
     */
+   @Named("sqs:SetQueueAttributes")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "SetQueueAttributes")

--- a/labs/elb/src/main/java/org/jclouds/elb/features/AvailabilityZoneAsyncApi.java
+++ b/labs/elb/src/main/java/org/jclouds/elb/features/AvailabilityZoneAsyncApi.java
@@ -22,6 +22,7 @@ import static org.jclouds.aws.reference.FormParameters.ACTION;
 
 import java.util.Set;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -53,6 +54,7 @@ public interface AvailabilityZoneAsyncApi {
    /**
     * @see AvailabilityZoneApi#addAvailabilityZonesToLoadBalancer
     */
+   @Named("elasticloadbalancing:EnableAvailabilityZonesForLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(AvailabilityZonesResultHandler.class)
@@ -65,6 +67,7 @@ public interface AvailabilityZoneAsyncApi {
    /**
     * @see AvailabilityZoneApi#addAvailabilityZoneToLoadBalancer
     */
+   @Named("elasticloadbalancing:EnableAvailabilityZonesForLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(AvailabilityZonesResultHandler.class)
@@ -76,6 +79,7 @@ public interface AvailabilityZoneAsyncApi {
    /**
     * @see AvailabilityZoneApi#removeAvailabilityZonesFromLoadBalancer
     */
+   @Named("elasticloadbalancing:DisableAvailabilityZonesForLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(AvailabilityZonesResultHandler.class)
@@ -87,6 +91,7 @@ public interface AvailabilityZoneAsyncApi {
    /**
     * @see AvailabilityZoneApi#removeAvailabilityZoneFromLoadBalancer
     */
+   @Named("elasticloadbalancing:DisableAvailabilityZonesForLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(AvailabilityZonesResultHandler.class)

--- a/labs/elb/src/main/java/org/jclouds/elb/features/InstanceAsyncApi.java
+++ b/labs/elb/src/main/java/org/jclouds/elb/features/InstanceAsyncApi.java
@@ -22,6 +22,7 @@ import static org.jclouds.aws.reference.FormParameters.ACTION;
 
 import java.util.Set;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -57,6 +58,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#getHealthOfInstancesOfLoadBalancer(String)
     */
+   @Named("elasticloadbalancing:DescribeInstanceHealth")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeInstanceHealthResultHandler.class)
@@ -68,6 +70,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#getHealthOfInstancesOfLoadBalancer(Iterable, String)
     */
+   @Named("elasticloadbalancing:DescribeInstanceHealth")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeInstanceHealthResultHandler.class)
@@ -81,6 +84,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#registerInstancesWithLoadBalancer
     */
+   @Named("elasticloadbalancing:RegisterInstancesWithLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(InstancesResultHandler.class)
@@ -93,6 +97,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#registerInstanceWithLoadBalancer
     */
+   @Named("elasticloadbalancing:RegisterInstancesWithLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(InstancesResultHandler.class)
@@ -104,6 +109,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#deregisterInstancesFromLoadBalancer
     */
+   @Named("elasticloadbalancing:DeregisterInstancesFromLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(InstancesResultHandler.class)
@@ -115,6 +121,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#deregisterInstanceFromLoadBalancer
     */
+   @Named("elasticloadbalancing:DeregisterInstancesFromLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(InstancesResultHandler.class)

--- a/labs/elb/src/main/java/org/jclouds/elb/features/LoadBalancerAsyncApi.java
+++ b/labs/elb/src/main/java/org/jclouds/elb/features/LoadBalancerAsyncApi.java
@@ -20,6 +20,7 @@ package org.jclouds.elb.features;
 
 import static org.jclouds.aws.reference.FormParameters.ACTION;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -67,6 +68,7 @@ public interface LoadBalancerAsyncApi {
    /**
     * @see LoadBalancerApi#createListeningInAvailabilityZones()
     */
+   @Named("elasticloadbalancing:CreateLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(CreateLoadBalancerResponseHandler.class)
@@ -78,6 +80,7 @@ public interface LoadBalancerAsyncApi {
    /**
     * @see LoadBalancerApi#createListeningInAvailabilityZones()
     */
+   @Named("elasticloadbalancing:CreateLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(CreateLoadBalancerResponseHandler.class)
@@ -89,6 +92,7 @@ public interface LoadBalancerAsyncApi {
    /**
     * @see LoadBalancerApi#createListeningInSubnetAssignedToSecurityGroups()
     */
+   @Named("elasticloadbalancing:CreateLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(CreateLoadBalancerResponseHandler.class)
@@ -101,6 +105,7 @@ public interface LoadBalancerAsyncApi {
    /**
     * @see LoadBalancerApi#createListeningInSubnetsAssignedToSecurityGroups()
     */
+   @Named("elasticloadbalancing:CreateLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(CreateLoadBalancerResponseHandler.class)
@@ -113,6 +118,7 @@ public interface LoadBalancerAsyncApi {
    /**
     * @see LoadBalancerApi#get()
     */
+   @Named("elasticloadbalancing:DescribeLoadBalancers")
    @POST
    @Path("/")
    @XMLResponseParser(LoadBalancerHandler.class)
@@ -123,6 +129,7 @@ public interface LoadBalancerAsyncApi {
    /**
     * @see LoadBalancerApi#list()
     */
+   @Named("elasticloadbalancing:DescribeLoadBalancers")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeLoadBalancersResultHandler.class)
@@ -134,6 +141,7 @@ public interface LoadBalancerAsyncApi {
    /**
     * @see LoadBalancerApi#list(ListLoadBalancersOptions)
     */
+   @Named("elasticloadbalancing:DescribeLoadBalancers")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeLoadBalancersResultHandler.class)
@@ -144,6 +152,7 @@ public interface LoadBalancerAsyncApi {
    /**
     * @see LoadBalancerApi#delete()
     */
+   @Named("elasticloadbalancing:DeleteLoadBalancer")
    @POST
    @Path("/")
    @ExceptionParser(ReturnVoidOnNotFoundOr404.class)

--- a/labs/elb/src/main/java/org/jclouds/elb/features/PolicyAsyncApi.java
+++ b/labs/elb/src/main/java/org/jclouds/elb/features/PolicyAsyncApi.java
@@ -20,6 +20,7 @@ package org.jclouds.elb.features;
 
 import java.util.Set;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -59,6 +60,7 @@ public interface PolicyAsyncApi {
    /**
     * @see PolicyApi#get()
     */
+   @Named("elasticloadbalancing:DescribeLoadBalancerPolicies")
    @POST
    @Path("/")
    @XMLResponseParser(PolicyHandler.class)
@@ -69,6 +71,7 @@ public interface PolicyAsyncApi {
    /**
     * @see PolicyApi#list()
     */
+   @Named("elasticloadbalancing:DescribeLoadBalancerPolicies")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeLoadBalancerPoliciesResultHandler.class)
@@ -79,6 +82,7 @@ public interface PolicyAsyncApi {
    /**
     * @see PolicyApi#list(ListPoliciesOptions)
     */
+   @Named("elasticloadbalancing:DescribeLoadBalancerPolicies")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeLoadBalancerPoliciesResultHandler.class)
@@ -90,6 +94,7 @@ public interface PolicyAsyncApi {
    /**
     * @see PolicyApi#getType()
     */
+   @Named("elasticloadbalancing:DescribeLoadBalancerPolicyTypes")
    @POST
    @Path("/")
    @XMLResponseParser(PolicyTypeHandler.class)
@@ -100,6 +105,7 @@ public interface PolicyAsyncApi {
    /**
     * @see PolicyApi#listTypes()
     */
+   @Named("elasticloadbalancing:DescribeLoadBalancerPolicyTypes")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeLoadBalancerPolicyTypesResultHandler.class)
@@ -110,6 +116,7 @@ public interface PolicyAsyncApi {
    /**
     * @see PolicyApi#listTypes(Iterable<String>)
     */
+   @Named("elasticloadbalancing:DescribeLoadBalancerPolicyTypes")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeLoadBalancerPolicyTypesResultHandler.class)

--- a/labs/iam/src/main/java/org/jclouds/iam/IAMAsyncApi.java
+++ b/labs/iam/src/main/java/org/jclouds/iam/IAMAsyncApi.java
@@ -18,6 +18,7 @@
  */
 package org.jclouds.iam;
 
+import javax.inject.Named;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 
@@ -49,6 +50,7 @@ public interface IAMAsyncApi {
    /**
     * @see IAMApi#getCurrentUser()
     */
+   @Named("iam:GetUser")
    @POST
    @Path("/")
    @XMLResponseParser(UserHandler.class)

--- a/labs/iam/src/main/java/org/jclouds/iam/features/UserAsyncApi.java
+++ b/labs/iam/src/main/java/org/jclouds/iam/features/UserAsyncApi.java
@@ -18,6 +18,7 @@
  */
 package org.jclouds.iam.features;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -54,6 +55,7 @@ public interface UserAsyncApi {
    /**
     * @see UserApi#getCurrent()
     */
+   @Named("iam:GetUser")
    @POST
    @Path("/")
    @XMLResponseParser(UserHandler.class)
@@ -63,6 +65,7 @@ public interface UserAsyncApi {
    /**
     * @see UserApi#get()
     */
+   @Named("iam:GetUser")
    @POST
    @Path("/")
    @XMLResponseParser(UserHandler.class)
@@ -73,6 +76,7 @@ public interface UserAsyncApi {
    /**
     * @see UserApi#list()
     */
+   @Named("iam:ListUsers")
    @POST
    @Path("/")
    @XMLResponseParser(ListUsersResultHandler.class)
@@ -83,6 +87,7 @@ public interface UserAsyncApi {
    /**
     * @see UserApi#list(ListUsersOptions)
     */
+   @Named("iam:ListUsers")
    @POST
    @Path("/")
    @XMLResponseParser(ListUsersResultHandler.class)

--- a/labs/rds/src/main/java/org/jclouds/rds/features/InstanceAsyncApi.java
+++ b/labs/rds/src/main/java/org/jclouds/rds/features/InstanceAsyncApi.java
@@ -20,6 +20,7 @@ package org.jclouds.rds.features;
 
 import static org.jclouds.aws.reference.FormParameters.ACTION;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -60,6 +61,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#create
     */
+   @Named("rds:CreateDBInstance")
    @POST
    @Path("/")
    @XMLResponseParser(InstanceHandler.class)
@@ -70,6 +72,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#createInAvailabilityZone
     */
+   @Named("rds:CreateDBInstance")
    @POST
    @Path("/")
    @XMLResponseParser(InstanceHandler.class)
@@ -81,6 +84,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#createMultiAZ
     */
+   @Named("rds:CreateDBInstance")
    @POST
    @Path("/")
    @XMLResponseParser(InstanceHandler.class)
@@ -91,6 +95,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#get()
     */
+   @Named("rds:DescribeDBInstances")
    @POST
    @Path("/")
    @XMLResponseParser(InstanceHandler.class)
@@ -101,6 +106,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#list()
     */
+   @Named("rds:DescribeDBInstances")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeDBInstancesResultHandler.class)
@@ -111,6 +117,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#list(ListInstancesOptions)
     */
+   @Named("rds:DescribeDBInstances")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeDBInstancesResultHandler.class)
@@ -120,6 +127,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#delete()
     */
+   @Named("rds:DeleteDBInstance")
    @POST
    @Path("/")
    @XMLResponseParser(InstanceHandler.class)
@@ -130,6 +138,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#deleteAndSaveSnapshot
     */
+   @Named("rds:DeleteDBInstance")
    @POST
    @Path("/")
    @XMLResponseParser(InstanceHandler.class)

--- a/labs/rds/src/main/java/org/jclouds/rds/features/SecurityGroupAsyncApi.java
+++ b/labs/rds/src/main/java/org/jclouds/rds/features/SecurityGroupAsyncApi.java
@@ -20,6 +20,7 @@ package org.jclouds.rds.features;
 
 import static org.jclouds.aws.reference.FormParameters.ACTION;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -57,6 +58,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#createWithNameAndDescription
     */
+   @Named("rds:CreateDBSecurityGroup")
    @POST
    @Path("/")
    @XMLResponseParser(SecurityGroupHandler.class)
@@ -67,6 +69,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#createInVPCWithNameAndDescription
     */
+   @Named("rds:CreateDBSecurityGroup")
    @POST
    @Path("/")
    @XMLResponseParser(SecurityGroupHandler.class)
@@ -77,6 +80,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#get()
     */
+   @Named("rds:DescribeDBSecurityGroups")
    @POST
    @Path("/")
    @XMLResponseParser(SecurityGroupHandler.class)
@@ -87,6 +91,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#list()
     */
+   @Named("rds:DescribeDBSecurityGroups")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeDBSecurityGroupsResultHandler.class)
@@ -97,6 +102,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#list(ListSecurityGroupsOptions)
     */
+   @Named("rds:DescribeDBSecurityGroups")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeDBSecurityGroupsResultHandler.class)
@@ -106,6 +112,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#authorizeIngressToIPRange
     */
+   @Named("rds:AuthorizeDBSecurityGroupIngress")
    @POST
    @Path("/")
    @XMLResponseParser(SecurityGroupHandler.class)
@@ -116,6 +123,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#authorizeIngressToEC2SecurityGroupOfOwner
     */
+   @Named("rds:AuthorizeDBSecurityGroupIngress")
    @POST
    @Path("/")
    @XMLResponseParser(SecurityGroupHandler.class)
@@ -128,6 +136,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#authorizeIngressToVPCSecurityGroup
     */
+   @Named("rds:AuthorizeDBSecurityGroupIngress")
    @POST
    @Path("/")
    @XMLResponseParser(SecurityGroupHandler.class)
@@ -139,6 +148,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#revokeIngressFromIPRange
     */
+   @Named("rds:RevokeDBSecurityGroupIngress")
    @POST
    @Path("/")
    @XMLResponseParser(SecurityGroupHandler.class)
@@ -149,6 +159,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#revokeIngressFromEC2SecurityGroupOfOwner
     */
+   @Named("rds:RevokeDBSecurityGroupIngress")
    @POST
    @Path("/")
    @XMLResponseParser(SecurityGroupHandler.class)
@@ -161,6 +172,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#revokeIngressFromVPCSecurityGroup
     */
+   @Named("rds:RevokeDBSecurityGroupIngress")
    @POST
    @Path("/")
    @XMLResponseParser(SecurityGroupHandler.class)
@@ -171,6 +183,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#delete()
     */
+   @Named("rds:DeleteDBSecurityGroup")
    @POST
    @Path("/")
    @ExceptionParser(ReturnVoidOnNotFoundOr404.class)

--- a/labs/rds/src/main/java/org/jclouds/rds/features/SubnetGroupAsyncApi.java
+++ b/labs/rds/src/main/java/org/jclouds/rds/features/SubnetGroupAsyncApi.java
@@ -20,6 +20,7 @@ package org.jclouds.rds.features;
 
 import static org.jclouds.aws.reference.FormParameters.ACTION;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -59,6 +60,7 @@ public interface SubnetGroupAsyncApi {
    /**
     * @see SubnetGroupApi#get()
     */
+   @Named("rds:DescribeDBSubnetGroups")
    @POST
    @Path("/")
    @XMLResponseParser(SubnetGroupHandler.class)
@@ -69,6 +71,7 @@ public interface SubnetGroupAsyncApi {
    /**
     * @see SubnetGroupApi#list()
     */
+   @Named("rds:DescribeDBSubnetGroups")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeDBSubnetGroupsResultHandler.class)
@@ -79,6 +82,7 @@ public interface SubnetGroupAsyncApi {
    /**
     * @see SubnetGroupApi#list(ListSubnetGroupsOptions)
     */
+   @Named("rds:DescribeDBSubnetGroups")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeDBSubnetGroupsResultHandler.class)
@@ -88,6 +92,7 @@ public interface SubnetGroupAsyncApi {
    /**
     * @see SubnetGroupApi#delete()
     */
+   @Named("rds:DeleteDBSubnetGroup")
    @POST
    @Path("/")
    @ExceptionParser(ReturnVoidOnNotFoundOr404.class)

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/AWSAMIAsyncClient.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/AWSAMIAsyncClient.java
@@ -22,6 +22,7 @@ import static org.jclouds.aws.reference.FormParameters.ACTION;
 
 import java.util.Set;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -55,6 +56,7 @@ public interface AWSAMIAsyncClient extends AMIAsyncClient {
    /**
     * @see AMIClient#getProductCodesForImageInRegion
     */
+   @Named("ec2:DescribeImageAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeImageAttribute", "productCodes" })
@@ -66,6 +68,7 @@ public interface AWSAMIAsyncClient extends AMIAsyncClient {
    /**
     * @see AMIClient#addProductCodesToImageInRegion
     */
+   @Named("ec2:ModifyImageAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "OperationType", "Attribute" }, values = { "ModifyImageAttribute", "add",
@@ -78,6 +81,7 @@ public interface AWSAMIAsyncClient extends AMIAsyncClient {
    /**
     * @see AMIClient#removeProductCodesToImageInRegion
     */
+   @Named("ec2:ModifyImageAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "OperationType", "Attribute" }, values = { "ModifyImageAttribute", "remove",

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/AWSInstanceAsyncClient.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/AWSInstanceAsyncClient.java
@@ -22,6 +22,7 @@ import static org.jclouds.aws.reference.FormParameters.ACTION;
 
 import java.util.Set;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -61,6 +62,7 @@ public interface AWSInstanceAsyncClient extends InstanceAsyncClient {
    /**
     * @see AWSInstanceClient#describeInstancesInRegion
     */
+   @Named("ec2:DescribeInstances")
    @Override
    @POST
    @Path("/")
@@ -74,6 +76,7 @@ public interface AWSInstanceAsyncClient extends InstanceAsyncClient {
    /**
     * @see AWSInstanceClient#runInstancesInRegion
     */
+   @Named("ec2:RunInstances")
    @Override
    @POST
    @Path("/")

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/AWSKeyPairAsyncClient.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/AWSKeyPairAsyncClient.java
@@ -20,6 +20,7 @@ package org.jclouds.aws.ec2.services;
 
 import static org.jclouds.aws.reference.FormParameters.ACTION;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -50,6 +51,7 @@ public interface AWSKeyPairAsyncClient extends KeyPairAsyncClient {
    /**
     * @see AWSKeyPairClient#importKeyPairInRegion
     */
+   @Named("ec2:ImportKeyPair")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ImportKeyPair")

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/AWSSecurityGroupAsyncClient.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/AWSSecurityGroupAsyncClient.java
@@ -22,6 +22,7 @@ import static org.jclouds.aws.reference.FormParameters.ACTION;
 
 import java.util.Set;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -64,6 +65,7 @@ public interface AWSSecurityGroupAsyncClient extends SecurityGroupAsyncClient {
    /**
     * @see AWSSecurityGroupClient#createSecurityGroupInRegion
     */
+   @Named("ec2:CreateSecurityGroup")
    @POST
    @Path("/")
    @XMLResponseParser(CreateSecurityGroupResponseHandler.class)
@@ -77,6 +79,7 @@ public interface AWSSecurityGroupAsyncClient extends SecurityGroupAsyncClient {
     * @see AWSSecurityGroupClient#authorizeSecurityGroupIngressInRegion(String,
     *      String,IpPermission)
     */
+   @Named("ec2:AuthorizeSecurityGroupIngress")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "AuthorizeSecurityGroupIngress")
@@ -88,6 +91,7 @@ public interface AWSSecurityGroupAsyncClient extends SecurityGroupAsyncClient {
     * @see AWSSecurityGroupClient#authorizeSecurityGroupIngressInRegion(String,
     *      String,Iterable)
     */
+   @Named("ec2:AuthorizeSecurityGroupIngress")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "AuthorizeSecurityGroupIngress")
@@ -100,6 +104,7 @@ public interface AWSSecurityGroupAsyncClient extends SecurityGroupAsyncClient {
     * @see AWSSecurityGroupClient#revokeSecurityGroupIngressInRegion(@Nullable
     *      Region, String,IpPermission)
     */
+   @Named("ec2:RevokeSecurityGroupIngress")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "RevokeSecurityGroupIngress")
@@ -111,6 +116,7 @@ public interface AWSSecurityGroupAsyncClient extends SecurityGroupAsyncClient {
     * @see AWSSecurityGroupClient#revokeSecurityGroupIngressInRegion(@Nullable
     *      Region, String,Iterable)
     */
+   @Named("ec2:RevokeSecurityGroupIngress")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "RevokeSecurityGroupIngress")
@@ -122,6 +128,7 @@ public interface AWSSecurityGroupAsyncClient extends SecurityGroupAsyncClient {
    /**
     * @see AWSSecurityGroupClient#deleteSecurityGroupInRegionById
     */
+   @Named("ec2:DeleteSecurityGroup")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeleteSecurityGroup")
@@ -132,6 +139,7 @@ public interface AWSSecurityGroupAsyncClient extends SecurityGroupAsyncClient {
    /**
     * @see AWSSecurityGroupClient#describeSecurityGroupsInRegionById
     */
+   @Named("ec2:DescribeSecurityGroups")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeSecurityGroups")

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/MonitoringAsyncClient.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/MonitoringAsyncClient.java
@@ -22,6 +22,7 @@ import static org.jclouds.aws.reference.FormParameters.ACTION;
 
 import java.util.Map;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -54,6 +55,7 @@ public interface MonitoringAsyncClient {
    /**
     * @see Monitoring#monitorInstancesInRegion
     */
+   @Named("ec2:MonitorInstances")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "MonitorInstances")
@@ -66,6 +68,7 @@ public interface MonitoringAsyncClient {
    /**
     * @see Monitoring#monitorInstancesInRegion
     */
+   @Named("ec2:UnmonitorInstances")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "UnmonitorInstances")

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/PlacementGroupAsyncClient.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/PlacementGroupAsyncClient.java
@@ -22,6 +22,7 @@ import static org.jclouds.aws.reference.FormParameters.ACTION;
 
 import java.util.Set;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -57,6 +58,7 @@ public interface PlacementGroupAsyncClient {
    /**
     * @see PlacementGroupClient#createPlacementGroupInRegion(String,String,String)
     */
+   @Named("ec2:CreatePlacementGroup")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreatePlacementGroup")
@@ -67,6 +69,7 @@ public interface PlacementGroupAsyncClient {
    /**
     * @see PlacementGroupClient#createPlacementGroupInRegion(String,String)
     */
+   @Named("ec2:CreatePlacementGroup")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Strategy" }, values = { "CreatePlacementGroup", "cluster" })
@@ -76,6 +79,7 @@ public interface PlacementGroupAsyncClient {
    /**
     * @see PlacementGroupClient#deletePlacementGroupInRegion
     */
+   @Named("ec2:DeletePlacementGroup")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeletePlacementGroup")
@@ -86,6 +90,7 @@ public interface PlacementGroupAsyncClient {
    /**
     * @see PlacementGroupClient#describePlacementGroupsInRegion
     */
+   @Named("ec2:DescribePlacementGroups")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribePlacementGroups")

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/SpotInstanceAsyncClient.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/SpotInstanceAsyncClient.java
@@ -22,6 +22,7 @@ import static org.jclouds.aws.reference.FormParameters.ACTION;
 
 import java.util.Set;
 
+import javax.inject.Named;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -64,6 +65,7 @@ public interface SpotInstanceAsyncClient {
    /**
     * @see SpotInstanceClient#describeSpotInstanceRequestsInRegion
     */
+   @Named("ec2:DescribeSpotInstanceRequests")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeSpotInstanceRequests")
@@ -76,6 +78,7 @@ public interface SpotInstanceAsyncClient {
    /**
     * @see SpotInstanceClient#requestSpotInstanceInRegion
     */
+   @Named("ec2:RequestSpotInstances")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "RequestSpotInstances")
@@ -88,6 +91,7 @@ public interface SpotInstanceAsyncClient {
    /**
     * @see SpotInstanceClient#requestSpotInstancesInRegion
     */
+   @Named("ec2:RequestSpotInstances")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "RequestSpotInstances")
@@ -101,6 +105,7 @@ public interface SpotInstanceAsyncClient {
    /**
     * @see SpotInstanceClient#describeSpotPriceHistoryInRegion
     */
+   @Named("ec2:DescribeSpotPriceHistory")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeSpotPriceHistory")
@@ -113,6 +118,7 @@ public interface SpotInstanceAsyncClient {
    /**
     * @see SpotInstanceClient#cancelSpotInstanceRequestsInRegion
     */
+   @Named("ec2:CancelSpotInstanceRequests")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CancelSpotInstanceRequests")

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/TagAsyncClient.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/TagAsyncClient.java
@@ -23,6 +23,7 @@ import static org.jclouds.aws.reference.FormParameters.ACTION;
 import java.util.Map;
 import java.util.Set;
 
+import javax.inject.Named;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 
@@ -62,6 +63,7 @@ public interface TagAsyncClient {
     /**
      * @see TagClient#createTagsInRegion(String, Iterable, Map)
      */
+    @Named("ec2:CreateTags")
     @POST
     @Path("/")
     @FormParams(keys = ACTION, values = "CreateTags")
@@ -72,6 +74,7 @@ public interface TagAsyncClient {
     /**
      * @see TagClient#deleteTagsInRegion(String, Iterable, Map)
      */
+    @Named("ec2:DeleteTags")
     @POST
     @Path("/")
     @FormParams(keys = ACTION, values = "DeleteTags")
@@ -83,6 +86,7 @@ public interface TagAsyncClient {
     /**
      * @see TagClient#describeTagsInRegion(String, Map)
      */
+    @Named("ec2:DescribeTags")
     @POST
     @Path("/")
     @FormParams(keys = ACTION, values = "DescribeTags")

--- a/providers/aws-s3/src/main/java/org/jclouds/aws/s3/AWSS3AsyncClient.java
+++ b/providers/aws-s3/src/main/java/org/jclouds/aws/s3/AWSS3AsyncClient.java
@@ -22,6 +22,7 @@ import static org.jclouds.blobstore.attr.BlobScopes.CONTAINER;
 
 import java.util.Map;
 
+import javax.inject.Named;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -75,6 +76,7 @@ public interface AWSS3AsyncClient extends S3AsyncClient {
    /**
     * @see AWSS3Client#initiateMultipartUpload
     */
+   @Named("s3:PutObject")
    @POST
    @QueryParams(keys = "uploads")
    @Path("/{key}")
@@ -87,6 +89,7 @@ public interface AWSS3AsyncClient extends S3AsyncClient {
    /**
     * @see AWSS3Client#abortMultipartUpload
     */
+   @Named("s3:AbortMultipartUpload")
    @DELETE
    @Path("/{key}")
    @ExceptionParser(ReturnVoidOnNotFoundOr404.class)
@@ -97,6 +100,7 @@ public interface AWSS3AsyncClient extends S3AsyncClient {
    /**
     * @see AWSS3Client#uploadPart
     */
+   @Named("s3:PutObject")
    @PUT
    @Path("/{key}")
    @ResponseParser(ParseETagHeader.class)
@@ -108,6 +112,7 @@ public interface AWSS3AsyncClient extends S3AsyncClient {
    /**
     * @see AWSS3Client#completeMultipartUpload
     */
+   @Named("s3:PutObject")
    @POST
    @Path("/{key}")
    @ResponseParser(ETagFromHttpResponseViaRegex.class)
@@ -119,6 +124,7 @@ public interface AWSS3AsyncClient extends S3AsyncClient {
    /**
     * @see AWSS3Client#deleteObjects
     */
+   @Named("s3:DeleteObject")
    @POST                              
    @Path("/")
    @QueryParams(keys = "delete")


### PR DESCRIPTION
allows for correlation of async calls to IAM actions for various reasons including log and event correlation, and also permission math

values scraped from urls including:
http://docs.amazonwebservices.com/AmazonS3/latest/dev/UsingIAMPolicies.html#UsingWithS3_Actions
http://docs.amazonwebservices.com/AmazonCloudWatch/latest/DeveloperGuide/UsingIAM.html#UsingWithCloudWatch_Actions
http://docs.amazonwebservices.com/ElasticLoadBalancing/latest/DeveloperGuide/UsingIAM.html
http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.html#UsingWithRDS_Actions
http://docs.amazonwebservices.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/UsingIAM.html#UsingWithSQS_Actions
