### PR TITLE
removed use of static fields to share type mapping info

### DIFF
--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/config/CloudStackRestClientModule.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/config/CloudStackRestClientModule.java
@@ -131,7 +131,6 @@ import org.jclouds.location.suppliers.ImplicitLocationSupplier;
 import org.jclouds.location.suppliers.implicit.OnlyLocationOrFirstZone;
 import org.jclouds.rest.ConfiguresRestClient;
 import org.jclouds.rest.RestContext;
-import org.jclouds.rest.config.BinderUtils;
 import org.jclouds.rest.config.RestClientModule;
 import org.jclouds.rest.internal.RestContextImpl;
 
@@ -199,26 +198,6 @@ public class CloudStackRestClientModule extends RestClientModule<CloudStackClien
             .put(SessionClient.class, SessionAsyncClient.class)//
             .build();
 
-   @Override
-   protected void bindAsyncClient() {
-      // bind the user client (default)
-      super.bindAsyncClient();
-      // bind the domain admin client
-      BinderUtils.bindAsyncClient(binder(), CloudStackDomainAsyncClient.class);
-      // bind the global admin client
-      BinderUtils.bindAsyncClient(binder(), CloudStackGlobalAsyncClient.class);
-   }
-
-   @Override
-   protected void bindClient() {
-      // bind the user client (default)
-      super.bindClient();
-      // bind the domain admin client
-      BinderUtils.bindClient(binder(), CloudStackDomainClient.class, CloudStackDomainAsyncClient.class, DELEGATE_MAP);
-      // bind the domain admin client
-      BinderUtils.bindClient(binder(), CloudStackGlobalClient.class, CloudStackGlobalAsyncClient.class, DELEGATE_MAP);
-   }
-
    public CloudStackRestClientModule() {
       super(DELEGATE_MAP);
    }
@@ -232,9 +211,10 @@ public class CloudStackRestClientModule extends RestClientModule<CloudStackClien
       }).to(new TypeLiteral<RestContextImpl<CloudStackGlobalClient, CloudStackGlobalAsyncClient>>() {
       });
       bind(CredentialType.class).toProvider(CredentialTypeFromPropertyOrDefault.class);
-      
       // session client is used directly for filters and retry handlers, so let's bind it explicitly
       bindClientAndAsyncClient(binder(), SessionClient.class, SessionAsyncClient.class);
+      bindClientAndAsyncClient(binder(), CloudStackDomainClient.class, CloudStackDomainAsyncClient.class);
+      bindClientAndAsyncClient(binder(), CloudStackGlobalClient.class, CloudStackGlobalAsyncClient.class);
       bind(HttpRetryHandler.class).annotatedWith(ClientError.class).to(InvalidateSessionAndRetryOn401AndLogoutOnClose.class);
       
       super.configure();

--- a/apis/filesystem/src/main/java/org/jclouds/filesystem/config/FilesystemBlobStoreContextModule.java
+++ b/apis/filesystem/src/main/java/org/jclouds/filesystem/config/FilesystemBlobStoreContextModule.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.filesystem.config;
 
+import static org.jclouds.rest.config.BinderUtils.bindClient;
+
 import org.jclouds.blobstore.AsyncBlobStore;
 import org.jclouds.blobstore.BlobRequestSigner;
 import org.jclouds.blobstore.BlobStore;
@@ -35,9 +37,7 @@ import org.jclouds.filesystem.predicates.validators.internal.FilesystemBlobKeyVa
 import org.jclouds.filesystem.predicates.validators.internal.FilesystemContainerNameValidatorImpl;
 import org.jclouds.filesystem.strategy.internal.FilesystemStorageStrategyImpl;
 import org.jclouds.filesystem.util.internal.FileSystemBlobUtilsImpl;
