### PR TITLE
Force the version of the Chef gem

### DIFF
--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/chef/InstallChefGems.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/chef/InstallChefGems.java
@@ -32,7 +32,9 @@ import org.jclouds.scriptbuilder.statements.ruby.InstallRuby;
 public class InstallChefGems extends StatementList {
 
    public InstallChefGems() {
-      super(new InstallRuby(), exec("gem install ohai chef --no-rdoc --no-ri"));
+      // Chef versions prior to 10.16.4 install an incompatible moneta gem.
+      // See: http://tickets.opscode.com/browse/CHEF-3721
+      super(new InstallRuby(), exec("gem install chef -v '>= 10.16.4' --no-rdoc --no-ri"));
    }
 
    @Override

--- a/scriptbuilder/src/main/resources/functions/installRuby.sh
+++ b/scriptbuilder/src/main/resources/functions/installRuby.sh
@@ -2,7 +2,7 @@ function installRuby() {
   if ! hash ruby 2>/dev/null; then
     if which dpkg &> /dev/null; then
       apt-get-update
-      apt-get install -y ruby ruby1.8-dev build-essential
+      apt-get install -y ruby ruby-dev build-essential
     elif which rpm &> /dev/null; then
       # Disable chef from the base repo (http://tickets.opscode.com/browse/CHEF-2906)
       sed -i "s/\[base\]/\0\n\exclude=ruby*/g" /etc/yum.repos.d/CentOS-Base.repo

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/chef/ChefSoloTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/chef/ChefSoloTest.java
@@ -382,7 +382,7 @@ public class ChefSoloTest {
 
    private static String installChefGems() throws IOException {
       return Resources.toString(Resources.getResource("test_install_ruby." + ShellToken.SH.to(OsFamily.UNIX)),
-            Charsets.UTF_8) + "gem install ohai chef --no-rdoc --no-ri\n";
+            Charsets.UTF_8) + "gem install chef -v '>= 10.16.4' --no-rdoc --no-ri\n";
    }
 
    private static String createConfigFile() {

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/chef/InstallChefGemsTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/chef/InstallChefGemsTest.java
@@ -38,8 +38,7 @@ import com.google.common.io.Resources;
 @Test(groups = "unit", testName = "InstallChefGemsTest")
 public class InstallChefGemsTest {
 
-   @Test(expectedExceptions = UnsupportedOperationException.class,
-         expectedExceptionsMessageRegExp = "windows not yet implemented")
+   @Test(expectedExceptions = UnsupportedOperationException.class, expectedExceptionsMessageRegExp = "windows not yet implemented")
    public void installChefGemsInWindows() {
       new InstallChefGems().render(OsFamily.WINDOWS);
    }
@@ -48,7 +47,7 @@ public class InstallChefGemsTest {
       assertEquals(
             new InstallChefGems().render(OsFamily.UNIX),
             Resources.toString(Resources.getResource("test_install_ruby." + ShellToken.SH.to(OsFamily.UNIX)),
-                  Charsets.UTF_8) + "gem install ohai chef --no-rdoc --no-ri\n");
+                  Charsets.UTF_8) + "gem install chef -v '>= 10.16.4' --no-rdoc --no-ri\n");
    }
 
    public void installChefGemsUnixInScriptBuilderSourcesSetupPublicCurl() throws IOException {

--- a/scriptbuilder/src/test/resources/test_install_chef_gems_scriptbuilder.sh
+++ b/scriptbuilder/src/test/resources/test_install_chef_gems_scriptbuilder.sh
@@ -140,7 +140,7 @@ function installRuby() {
   if ! hash ruby 2>/dev/null; then
     if which dpkg &> /dev/null; then
       apt-get-update
-      apt-get install -y ruby ruby1.8-dev build-essential
+      apt-get install -y ruby ruby-dev build-essential
     elif which rpm &> /dev/null; then
       # Disable chef from the base repo (http://tickets.opscode.com/browse/CHEF-2906)
       sed -i "s/\[base\]/\0\n\exclude=ruby*/g" /etc/yum.repos.d/CentOS-Base.repo
@@ -178,7 +178,7 @@ END_OF_JCLOUDS_SCRIPT
 	gem update --system
 	gem update --no-rdoc --no-ri
 	
-	gem install ohai chef --no-rdoc --no-ri
+	gem install chef -v '>= 10.16.4' --no-rdoc --no-ri
 	
 END_OF_JCLOUDS_SCRIPT
    

--- a/scriptbuilder/src/test/resources/test_install_ruby_scriptbuilder.sh
+++ b/scriptbuilder/src/test/resources/test_install_ruby_scriptbuilder.sh
@@ -140,7 +140,7 @@ function installRuby() {
   if ! hash ruby 2>/dev/null; then
     if which dpkg &> /dev/null; then
       apt-get-update
-      apt-get install -y ruby ruby1.8-dev build-essential
+      apt-get install -y ruby ruby-dev build-essential
     elif which rpm &> /dev/null; then
       # Disable chef from the base repo (http://tickets.opscode.com/browse/CHEF-2906)
       sed -i "s/\[base\]/\0\n\exclude=ruby*/g" /etc/yum.repos.d/CentOS-Base.repo


### PR DESCRIPTION
Force the version of the Chef gems, in order to get rid of [CHEF-3721](http://tickets.opscode.com/browse/CHEF-3721) and make sure [jclouds-chef #39](https://github.com/jclouds/jclouds-chef/issues/39) does not reproduce.

/cc @andreaturli