-import org.jclouds.rest.config.BinderUtils;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.AbstractModule;
 
 /**
@@ -50,7 +50,7 @@ public class FilesystemBlobStoreContextModule extends AbstractModule {
    protected void configure() {
       bind(AsyncBlobStore.class).to(LocalAsyncBlobStore.class).asEagerSingleton();
       // forward all requests from TransientBlobStore to TransientAsyncBlobStore.  needs above binding as cannot proxy a class
-      BinderUtils.bindClient(binder(), LocalBlobStore.class, AsyncBlobStore.class, ImmutableMap.<Class<?>, Class<?>>of());
+      bindClient(binder(), LocalBlobStore.class, AsyncBlobStore.class);
       bind(BlobStore.class).to(LocalBlobStore.class);
 
       install(new BlobStoreObjectModule());

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/KeystoneAuthenticationModule.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/KeystoneAuthenticationModule.java
@@ -144,8 +144,7 @@ public class KeystoneAuthenticationModule extends AbstractModule {
    }
 
    protected void bindAuthenticationApi() {
-      // AuthenticationApi is used directly for filters and retry handlers, so let's bind it
-      // explicitly
+      // AuthenticationApi is used directly for filters and retry handlers, so let's bind it explicitly
       bindClientAndAsyncClient(binder(), AuthenticationApi.class, AuthenticationAsyncApi.class);
    }
 

--- a/apis/rackspace-cloudidentity/src/main/java/org/jclouds/rackspace/cloudidentity/v2_0/config/CloudIdentityAuthenticationModule.java
+++ b/apis/rackspace-cloudidentity/src/main/java/org/jclouds/rackspace/cloudidentity/v2_0/config/CloudIdentityAuthenticationModule.java
@@ -47,10 +47,9 @@ public class CloudIdentityAuthenticationModule extends KeystoneAuthenticationMod
 
    @Override
    protected void bindAuthenticationApi() {
-      // AuthenticationApi is used directly for filters and retry handlers, so let's bind it
-      // explicitly
+      // AuthenticationApi is used directly for filters and retry handlers, so let's bind it explicitly
       bindClientAndAsyncClient(binder(), CloudIdentityAuthenticationApi.class,
-               CloudIdentityAuthenticationAsyncApi.class);
+            CloudIdentityAuthenticationAsyncApi.class);
       bind(AuthenticationApi.class).to(CloudIdentityAuthenticationApi.class).in(Scopes.SINGLETON);
       bind(AuthenticationAsyncApi.class).to(CloudIdentityAuthenticationAsyncApi.class).in(Scopes.SINGLETON);
    }

--- a/blobstore/src/main/java/org/jclouds/blobstore/config/TransientBlobStoreContextModule.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/config/TransientBlobStoreContextModule.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.blobstore.config;
 
+import static org.jclouds.rest.config.BinderUtils.bindClient;
+
 import org.jclouds.blobstore.AsyncBlobStore;
 import org.jclouds.blobstore.BlobRequestSigner;
 import org.jclouds.blobstore.BlobStore;
@@ -26,9 +28,7 @@ import org.jclouds.blobstore.LocalBlobRequestSigner;
 import org.jclouds.blobstore.LocalStorageStrategy;
 import org.jclouds.blobstore.TransientStorageStrategy;
 import org.jclouds.blobstore.attr.ConsistencyModel;
-import org.jclouds.rest.config.BinderUtils;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.AbstractModule;
 
 /**
@@ -41,7 +41,7 @@ public class TransientBlobStoreContextModule extends AbstractModule {
    protected void configure() {
       bind(AsyncBlobStore.class).to(LocalAsyncBlobStore.class).asEagerSingleton();
       // forward all requests from TransientBlobStore to TransientAsyncBlobStore.  needs above binding as cannot proxy a class
-      BinderUtils.bindClient(binder(), LocalBlobStore.class, AsyncBlobStore.class, ImmutableMap.<Class<?>, Class<?>>of());
+      bindClient(binder(), LocalBlobStore.class, AsyncBlobStore.class);
       install(new BlobStoreObjectModule());
       install(new BlobStoreMapModule());
       bind(BlobStore.class).to(LocalBlobStore.class);

--- a/common/openstack/src/main/java/org/jclouds/openstack/config/OpenStackAuthenticationModule.java
+++ b/common/openstack/src/main/java/org/jclouds/openstack/config/OpenStackAuthenticationModule.java
@@ -63,8 +63,7 @@ public class OpenStackAuthenticationModule extends AbstractModule {
    protected void configure() {
       bind(new TypeLiteral<Function<Credentials, AuthenticationResponse>>() {
       }).to(GetAuthenticationResponse.class);
-      // OpenStackAuthClient is used directly for filters and retry handlers, so let's bind it
-      // explicitly
+      // OpenStackAuthClient is used directly for filters and retry handlers, so let's bind it explicitly
       bindClientAndAsyncClient(binder(), OpenStackAuthClient.class, OpenStackAuthAsyncClient.class);
       install(new FactoryModuleBuilder().build(URIFromAuthenticationResponseForService.Factory.class));
       bind(HttpRetryHandler.class).annotatedWith(ClientError.class).to(RetryOnRenew.class);

--- a/common/openstack/src/main/java/org/jclouds/openstack/keystone/v1_1/config/AuthenticationServiceModule.java
+++ b/common/openstack/src/main/java/org/jclouds/openstack/keystone/v1_1/config/AuthenticationServiceModule.java
@@ -63,8 +63,7 @@ public class AuthenticationServiceModule extends AbstractModule {
    protected void configure() {
       bind(new TypeLiteral<Function<Credentials, Auth>>() {
       }).to(GetAuth.class);
-      // ServiceClient is used directly for filters and retry handlers, so let's bind it
-      // explicitly
+      // ServiceClient is used directly for filters and retry handlers, so let's bind it explicitly
       bindClientAndAsyncClient(binder(), AuthenticationClient.class, AuthenticationAsyncClient.class);
       install(new FactoryModuleBuilder().implement(RegionIdToURISupplier.class,
                RegionIdToURIFromAuthForServiceSupplier.class).build(RegionIdToURISupplier.Factory.class));

--- a/core/src/main/java/org/jclouds/config/BindRestContextWithWildcardExtendsExplicitAndRawType.java
+++ b/core/src/main/java/org/jclouds/config/BindRestContextWithWildcardExtendsExplicitAndRawType.java
@@ -49,21 +49,21 @@ public class BindRestContextWithWildcardExtendsExplicitAndRawType extends Abstra
    @SuppressWarnings("unchecked")
    @Override
    protected void configure() {
-      TypeToken concreteType = BaseRestApiMetadata.contextToken(TypeToken.of(restApiMetadata.getApi()), TypeToken
+      TypeToken<?> concreteType = BaseRestApiMetadata.contextToken(TypeToken.of(restApiMetadata.getApi()), TypeToken
                .of(restApiMetadata.getAsyncApi()));
       // bind explicit type
       bind(TypeLiteral.get(concreteType.getType())).to(
-               (TypeLiteral) TypeLiteral.get(Types.newParameterizedType(RestContextImpl.class,
-                        restApiMetadata.getApi(), restApiMetadata.getAsyncApi())));
+            TypeLiteral.class.cast(TypeLiteral.get(Types.newParameterizedType(RestContextImpl.class,
+                  restApiMetadata.getApi(), restApiMetadata.getAsyncApi()))));
       // bind potentially wildcard type
       if (!concreteType.equals(restApiMetadata.getContext())) {
          bind(TypeLiteral.get(restApiMetadata.getContext().getType())).to(
-                  (TypeLiteral) TypeLiteral.get(Types.newParameterizedType(RestContextImpl.class, restApiMetadata
-                           .getApi(), restApiMetadata.getAsyncApi())));
+               TypeLiteral.class.cast(TypeLiteral.get(Types.newParameterizedType(RestContextImpl.class,
+                     restApiMetadata.getApi(), restApiMetadata.getAsyncApi()))));
       }
       // bind w/o types
       bind(TypeLiteral.get(RestContext.class)).to(
-               (TypeLiteral) TypeLiteral.get(Types.newParameterizedType(RestContextImpl.class,
-                        restApiMetadata.getApi(), restApiMetadata.getAsyncApi())));
+            TypeLiteral.class.cast(TypeLiteral.get(Types.newParameterizedType(RestContextImpl.class,
+                  restApiMetadata.getApi(), restApiMetadata.getAsyncApi()))));
    }
 }

--- a/core/src/main/java/org/jclouds/rest/AsyncClientFactory.java
+++ b/core/src/main/java/org/jclouds/rest/AsyncClientFactory.java
@@ -39,7 +39,7 @@ public class AsyncClientFactory {
    private final Injector injector;
 
    @Inject
-   public AsyncClientFactory(Injector injector) {
+   private AsyncClientFactory(Injector injector) {
       this.injector = injector;
    }
 

--- a/core/src/main/java/org/jclouds/rest/config/AsyncClientProvider.java
+++ b/core/src/main/java/org/jclouds/rest/config/AsyncClientProvider.java
@@ -23,7 +23,6 @@ import javax.inject.Singleton;
 
 import org.jclouds.rest.AsyncClientFactory;
 
-import com.google.inject.Injector;
 import com.google.inject.Provider;
 
 /**
@@ -32,19 +31,19 @@ import com.google.inject.Provider;
  */
 @Singleton
 public class AsyncClientProvider<A> implements Provider<A> {
-   @Inject
-   Injector injector;
-   private final Class<?> asyncClientType;
+   private final Class<A> asyncClientType;
+   private final AsyncClientFactory factory;
 
    @Inject
-   AsyncClientProvider(Class<?> asyncClientType) {
+   private AsyncClientProvider(AsyncClientFactory factory, Class<A> asyncClientType) {
+      this.factory = factory;
       this.asyncClientType = asyncClientType;
    }
 
    @Override
    @Singleton
    public A get() {
-      return (A) injector.getInstance(AsyncClientFactory.class).create(asyncClientType);
+      return factory.create(asyncClientType);
    }
 
 }

--- a/core/src/main/java/org/jclouds/rest/config/ClientProvider.java
+++ b/core/src/main/java/org/jclouds/rest/config/ClientProvider.java
@@ -18,62 +18,38 @@
  */
 package org.jclouds.rest.config;
 
-import java.util.Map;
+import static com.google.common.reflect.Reflection.newProxy;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.jclouds.concurrent.internal.SyncProxy;
-import org.jclouds.internal.ClassMethodArgs;
-import org.jclouds.internal.ClassMethodArgsAndReturnVal;
 
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
-import com.google.common.base.Throwables;
-import com.google.common.cache.LoadingCache;
-import com.google.inject.Injector;
-import com.google.inject.Key;
 import com.google.inject.Provider;
-import com.google.inject.TypeLiteral;
-import com.google.inject.name.Names;
 
 /**
- * ClientProvider makes the primary interface for the provider context. ex. {@code
- * context.getProviderSpecificContext().getApi()} is created by ClientProvider, which is a singleton
+ * ClientProvider makes the primary interface for the provider context. ex.
+ * {@code context.getProviderSpecificContext().getApi()} is created by ClientProvider, which is a singleton
  * 
  * @author Adrian Cole
  */
 @Singleton
 public class ClientProvider<S, A> implements Provider<S> {
-   @Inject
-   Injector injector;
-   private final Class<?> syncClientType;
-   private final Class<?> asyncClientType;
-   private final Map<Class<?>, Class<?>> sync2Async;
+
+   private final SyncProxy.Factory factory;
+   private final Class<S> syncClientType;
+   private final A asyncClient;
 
    @Inject
-   ClientProvider(Class<?> syncClientType, Class<?> asyncClientType, Map<Class<?>, Class<?>> sync2Async) {
-      this.asyncClientType = asyncClientType;
+   private ClientProvider(SyncProxy.Factory factory, Class<S> syncClientType, A asyncClient) {
+      this.factory = factory;
+      this.asyncClient = asyncClient;
       this.syncClientType = syncClientType;
-      this.sync2Async = sync2Async;
    }
 
    @Override
    @Singleton
    public S get() {
-      A client = (A) injector.getInstance(Key.get(asyncClientType));
-      Function<ClassMethodArgsAndReturnVal, Optional<Object>> optionalConverter = injector.getInstance(Key.get(new TypeLiteral<Function<ClassMethodArgsAndReturnVal, Optional<Object>>>() {
-      }));
-      LoadingCache<ClassMethodArgs, Object> delegateMap = injector.getInstance(Key.get(
-               new TypeLiteral<LoadingCache<ClassMethodArgs, Object>>() {
-               }, Names.named("sync")));
-      Map<String, Long> timeoutsMap = injector.getInstance(Key.get(new TypeLiteral<Map<String, Long>>() {
-      }, Names.named("TIMEOUTS")));
-      try {
-         return (S) SyncProxy.proxy(optionalConverter, syncClientType, client, delegateMap, sync2Async,
-               timeoutsMap);
-      } catch (Exception e) {
-         throw Throwables.propagate(e);
-      }
+      return newProxy(syncClientType, factory.create(syncClientType, asyncClient));
    }
 }

--- a/core/src/main/java/org/jclouds/rest/config/RestClientModule.java
+++ b/core/src/main/java/org/jclouds/rest/config/RestClientModule.java
@@ -19,7 +19,7 @@
 package org.jclouds.rest.config;
 
 import java.util.Map;
-
+import static org.jclouds.rest.config.BinderUtils.*;
 import org.jclouds.rest.ConfiguresRestClient;
 import org.jclouds.util.TypeTokens2;
 
@@ -42,8 +42,10 @@ public class RestClientModule<S, A> extends RestModule {
    protected RestClientModule(Map<Class<?>, Class<?>> sync2Async) {
       super(sync2Async);
       this.syncClientType = TypeTokens2.checkBound(new TypeToken<S>(getClass()) {
+         private static final long serialVersionUID = 1L;
       });
       this.asyncClientType = TypeTokens2.checkBound(new TypeToken<A>(getClass()) {
+         private static final long serialVersionUID = 1L;
       });
    }
 
@@ -73,8 +75,7 @@ public class RestClientModule<S, A> extends RestModule {
    @Override
    protected void configure() {
       super.configure();
-      bindAsyncClient();
-      bindClient();
+      bindClientAndAsyncClient(binder(), syncClientType.getRawType(), asyncClientType.getRawType());
       bindErrorHandlers();
       bindRetryHandlers();
    }
@@ -109,14 +110,7 @@ public class RestClientModule<S, A> extends RestModule {
     * 
     */
    protected void bindErrorHandlers() {
-   }
 
-   protected void bindAsyncClient() {
-      BinderUtils.bindAsyncClient(binder(), asyncClientType.getRawType());
-   }
-
-   protected void bindClient() {
-      BinderUtils.bindClient(binder(), syncClientType.getRawType(), asyncClientType.getRawType(), sync2Async);
    }
 
 }

--- a/core/src/test/java/org/jclouds/events/config/EventBusModuleTest.java
+++ b/core/src/test/java/org/jclouds/events/config/EventBusModuleTest.java
@@ -25,7 +25,7 @@ import static org.testng.Assert.assertTrue;
 import org.jclouds.Constants;
 import org.jclouds.concurrent.config.ExecutorServiceModule;
 import org.jclouds.events.config.annotations.AsyncBus;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.google.common.eventbus.AsyncEventBus;
@@ -44,7 +44,7 @@ import com.google.inject.name.Names;
 public class EventBusModuleTest {
     private Injector injector;
     
-    @BeforeMethod
+    @BeforeClass
     public void setup() {
         ExecutorServiceModule executorServiceModule = new ExecutorServiceModule() {
             @Override

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/config/AbiquoRestClientModule.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/config/AbiquoRestClientModule.java
@@ -21,6 +21,7 @@ package org.jclouds.abiquo.config;
 
 import static org.jclouds.Constants.PROPERTY_SESSION_INTERVAL;
 import static org.jclouds.abiquo.domain.DomainWrapper.wrap;
+import static org.jclouds.rest.config.BinderUtils.bindClientAndAsyncClient;
 
 import java.util.List;
 import java.util.Map;
@@ -65,7 +66,6 @@ import org.jclouds.rest.AuthorizationException;
 import org.jclouds.rest.ConfiguresRestClient;
 import org.jclouds.rest.RestContext;
 import org.jclouds.rest.Utils;
-import org.jclouds.rest.config.BinderUtils;
 import org.jclouds.rest.config.RestClientModule;
 import org.jclouds.rest.suppliers.MemoizedRetryOnTimeOutButNotOnAuthorizationExceptionSupplier;
 import org.jclouds.util.Suppliers2;
@@ -101,21 +101,9 @@ public class AbiquoRestClientModule extends RestClientModule<AbiquoApi, AbiquoAs
    }
 
    @Override
-   protected void bindAsyncClient() {
-      super.bindAsyncClient();
-      BinderUtils.bindAsyncClient(binder(), AbiquoHttpAsyncClient.class);
-   }
-
-   @Override
-   protected void bindClient() {
-      super.bindClient();
-      BinderUtils.bindClient(binder(), AbiquoHttpClient.class, AbiquoHttpAsyncClient.class,
-            ImmutableMap.<Class<?>, Class<?>> of(AbiquoHttpClient.class, AbiquoHttpAsyncClient.class));
-   }
-
-   @Override
    protected void configure() {
       super.configure();
+      bindClientAndAsyncClient(binder(), AbiquoHttpClient.class, AbiquoHttpAsyncClient.class);
       bind(Utils.class).to(ExtendedUtils.class);
    }
 

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/config/VCloudDirectorRestClientModule.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/config/VCloudDirectorRestClientModule.java
@@ -37,7 +37,6 @@ import org.jclouds.http.annotation.ServerError;
 import org.jclouds.location.Provider;
 import org.jclouds.rest.ConfiguresRestClient;
 import org.jclouds.rest.RestContext;
-import org.jclouds.rest.config.BinderUtils;
 import org.jclouds.rest.config.RestClientModule;
 import org.jclouds.rest.internal.RestContextImpl;
 import org.jclouds.util.Suppliers2;
@@ -140,22 +139,6 @@ public class VCloudDirectorRestClientModule extends RestClientModule<VCloudDirec
          .put(UserApi.class, UserAsyncApi.class)
          .build();
    
-   @Override
-   protected void bindAsyncClient() {
-      // bind the user api (default)
-      super.bindAsyncClient();
-      // bind the admin api
-      BinderUtils.bindAsyncClient(binder(), VCloudDirectorAdminAsyncApi.class);
-   }
-   
-   @Override
-   protected void bindClient() {
-      // bind the user api (default)
-      super.bindClient();
-      // bind the admin api
-      BinderUtils.bindClient(binder(), VCloudDirectorAdminApi.class, VCloudDirectorAdminAsyncApi.class, ADMIN_DELEGATE_MAP);
-   }
-   
    public VCloudDirectorRestClientModule() {
       super(ADMIN_DELEGATE_MAP);
    }
@@ -176,6 +159,8 @@ public class VCloudDirectorRestClientModule extends RestClientModule<VCloudDirec
       bind(HttpRetryHandler.class).annotatedWith(ClientError.class).to(InvalidateSessionAndRetryOn401AndLogoutOnClose.class);
       
       super.configure();
+      bindClientAndAsyncClient(binder(),  VCloudDirectorAdminApi.class, VCloudDirectorAdminAsyncApi.class);
+
    }
    
    @Override


### PR DESCRIPTION
$subject

unwound things that can be done in guice with sufficient handle on type parameters.  There's no longer any unnatural binding or object sharing going on.

When this is merged, we need to merge the following cc: @nacx

https://github.com/jclouds/jclouds-chef/tree/no-static
