### PR TITLE
fixed covariance and warnings on ApiMetadata subclasses

### DIFF
--- a/apis/atmos/src/main/java/org/jclouds/atmos/AtmosApiMetadata.java
+++ b/apis/atmos/src/main/java/org/jclouds/atmos/AtmosApiMetadata.java
@@ -38,15 +38,15 @@ import com.google.common.reflect.TypeToken;
 import com.google.inject.Module;
 
 /**
- * Implementation of {@link ApiMetadata} for Rackspace Cloud Files API
+ * Implementation of {@link ApiMetadata} for EMC Atmos API
  * 
  * @author Adrian Cole
  */
 public class AtmosApiMetadata extends BaseRestApiMetadata {
 
    public static final TypeToken<RestContext<AtmosClient, AtmosAsyncClient>> CONTEXT_TOKEN = new TypeToken<RestContext<AtmosClient, AtmosAsyncClient>>() {
+      private static final long serialVersionUID = 1L;
    };
-   
    
    private static Builder builder() {
       return new Builder();
@@ -76,7 +76,7 @@ public class AtmosApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
       protected Builder() {
          super(AtmosClient.class, AtmosAsyncClient.class);
          id("atmos")
@@ -97,8 +97,7 @@ public class AtmosApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
    }

--- a/apis/byon/src/main/java/org/jclouds/byon/BYONApiMetadata.java
+++ b/apis/byon/src/main/java/org/jclouds/byon/BYONApiMetadata.java
@@ -55,7 +55,7 @@ public class BYONApiMetadata extends BaseApiMetadata {
       super(builder);
    }
 
-   public static class Builder extends BaseApiMetadata.Builder {
+   public static class Builder extends BaseApiMetadata.Builder<Builder> {
 
       protected Builder() {
          id("byon")
@@ -77,11 +77,8 @@ public class BYONApiMetadata extends BaseApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
-
 }

--- a/apis/cloudfiles/src/main/java/org/jclouds/cloudfiles/CloudFilesApiMetadata.java
+++ b/apis/cloudfiles/src/main/java/org/jclouds/cloudfiles/CloudFilesApiMetadata.java
@@ -47,19 +47,16 @@ import com.google.inject.TypeLiteral;
 public class CloudFilesApiMetadata extends SwiftApiMetadata {
 
    public static final TypeToken<RestContext<CloudFilesClient, CloudFilesAsyncClient>> CONTEXT_TOKEN = new TypeToken<RestContext<CloudFilesClient, CloudFilesAsyncClient>>() {
+      private static final long serialVersionUID = 1L;
    };
-
-   private static Builder builder() {
-      return new Builder();
-   }
 
    @Override
    public Builder toBuilder() {
-      return builder().fromApiMetadata(this);
+      return new Builder().fromApiMetadata(this);
    }
 
    public CloudFilesApiMetadata() {
-      this(builder());
+      this(new Builder());
    }
 
    protected CloudFilesApiMetadata(Builder builder) {
@@ -72,7 +69,7 @@ public class CloudFilesApiMetadata extends SwiftApiMetadata {
       return properties;
    }
 
-   public static class Builder extends SwiftApiMetadata.Builder {
+   public static class Builder extends SwiftApiMetadata.Builder<Builder> {
       protected Builder(){
          super(CloudFilesClient.class, CloudFilesAsyncClient.class);
          id("cloudfiles")
@@ -95,19 +92,16 @@ public class CloudFilesApiMetadata extends SwiftApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
    }
 
    public static class CloudFilesTemporaryUrlExtensionModule extends TemporaryUrlExtensionModule<CloudFilesAsyncClient> {
-
       @Override
       protected void bindRequestSigner() {
          bind(BlobRequestSigner.class).to(new TypeLiteral<SwiftBlobSigner<CloudFilesAsyncClient>>() {
          });
       }
-
    }
 }

--- a/apis/cloudservers/src/main/java/org/jclouds/cloudservers/CloudServersApiMetadata.java
+++ b/apis/cloudservers/src/main/java/org/jclouds/cloudservers/CloudServersApiMetadata.java
@@ -44,6 +44,7 @@ import com.google.inject.Module;
 public class CloudServersApiMetadata extends BaseRestApiMetadata {
 
    public static final TypeToken<RestContext<CloudServersClient, CloudServersAsyncClient>> CONTEXT_TOKEN = new TypeToken<RestContext<CloudServersClient, CloudServersAsyncClient>>() {
+      private static final long serialVersionUID = 1L;
    };
 
    @Override
@@ -66,7 +67,7 @@ public class CloudServersApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(CloudServersClient.class, CloudServersAsyncClient.class);
@@ -88,11 +89,8 @@ public class CloudServersApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
-
 }

--- a/apis/cloudsigma/src/main/java/org/jclouds/cloudsigma/CloudSigmaApiMetadata.java
+++ b/apis/cloudsigma/src/main/java/org/jclouds/cloudsigma/CloudSigmaApiMetadata.java
@@ -45,6 +45,7 @@ import com.google.inject.Module;
 public class CloudSigmaApiMetadata extends BaseRestApiMetadata {
 
    public static final TypeToken<RestContext<CloudSigmaClient, CloudSigmaAsyncClient>> CONTEXT_TOKEN = new TypeToken<RestContext<CloudSigmaClient, CloudSigmaAsyncClient>>() {
+      private static final long serialVersionUID = 1L;
    };
    
    @Override
@@ -73,7 +74,7 @@ public class CloudSigmaApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(CloudSigmaClient.class, CloudSigmaAsyncClient.class);
@@ -95,11 +96,8 @@ public class CloudSigmaApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
-
 }

--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/CloudStackApiMetadata.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/CloudStackApiMetadata.java
@@ -38,23 +38,12 @@ import com.google.inject.Module;
 /**
  * Implementation of {@link ApiMetadata} for Citrix/Apache CloudStack api.
  * 
- * <h3>note</h3>
- * <p/>
- * This class allows overriding of types {@code S}(client) and {@code A}
- * (asyncClient), so that children can add additional methods not declared here,
- * such as new features from AWS.
- * <p/>
- * 
- * As this is a popular api, we also allow overrides for type {@code C}
- * (context). This allows subtypes to add in new feature groups or extensions,
- * not present in the base api. For example, you could make a subtype for
- * context, that exposes admin operations.
- * 
  * @author Adrian Cole
  */
 public class CloudStackApiMetadata extends BaseRestApiMetadata {
    
    public static final TypeToken<RestContext<CloudStackClient, CloudStackAsyncClient>> CONTEXT_TOKEN = new TypeToken<RestContext<CloudStackClient, CloudStackAsyncClient>>() {
+      private static final long serialVersionUID = 1L;
    };
    
    @Override
@@ -80,8 +69,7 @@ public class CloudStackApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder
-         extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(CloudStackClient.class, CloudStackAsyncClient.class);
@@ -104,13 +92,10 @@ public class CloudStackApiMetadata extends BaseRestApiMetadata {
       public CloudStackApiMetadata build() {
          return new CloudStackApiMetadata(this);
       }
-      
+
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
-
 }

--- a/apis/cloudwatch/src/main/java/org/jclouds/cloudwatch/CloudWatchApiMetadata.java
+++ b/apis/cloudwatch/src/main/java/org/jclouds/cloudwatch/CloudWatchApiMetadata.java
@@ -41,6 +41,7 @@ import com.google.common.reflect.TypeToken;
 public class CloudWatchApiMetadata extends BaseRestApiMetadata {
 
    public static final TypeToken<RestContext<CloudWatchApi, CloudWatchAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<CloudWatchApi, CloudWatchAsyncApi>>() {
+      private static final long serialVersionUID = 1L;
    };
 
    @Override
@@ -64,7 +65,7 @@ public class CloudWatchApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder(Class<?> api, Class<?> asyncApi) {
          super(api, asyncApi);
@@ -85,10 +86,8 @@ public class CloudWatchApiMetadata extends BaseRestApiMetadata {
       }
       
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
    }
-
 }

--- a/apis/ec2/src/main/java/org/jclouds/ec2/EC2ApiMetadata.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/EC2ApiMetadata.java
@@ -62,18 +62,19 @@ import com.google.inject.Module;
 public class EC2ApiMetadata extends BaseRestApiMetadata {
    
    public static final TypeToken<RestContext<? extends EC2Client, ? extends EC2AsyncClient>> CONTEXT_TOKEN = new TypeToken<RestContext<? extends EC2Client, ? extends EC2AsyncClient>>() {
+      private static final long serialVersionUID = 1L;
    };
 
    @Override
-   public Builder toBuilder() {
-      return (Builder) new Builder(getApi(), getAsyncApi()).fromApiMetadata(this);
+   public Builder<?> toBuilder() {
+      return new ConcreteBuilder().fromApiMetadata(this);
    }
 
    public EC2ApiMetadata() {
-      this(new Builder(EC2Client.class, EC2AsyncClient.class));
+      this(new ConcreteBuilder());
    }
 
-   protected EC2ApiMetadata(Builder builder) {
+   protected EC2ApiMetadata(Builder<?> builder) {
       super(builder);
    }
 
@@ -90,8 +91,10 @@ public class EC2ApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder
-         extends BaseRestApiMetadata.Builder {
+   public static abstract class Builder<T extends Builder<T>> extends BaseRestApiMetadata.Builder<T> {
+      protected Builder() {
+         this(EC2Client.class, EC2AsyncClient.class);
+      }
 
       protected Builder(Class<?> syncClient, Class<?> asyncClient) {
          super(syncClient, asyncClient);
@@ -112,13 +115,12 @@ public class EC2ApiMetadata extends BaseRestApiMetadata {
       public ApiMetadata build() {
          return new EC2ApiMetadata(this);
       }
-
+   }
+   
+   private static class ConcreteBuilder extends Builder<ConcreteBuilder> {
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected ConcreteBuilder self() {
          return this;
       }
-
    }
-
 }

--- a/apis/elasticstack/src/main/java/org/jclouds/elasticstack/ElasticStackApiMetadata.java
+++ b/apis/elasticstack/src/main/java/org/jclouds/elasticstack/ElasticStackApiMetadata.java
@@ -44,6 +44,7 @@ import com.google.inject.Module;
 public class ElasticStackApiMetadata extends BaseRestApiMetadata {
 
    public static final TypeToken<RestContext<ElasticStackClient, ElasticStackAsyncClient>> CONTEXT_TOKEN = new TypeToken<RestContext<ElasticStackClient, ElasticStackAsyncClient>>() {
+      private static final long serialVersionUID = 1L;
    };
    
    @Override
@@ -73,9 +74,7 @@ public class ElasticStackApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder
-         extends
-         BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(ElasticStackClient.class, ElasticStackAsyncClient.class);
@@ -97,11 +96,8 @@ public class ElasticStackApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
-
 }

--- a/apis/filesystem/src/main/java/org/jclouds/filesystem/FilesystemApiMetadata.java
+++ b/apis/filesystem/src/main/java/org/jclouds/filesystem/FilesystemApiMetadata.java
@@ -31,24 +31,20 @@ import org.jclouds.filesystem.config.FilesystemBlobStoreContextModule;
  */
 public class FilesystemApiMetadata extends BaseApiMetadata {
 
-   public static Builder builder() {
-      return new Builder();
-   }
-
    @Override
    public Builder toBuilder() {
-      return Builder.class.cast(builder().fromApiMetadata(this));
+      return new Builder().fromApiMetadata(this);
    }
 
    public FilesystemApiMetadata() {
-      super(builder());
+      super(new Builder());
    }
 
    protected FilesystemApiMetadata(Builder builder) {
       super(builder);
    }
 
-   public static class Builder extends BaseApiMetadata.Builder {
+   public static class Builder extends BaseApiMetadata.Builder<Builder> {
 
       protected Builder() {
          id("filesystem")
@@ -68,6 +64,9 @@ public class FilesystemApiMetadata extends BaseApiMetadata {
          return new FilesystemApiMetadata(this);
       }
 
+      @Override
+      protected Builder self() {
+         return this;
+      }
    }
-
 }

--- a/apis/openstack-cinder/src/main/java/org/jclouds/openstack/cinder/v1/CinderApiMetadata.java
+++ b/apis/openstack-cinder/src/main/java/org/jclouds/openstack/cinder/v1/CinderApiMetadata.java
@@ -48,6 +48,7 @@ import com.google.inject.Module;
 public class CinderApiMetadata extends BaseRestApiMetadata {
    
    public static final TypeToken<RestContext<CinderApi, CinderAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<CinderApi, CinderAsyncApi>>() {
+      private static final long serialVersionUID = 1L;
    };
 
    @Override
@@ -71,7 +72,7 @@ public class CinderApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(CinderApi.class, CinderAsyncApi.class);
@@ -90,7 +91,7 @@ public class CinderApiMetadata extends BaseRestApiMetadata {
                                      .add(CinderParserModule.class)
                                      .add(CinderRestClientModule.class)
                                      .build());
-      }  
+      }
       
       @Override
       public CinderApiMetadata build() {
@@ -98,8 +99,7 @@ public class CinderApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
    }

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/KeystoneApiMetadata.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/KeystoneApiMetadata.java
@@ -27,7 +27,6 @@ import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.SERV
 import java.net.URI;
 import java.util.Properties;
 
-import org.jclouds.apis.ApiMetadata;
 import org.jclouds.openstack.keystone.v2_0.config.CredentialTypes;
 import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule;
 import org.jclouds.openstack.keystone.v2_0.config.KeystoneParserModule;
@@ -49,18 +48,19 @@ import com.google.inject.Module;
 public class KeystoneApiMetadata extends BaseRestApiMetadata {
    
    public static final TypeToken<RestContext<? extends KeystoneApi,? extends  KeystoneAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<? extends KeystoneApi,? extends  KeystoneAsyncApi>>() {
+      private static final long serialVersionUID = 1L;
    };
 
    @Override
-   public Builder toBuilder() {
-      return (Builder) new Builder(getApi(), getAsyncApi()).fromApiMetadata(this);
+   public Builder<?> toBuilder() {
+      return new ConcreteBuilder().fromApiMetadata(this);
    }
 
    public KeystoneApiMetadata() {
-      this(new Builder(KeystoneApi.class, KeystoneAsyncApi.class));
+      this(new ConcreteBuilder());
    }
 
-   protected KeystoneApiMetadata(Builder builder) {
+   protected KeystoneApiMetadata(Builder<?> builder) {
       super(builder);
    }
 
@@ -73,7 +73,10 @@ public class KeystoneApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static abstract class Builder<T extends Builder<T>> extends BaseRestApiMetadata.Builder<T> {
+      protected Builder() {
+         this(KeystoneApi.class, KeystoneAsyncApi.class);
+      }
 
       protected Builder(Class<?> api, Class<?> asyncApi) {
          super(api, asyncApi);
@@ -97,13 +100,12 @@ public class KeystoneApiMetadata extends BaseRestApiMetadata {
       public KeystoneApiMetadata build() {
          return new KeystoneApiMetadata(this);
       }
-
-      @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
-         return this;
-      }
-
    }
 
+   private static class ConcreteBuilder extends Builder<ConcreteBuilder> {
+      @Override
+      protected ConcreteBuilder self() {
+         return this;
+      }
+   }
 }

--- a/apis/openstack-nova-ec2/src/main/java/org/jclouds/openstack/nova/ec2/NovaEC2ApiMetadata.java
+++ b/apis/openstack-nova-ec2/src/main/java/org/jclouds/openstack/nova/ec2/NovaEC2ApiMetadata.java
@@ -47,19 +47,16 @@ import com.google.inject.Module;
 public class NovaEC2ApiMetadata extends EC2ApiMetadata {
 
    public static final TypeToken<RestContext<NovaEC2Client, NovaEC2AsyncClient>> CONTEXT_TOKEN = new TypeToken<RestContext<NovaEC2Client, NovaEC2AsyncClient>>() {
+      private static final long serialVersionUID = 1L;
    };
-
-   private static Builder builder() {
-      return new Builder();
-   }
 
    @Override
    public Builder toBuilder() {
-      return builder().fromApiMetadata(this);
+      return new Builder().fromApiMetadata(this);
    }
 
    public NovaEC2ApiMetadata() {
-      this(builder());
+      this(new Builder());
    }
 
    protected NovaEC2ApiMetadata(Builder builder) {
@@ -83,7 +80,7 @@ public class NovaEC2ApiMetadata extends EC2ApiMetadata {
       return properties;
    }
 
-   public static class Builder extends EC2ApiMetadata.Builder {
+   public static class Builder extends EC2ApiMetadata.Builder<Builder> {
       protected Builder(){
          super(NovaEC2Client.class, NovaEC2AsyncClient.class);
          id("openstack-nova-ec2")
@@ -105,10 +102,8 @@ public class NovaEC2ApiMetadata extends EC2ApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
    }
-
 }

--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/NovaApiMetadata.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/NovaApiMetadata.java
@@ -46,13 +46,14 @@ import com.google.common.reflect.TypeToken;
 import com.google.inject.Module;
 
 /**
- * Implementation of {@link ApiMetadata} for Nova 1.0 API
+ * Implementation of {@link ApiMetadata} for Nova 2.0 API
  * 
  * @author Adrian Cole
  */
 public class NovaApiMetadata extends BaseRestApiMetadata {
 
    public static final TypeToken<RestContext<NovaApi, NovaAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<NovaApi, NovaAsyncApi>>() {
+      private static final long serialVersionUID = 1L;
    };
 
    @Override
@@ -83,7 +84,7 @@ public class NovaApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(NovaApi.class, NovaAsyncApi.class);
@@ -111,11 +112,8 @@ public class NovaApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
-
 }

--- a/apis/rackspace-cloudidentity/src/main/java/org/jclouds/rackspace/cloudidentity/v2_0/CloudIdentityApiMetadata.java
+++ b/apis/rackspace-cloudidentity/src/main/java/org/jclouds/rackspace/cloudidentity/v2_0/CloudIdentityApiMetadata.java
@@ -47,19 +47,16 @@ import com.google.inject.Module;
 public class CloudIdentityApiMetadata extends KeystoneApiMetadata {
    
    public static final TypeToken<RestContext<KeystoneApi, KeystoneAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<KeystoneApi, KeystoneAsyncApi>>() {
+      private static final long serialVersionUID = 1L;
    };
-   
-   private static Builder builder() {
-      return new Builder();
-   }
 
    @Override
    public Builder toBuilder() {
-      return builder().fromApiMetadata(this);
+      return new Builder().fromApiMetadata(this);
    }
 
    public CloudIdentityApiMetadata() {
-      this(builder());
+      this(new Builder());
    }
 
    protected CloudIdentityApiMetadata(Builder builder) {
@@ -72,7 +69,7 @@ public class CloudIdentityApiMetadata extends KeystoneApiMetadata {
       return properties;
    }
 
-   public static class Builder extends KeystoneApiMetadata.Builder {
+   public static class Builder extends KeystoneApiMetadata.Builder<Builder> {
       protected Builder(){
          super(KeystoneApi.class, KeystoneAsyncApi.class);
          id("rackspace-cloudidentity")
@@ -97,10 +94,8 @@ public class CloudIdentityApiMetadata extends KeystoneApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
    }
-
 }

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/CloudLoadBalancersApiMetadata.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/CloudLoadBalancersApiMetadata.java
@@ -48,9 +48,9 @@ import com.google.inject.Module;
  */
 public class CloudLoadBalancersApiMetadata extends BaseRestApiMetadata {
 
-   @SuppressWarnings("serial")
-   public static final TypeToken<RestContext<CloudLoadBalancersApi, CloudLoadBalancersAsyncApi>> CONTEXT_TOKEN = 
-         new TypeToken<RestContext<CloudLoadBalancersApi, CloudLoadBalancersAsyncApi>>() {};
+   public static final TypeToken<RestContext<CloudLoadBalancersApi, CloudLoadBalancersAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<CloudLoadBalancersApi, CloudLoadBalancersAsyncApi>>() {
+      private static final long serialVersionUID = 1L;
+   };
 
    @Override
    public Builder toBuilder() {
@@ -73,7 +73,7 @@ public class CloudLoadBalancersApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(CloudLoadBalancersApi.class, CloudLoadBalancersAsyncApi.class);
@@ -81,8 +81,7 @@ public class CloudLoadBalancersApiMetadata extends BaseRestApiMetadata {
                .name("Rackspace Cloud Load Balancers API")
                .identityName("Username")
                .credentialName("API Key")
-               .documentation(
-                     URI.create("http://docs.rackspace.com/loadbalancers/api/clb-devguide-latest/index.html"))
+               .documentation(URI.create("http://docs.rackspace.com/loadbalancers/api/clb-devguide-latest/index.html"))
                .version("1.0")
                .defaultEndpoint("https://identity.api.rackspacecloud.com/v2.0/")
                .defaultProperties(CloudLoadBalancersApiMetadata.defaultProperties())
@@ -101,11 +100,8 @@ public class CloudLoadBalancersApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
-
 }

--- a/apis/s3/src/main/java/org/jclouds/s3/S3ApiMetadata.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/S3ApiMetadata.java
@@ -66,18 +66,19 @@ import com.google.inject.Module;
 public class S3ApiMetadata extends BaseRestApiMetadata {
    
    public static final TypeToken<RestContext<? extends S3Client,? extends  S3AsyncClient>> CONTEXT_TOKEN = new TypeToken<RestContext<? extends S3Client,? extends  S3AsyncClient>>() {
+      private static final long serialVersionUID = 1L;
    };
 
    @Override
-   public Builder toBuilder() {
-      return (Builder) new Builder(getApi(), getAsyncApi()).fromApiMetadata(this);
+   public Builder<?> toBuilder() {
+      return new ConcreteBuilder().fromApiMetadata(this);
    }
 
    public S3ApiMetadata() {
-      this(new Builder(S3Client.class, S3AsyncClient.class));
+      this(new ConcreteBuilder());
    }
 
-   protected S3ApiMetadata(Builder builder) {
+   protected S3ApiMetadata(Builder<?> builder) {
       super(builder);
    }
 
@@ -100,7 +101,10 @@ public class S3ApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
    
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static abstract class Builder<T extends Builder<T>> extends BaseRestApiMetadata.Builder<T> {
+      protected Builder() {
+         this(S3Client.class, S3AsyncClient.class);
+      }
 
       protected Builder(Class<?> syncClient, Class<?> asyncClient){
          super(syncClient, asyncClient);
@@ -121,12 +125,12 @@ public class S3ApiMetadata extends BaseRestApiMetadata {
       public ApiMetadata build() {
          return new S3ApiMetadata(this);
       }
-
+   }
+   
+   private static class ConcreteBuilder extends Builder<ConcreteBuilder> {
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected ConcreteBuilder self() {
          return this;
       }
    }
-
 }

--- a/apis/sqs/src/main/java/org/jclouds/sqs/SQSApiMetadata.java
+++ b/apis/sqs/src/main/java/org/jclouds/sqs/SQSApiMetadata.java
@@ -45,6 +45,7 @@ import com.google.inject.Module;
 public class SQSApiMetadata extends BaseRestApiMetadata {
    
    public static final TypeToken<RestContext<SQSApi, SQSAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<SQSApi, SQSAsyncApi>>() {
+      private static final long serialVersionUID = 1L;
    };
 
    @Override
@@ -72,7 +73,7 @@ public class SQSApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
    
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder(Class<?> api, Class<?> asyncApi) {
          super(api, asyncApi);
@@ -91,12 +92,10 @@ public class SQSApiMetadata extends BaseRestApiMetadata {
       public SQSApiMetadata build() {
          return new SQSApiMetadata(this);
       }
-      
+
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
    }
-
 }

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/SwiftApiMetadata.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/SwiftApiMetadata.java
@@ -47,19 +47,20 @@ import com.google.inject.Module;
  */
 public class SwiftApiMetadata extends BaseRestApiMetadata {
 
-   public static final TypeToken<RestContext<SwiftClient, SwiftAsyncClient>> CONTEXT_TOKEN = new TypeToken<RestContext<SwiftClient, SwiftAsyncClient>>() {
+   public static final TypeToken<RestContext<? extends SwiftClient, ? extends SwiftAsyncClient>> CONTEXT_TOKEN = new TypeToken<RestContext<? extends SwiftClient, ? extends SwiftAsyncClient>>() {
+      private static final long serialVersionUID = 1L;
    };
 
    @Override
-   public Builder toBuilder() {
-      return (Builder) new Builder(getApi(), getAsyncApi()).fromApiMetadata(this);
+   public Builder<?> toBuilder() {
+      return new ConcreteBuilder().fromApiMetadata(this);
    }
 
    public SwiftApiMetadata() {
-      this(new Builder(SwiftClient.class, SwiftAsyncClient.class));
+      this(new ConcreteBuilder());
    }
 
-   protected SwiftApiMetadata(Builder builder) {
+   protected SwiftApiMetadata(Builder<?> builder) {
       super(builder);
    }
 
@@ -76,7 +77,11 @@ public class SwiftApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static abstract class Builder<T extends Builder<T>> extends BaseRestApiMetadata.Builder<T> {
+      protected Builder() {
+         this(SwiftClient.class, SwiftAsyncClient.class);
+      }
+      
       protected Builder(Class<?> syncClient, Class<?> asyncClient){
          super(syncClient, asyncClient);
          id("swift")
@@ -99,10 +104,11 @@ public class SwiftApiMetadata extends BaseRestApiMetadata {
       public SwiftApiMetadata build() {
          return new SwiftApiMetadata(this);
       }
-
+   }
+   
+   private static class ConcreteBuilder extends Builder<ConcreteBuilder> {
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected ConcreteBuilder self() {
          return this;
       }
    }

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/SwiftKeystoneApiMetadata.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/SwiftKeystoneApiMetadata.java
@@ -46,22 +46,19 @@ import com.google.inject.Module;
 public class SwiftKeystoneApiMetadata extends SwiftApiMetadata {
 
    public static final TypeToken<RestContext<SwiftKeystoneClient, SwiftKeystoneAsyncClient>> CONTEXT_TOKEN = new TypeToken<RestContext<SwiftKeystoneClient, SwiftKeystoneAsyncClient>>() {
+      private static final long serialVersionUID = 1L;
    };
 
-   private static Builder builder() {
-      return new Builder();
-   }
-
    @Override
-   public Builder toBuilder() {
-      return builder().fromApiMetadata(this);
+   public Builder<?> toBuilder() {
+      return new ConcreteBuilder().fromApiMetadata(this);
    }
 
    public SwiftKeystoneApiMetadata() {
-      this(builder());
+      this(new ConcreteBuilder());
    }
 
-   protected SwiftKeystoneApiMetadata(Builder builder) {
+   protected SwiftKeystoneApiMetadata(Builder<?> builder) {
       super(builder);
    }
 
@@ -73,7 +70,7 @@ public class SwiftKeystoneApiMetadata extends SwiftApiMetadata {
       return properties;
    }
 
-   public static class Builder extends SwiftApiMetadata.Builder {
+   public static abstract class Builder<T extends Builder<T>> extends SwiftApiMetadata.Builder<T> {
       protected Builder() {
          this(SwiftKeystoneClient.class, SwiftKeystoneAsyncClient.class);
       }
@@ -100,10 +97,11 @@ public class SwiftKeystoneApiMetadata extends SwiftApiMetadata {
       public SwiftKeystoneApiMetadata build() {
          return new SwiftKeystoneApiMetadata(this);
       }
-
+   }
+   
+   private static class ConcreteBuilder extends Builder<ConcreteBuilder> {
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected ConcreteBuilder self() {
          return this;
       }
    }

--- a/apis/vcloud/src/main/java/org/jclouds/vcloud/VCloudApiMetadata.java
+++ b/apis/vcloud/src/main/java/org/jclouds/vcloud/VCloudApiMetadata.java
@@ -51,6 +51,7 @@ import com.google.inject.Module;
 public class VCloudApiMetadata extends BaseRestApiMetadata {
 
    public static final TypeToken<RestContext<VCloudClient, VCloudAsyncClient>> CONTEXT_TOKEN = new TypeToken<RestContext<VCloudClient, VCloudAsyncClient>>() {
+      private static final long serialVersionUID = 1L;
    };
    
    @Override
@@ -89,7 +90,7 @@ public class VCloudApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(VCloudClient.class, VCloudAsyncClient.class);
@@ -110,11 +111,8 @@ public class VCloudApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
-
 }

--- a/blobstore/src/main/java/org/jclouds/blobstore/TransientApiMetadata.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/TransientApiMetadata.java
@@ -36,18 +36,18 @@ public class TransientApiMetadata extends BaseApiMetadata {
 
    @Override
    public Builder toBuilder() {
-      return Builder.class.cast(builder().fromApiMetadata(this));
+      return new Builder().fromApiMetadata(this);
    }
 
    public TransientApiMetadata() {
-      super(builder());
+      super(new Builder());
    }
 
    protected TransientApiMetadata(Builder builder) {
       super(builder);
    }
 
-   public static class Builder extends BaseApiMetadata.Builder {
+   public static class Builder extends BaseApiMetadata.Builder<Builder> {
 
       protected Builder() {
          id("transient")
@@ -67,6 +67,9 @@ public class TransientApiMetadata extends BaseApiMetadata {
          return new TransientApiMetadata(this);
       }
 
+      @Override
+      protected Builder self() {
+         return this;
+      }
    }
-
 }

--- a/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/internal/TerremarkVCloudApiMetadata.java
+++ b/common/trmk/src/main/java/org/jclouds/trmk/vcloud_0_8/internal/TerremarkVCloudApiMetadata.java
@@ -26,7 +26,7 @@ import org.jclouds.rest.internal.BaseRestApiMetadata;
  */
 public abstract class TerremarkVCloudApiMetadata extends BaseRestApiMetadata {
 
-   protected TerremarkVCloudApiMetadata(Builder builder) {
+   protected TerremarkVCloudApiMetadata(Builder<?> builder) {
       super(builder);
    }
 
@@ -50,7 +50,7 @@ public abstract class TerremarkVCloudApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public abstract static class Builder extends BaseRestApiMetadata.Builder {
+   public abstract static class Builder<B extends Builder<B>> extends BaseRestApiMetadata.Builder<B> {
 
       protected Builder(Class<?> syncClient, Class<?> asyncClient) {
          super(syncClient, asyncClient);
@@ -60,13 +60,5 @@ public abstract class TerremarkVCloudApiMetadata extends BaseRestApiMetadata {
          .defaultProperties(TerremarkVCloudApiMetadata.defaultProperties())
          .view(ComputeServiceContext.class);
       }
-
-      @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
-         return this;
-      }
-
    }
-
 }

--- a/compute/src/main/java/org/jclouds/compute/stub/StubApiMetadata.java
+++ b/compute/src/main/java/org/jclouds/compute/stub/StubApiMetadata.java
@@ -30,25 +30,21 @@ import org.jclouds.compute.stub.config.StubComputeServiceContextModule;
  * @author Adrian Cole
  */
 public class StubApiMetadata extends BaseApiMetadata {
-   
-   public static Builder builder() {
-      return new Builder();
-   }
 
    @Override
    public Builder toBuilder() {
-      return Builder.class.cast(builder().fromApiMetadata(this));
+      return new Builder().fromApiMetadata(this);
    }
 
    public StubApiMetadata() {
-      super(builder());
+      super(new Builder());
    }
 
    protected StubApiMetadata(Builder builder) {
       super(builder);
    }
 
-   public static class Builder extends BaseApiMetadata.Builder {
+   public static class Builder extends BaseApiMetadata.Builder<Builder> {
 
       protected Builder(){
          id("stub")
@@ -67,5 +63,9 @@ public class StubApiMetadata extends BaseApiMetadata {
          return new StubApiMetadata(this);
       }
 
+      @Override
+      protected Builder self() {
+         return this;
+      }
    }
 }

--- a/core/src/main/java/org/jclouds/apis/ApiMetadata.java
+++ b/core/src/main/java/org/jclouds/apis/ApiMetadata.java
@@ -41,107 +41,107 @@ import com.google.inject.Module;
 @Beta
 public interface ApiMetadata {
 
-   public static interface Builder {
+   public static interface Builder<B extends Builder<B>>{
       /**
        * @see ApiMetadata#getId()
        */
-      Builder id(String id);
+      B id(String id);
 
       /**
        * @see ApiMetadata#getName()
        */
-      Builder name(String name);
+      B name(String name);
 
       /**
        * @see ApiMetadata#getContext()
        */
-      Builder context(TypeToken<? extends Context> context);
+      B context(TypeToken<? extends Context> context);
 
       /**
        * @see ApiMetadata#getViews()
        */
-      Builder view(Class<? extends View> view);
+      B view(Class<? extends View> view);
       
       /**
        * @see ApiMetadata#getViews()
        */
-      Builder view(TypeToken<? extends View> view);
+      B view(TypeToken<? extends View> view);
 
       /**
        * @see ApiMetadata#getViews()
        */
-      Builder views(Set<TypeToken<? extends View>> views);
+      B views(Set<TypeToken<? extends View>> views);
 
       /**
        * @see ApiMetadata#getEndpointName()
        */
-      Builder endpointName(String endpointName);
+      B endpointName(String endpointName);
 
       /**
        * @see ApiMetadata#getIdentityName()
        */
-      Builder identityName(String identityName);
+      B identityName(String identityName);
 
       /**
        * @see ApiMetadata#getCredentialName()
        */
-      Builder credentialName(@Nullable String credentialName);
+      B credentialName(@Nullable String credentialName);
 
       /**
        * @see ApiMetadata#getVersion()
        */
-      Builder version(String version);
+      B version(String version);
 
       /**
        * @see ApiMetadata#getBuildVersion()
        */
-      Builder buildVersion(@Nullable String buildVersion);
+      B buildVersion(@Nullable String buildVersion);
 
       /**
        * @see ApiMetadata#getDefaultEndpoint()
        */
-      Builder defaultEndpoint(@Nullable String defaultEndpoint);
+      B defaultEndpoint(@Nullable String defaultEndpoint);
 
       /**
        * @see ApiMetadata#getDefaultIdentity()
        */
-      Builder defaultIdentity(@Nullable String defaultIdentity);
+      B defaultIdentity(@Nullable String defaultIdentity);
 
       /**
        * @see ApiMetadata#getDefaultCredential()
        */
-      Builder defaultCredential(@Nullable String defaultCredential);
+      B defaultCredential(@Nullable String defaultCredential);
 
       /**
        * @see ApiMetadata#getDefaultProperties()
        */
-      Builder defaultProperties(Properties defaultProperties);
+      B defaultProperties(Properties defaultProperties);
       
       /**
        * @see ApiMetadata#getDefaultModules()
        */
-      Builder defaultModule(Class<? extends Module> defaultModule);
+      B defaultModule(Class<? extends Module> defaultModule);
 
       /**
        * @see ApiMetadata#getDefaultModules()
        */
-      Builder defaultModules(Set<Class<? extends Module>> defaultModules);
+      B defaultModules(Set<Class<? extends Module>> defaultModules);
       
       /**
        * @see ApiMetadata#getDocumentation()
        */
-      Builder documentation(URI documentation);
+      B documentation(URI documentation);
 
       ApiMetadata build();
 
-      Builder fromApiMetadata(ApiMetadata from);
+      B fromApiMetadata(ApiMetadata from);
       
    }
 
    /**
     * @see Builder
     */
-   Builder toBuilder();
+   Builder<?> toBuilder();
 
    /**
     * 

--- a/core/src/main/java/org/jclouds/apis/internal/BaseApiMetadata.java
+++ b/core/src/main/java/org/jclouds/apis/internal/BaseApiMetadata.java
@@ -42,8 +42,8 @@ import org.jclouds.View;
 import org.jclouds.apis.ApiMetadata;
 
 import com.google.common.base.Objects;
-import com.google.common.base.Optional;
 import com.google.common.base.Objects.ToStringHelper;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.TypeToken;
 import com.google.inject.Module;
@@ -76,7 +76,9 @@ public abstract class BaseApiMetadata implements ApiMetadata {
       return props;
    }
    
-   public static class Builder implements ApiMetadata.Builder {
+   public static abstract class Builder<T extends Builder<T>> implements ApiMetadata.Builder<T> {
+      protected abstract T self();
+
       protected String id;
       protected String name;
       protected Set<TypeToken<? extends View>> views = ImmutableSet.of();
@@ -98,25 +100,25 @@ public abstract class BaseApiMetadata implements ApiMetadata {
        * {@inheritDoc}
        */
       @Override
-      public Builder id(String id) {
+      public T id(String id) {
          this.id = checkNotNull(id, "id");
-         return this;
+         return self();
       }
 
       /**
        * {@inheritDoc}
        */
       @Override
-      public Builder name(String name) {
+      public T name(String name) {
          this.name = checkNotNull(name, "name");
-         return this;
+         return self();
       }
       
       /**
        * {@inheritDoc}
        */
       @Override
-      public Builder view(Class<? extends View> view) {
+      public T view(Class<? extends View> view) {
          return view(TypeToken.of(checkNotNull(view, "view")));
       }
       
@@ -124,7 +126,7 @@ public abstract class BaseApiMetadata implements ApiMetadata {
        * {@inheritDoc}
        */
       @Override
-      public Builder view(TypeToken<? extends View> view) {
+      public T view(TypeToken<? extends View> view) {
          return views(ImmutableSet.<TypeToken<? extends View>>of(checkNotNull(view, "view")));
       }
       
@@ -132,115 +134,115 @@ public abstract class BaseApiMetadata implements ApiMetadata {
        * {@inheritDoc}
        */
       @Override
-      public Builder views(Set<TypeToken<? extends View>> views) {
+      public T views(Set<TypeToken<? extends View>> views) {
          this.views = ImmutableSet.copyOf(checkNotNull(views, "views"));
-         return this;
+         return self();
       }
 
       /**
        * {@inheritDoc}
        */
       @Override
-      public Builder endpointName(String endpointName) {
+      public T endpointName(String endpointName) {
          this.endpointName = checkNotNull(endpointName, "endpointName");
-         return this;
+         return self();
       }
 
       /**
        * {@inheritDoc}
        */
       @Override
-      public Builder identityName(String identityName) {
+      public T identityName(String identityName) {
          this.identityName = checkNotNull(identityName, "identityName");
-         return this;
+         return self();
       }
 
       /**
        * {@inheritDoc}
        */
       @Override
-      public Builder credentialName(String credentialName) {
+      public T credentialName(String credentialName) {
          this.credentialName = Optional.fromNullable(credentialName);
-         return this;
+         return self();
       }
 
       /**
        * {@inheritDoc}
        */
       @Override
-      public Builder version(String version) {
+      public T version(String version) {
          this.version = checkNotNull(version, "version");
-         return this;
+         return self();
       }
 
       /**
        * {@inheritDoc}
        */
       @Override
-      public Builder buildVersion(String buildVersion) {
+      public T buildVersion(String buildVersion) {
          this.buildVersion = Optional.fromNullable(buildVersion);
-         return this;
+         return self();
       }
 
       /**
        * {@inheritDoc}
        */
       @Override
-      public Builder defaultEndpoint(String defaultEndpoint) {
+      public T defaultEndpoint(String defaultEndpoint) {
          this.defaultEndpoint = Optional.fromNullable(defaultEndpoint);
-         return this;
+         return self();
       }
 
       /**
        * {@inheritDoc}
        */
       @Override
-      public Builder defaultIdentity(String defaultIdentity) {
+      public T defaultIdentity(String defaultIdentity) {
          this.defaultIdentity = Optional.fromNullable(defaultIdentity);
-         return this;
+         return self();
       }
 
       /**
        * {@inheritDoc}
        */
       @Override
-      public Builder defaultCredential(String defaultCredential) {
+      public T defaultCredential(String defaultCredential) {
          this.defaultCredential = Optional.fromNullable(defaultCredential);
-         return this;
+         return self();
       }
 
       /**
        * {@inheritDoc}
        */
       @Override
-      public Builder defaultProperties(Properties defaultProperties) {
+      public T defaultProperties(Properties defaultProperties) {
          this.defaultProperties = checkNotNull(defaultProperties, "defaultProperties");
-         return this;
+         return self();
       }
 
       /**
        * {@inheritDoc}
        */
       @Override
-      public Builder documentation(URI documentation) {
+      public T documentation(URI documentation) {
          this.documentation = checkNotNull(documentation, "documentation");
-         return this;
+         return self();
       }
 
       /**
        * {@inheritDoc}
        */
       @Override
-      public Builder context(TypeToken<? extends Context> context) {
+      public T context(TypeToken<? extends Context> context) {
          this.context = checkNotNull(context, "context");
-         return this;
+         return self();
       }
 
       /**
        * {@inheritDoc}
        */
       @Override
-      public Builder defaultModule(Class<? extends Module> defaultModule) {
+      public T defaultModule(Class<? extends Module> defaultModule) {
          return defaultModules(ImmutableSet.<Class<? extends Module>>of(checkNotNull(defaultModule, "defaultModule")));
       }
       
@@ -248,12 +250,12 @@ public abstract class BaseApiMetadata implements ApiMetadata {
        * {@inheritDoc}
        */
       @Override
-      public Builder defaultModules(Set<Class<? extends Module>> defaultModules) {
+      public T defaultModules(Set<Class<? extends Module>> defaultModules) {
          this.defaultModules = ImmutableSet.copyOf(checkNotNull(defaultModules, "defaultModules"));
-         return this;
+         return self();
       }
 
-      public Builder fromApiMetadata(ApiMetadata in) {
+      public T fromApiMetadata(ApiMetadata in) {
          return id(in.getId()).views(in.getViews()).name(in.getName()).endpointName(in.getEndpointName()).identityName(
                   in.getIdentityName()).credentialName(in.getCredentialName().orNull()).version(in.getVersion())
                   .buildVersion(in.getBuildVersion().orNull()).defaultEndpoint(in.getDefaultEndpoint().orNull())
@@ -261,13 +263,6 @@ public abstract class BaseApiMetadata implements ApiMetadata {
                            in.getDefaultCredential().orNull()).defaultProperties(in.getDefaultProperties())
                   .documentation(in.getDocumentation()).context(in.getContext()).defaultModules(in.getDefaultModules());
       }
-
-      @Override
-      public ApiMetadata build() {
-         return new BaseApiMetadata(this) {
-         };
-      }
-
    }
 
    protected final String id;
@@ -286,7 +281,7 @@ public abstract class BaseApiMetadata implements ApiMetadata {
    protected final TypeToken<? extends Context> context;
    protected final Set<Class<? extends Module>> defaultModules;
 
-   protected BaseApiMetadata(Builder builder) {
+   protected BaseApiMetadata(Builder<?> builder) {
       this(builder.id, builder.name, builder.views, builder.endpointName, builder.identityName, builder.credentialName,
                builder.version, builder.buildVersion, builder.defaultEndpoint, builder.defaultIdentity,
                builder.defaultCredential, builder.defaultProperties, builder.documentation, builder.context,
@@ -462,11 +457,6 @@ public abstract class BaseApiMetadata implements ApiMetadata {
    @Override
    public Set<Class<? extends Module>> getDefaultModules() {
       return defaultModules;
-   }
-
-   @Override
-   public Builder toBuilder() {
-      return new Builder().fromApiMetadata(this);
    }
 
 }

--- a/core/src/main/java/org/jclouds/rest/AnonymousRestApiMetadata.java
+++ b/core/src/main/java/org/jclouds/rest/AnonymousRestApiMetadata.java
@@ -20,7 +20,6 @@ package org.jclouds.rest;
 
 import java.net.URI;
 
-import org.jclouds.apis.ApiMetadata;
 import org.jclouds.rest.internal.BaseRestApiMetadata;
 
 import com.google.common.annotations.Beta;
@@ -50,7 +49,7 @@ public class AnonymousRestApiMetadata extends BaseRestApiMetadata {
       super(builder);
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static final class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       public Builder(Class<?> client, Class<?> asyncClient) {
          super(client, asyncClient);
@@ -65,12 +64,10 @@ public class AnonymousRestApiMetadata extends BaseRestApiMetadata {
       public AnonymousRestApiMetadata build() {
          return new AnonymousRestApiMetadata(this);
       }
-      
+
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
    }
-
 }

--- a/core/src/main/java/org/jclouds/rest/RestApiMetadata.java
+++ b/core/src/main/java/org/jclouds/rest/RestApiMetadata.java
@@ -30,13 +30,13 @@ import com.google.common.annotations.Beta;
 @Beta
 public interface RestApiMetadata extends ApiMetadata {
 
-   public static interface Builder extends ApiMetadata.Builder {
+   public static interface Builder<T extends Builder<T>> extends ApiMetadata.Builder<T> {
 
       /**
        * @see ApiMetadata#getApi()
        * @see ApiMetadata#getAsyncApi()
        */
-      Builder javaApi(Class<?> api, Class<?> asyncApi);
+      T javaApi(Class<?> api, Class<?> asyncApi);
    }
 
    /**

--- a/core/src/main/java/org/jclouds/rest/internal/BaseRestApiMetadata.java
+++ b/core/src/main/java/org/jclouds/rest/internal/BaseRestApiMetadata.java
@@ -38,23 +38,12 @@ import com.google.common.reflect.TypeToken;
  * @author Adrian Cole
  */
 @Beta
-public class BaseRestApiMetadata extends BaseApiMetadata implements RestApiMetadata {
+public abstract class BaseRestApiMetadata extends BaseApiMetadata implements RestApiMetadata {
 
    protected final Class<?> api;
    protected final Class<?> asyncApi;
 
-   @Override
-   public Builder toBuilder() {
-      return new Builder(getApi(), getAsyncApi()).fromApiMetadata(this);
-   }
-
-   public BaseRestApiMetadata(Class<?> api, Class<?> asyncApi) {
-      super(new Builder(api, asyncApi));
-      this.api = checkNotNull(api, "api");
-      this.asyncApi = checkNotNull(asyncApi, "asyncApi");
-   }
-
-   protected BaseRestApiMetadata(Builder builder) {
+   protected BaseRestApiMetadata(Builder<?> builder) {
       super(builder);
       this.api = checkNotNull(builder.api, "api");
       this.asyncApi = checkNotNull(builder.asyncApi, "asyncApi");
@@ -73,12 +62,11 @@ public class BaseRestApiMetadata extends BaseApiMetadata implements RestApiMetad
       }, asyncApiToken);
    }
    
-   public static class Builder extends BaseApiMetadata.Builder implements RestApiMetadata.Builder {
+   public static abstract class Builder<T extends Builder<T>> extends BaseApiMetadata.Builder<T> implements RestApiMetadata.Builder<T> {
       protected Class<?> api;
       protected Class<?> asyncApi;
-
       
-      public Builder(Class<?> api, Class<?> asyncApi) {
+      protected Builder(Class<?> api, Class<?> asyncApi) {
          checkNotNull(api, "api");
          checkNotNull(asyncApi, "asyncApi");
          javaApi(api, asyncApi)
@@ -91,26 +79,20 @@ public class BaseRestApiMetadata extends BaseApiMetadata implements RestApiMetad
        * {@inheritDoc}
        */
       @Override
-      public Builder javaApi(Class<?> api, Class<?> asyncApi) {
+      public T javaApi(Class<?> api, Class<?> asyncApi) {
          this.api = checkNotNull(api, "api");
          this.asyncApi = checkNotNull(asyncApi, "asyncApi");
-         return this;
-      }
-
-
-      @Override
-      public ApiMetadata build() {
-         return new BaseRestApiMetadata(this);
+         return self();
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
+      public T fromApiMetadata(ApiMetadata in) {
          if (in instanceof RestApiMetadata) {
             RestApiMetadata rest = RestApiMetadata.class.cast(in);
             javaApi(rest.getApi(), rest.getAsyncApi());
          }
          super.fromApiMetadata(in);
-         return this;
+         return self();
       }
 
    }

--- a/core/src/test/java/org/jclouds/apis/JcloudsTestBlobStoreApiMetadata.java
+++ b/core/src/test/java/org/jclouds/apis/JcloudsTestBlobStoreApiMetadata.java
@@ -48,9 +48,7 @@ public class JcloudsTestBlobStoreApiMetadata extends BaseRestApiMetadata {
       super(builder);
    }
 
-   public static class Builder
-         extends
-         BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder(){
          super(IntegrationTestClient.class, IntegrationTestAsyncClient.class);
@@ -67,6 +65,9 @@ public class JcloudsTestBlobStoreApiMetadata extends BaseRestApiMetadata {
          return new JcloudsTestBlobStoreApiMetadata(this);
       }
 
+      @Override
+      protected Builder self() {
+         return this;
+      }
    }
-
 }

--- a/core/src/test/java/org/jclouds/apis/JcloudsTestComputeApiMetadata.java
+++ b/core/src/test/java/org/jclouds/apis/JcloudsTestComputeApiMetadata.java
@@ -48,7 +48,7 @@ public class JcloudsTestComputeApiMetadata extends BaseRestApiMetadata {
       super(builder);
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder(){
          super(IntegrationTestClient.class, IntegrationTestAsyncClient.class);
@@ -65,6 +65,9 @@ public class JcloudsTestComputeApiMetadata extends BaseRestApiMetadata {
          return new JcloudsTestComputeApiMetadata(this);
       }
 
+      @Override
+      protected Builder self() {
+         return this;
+      }
    }
-
 }

--- a/core/src/test/java/org/jclouds/apis/JcloudsTestYetAnotherComputeApiMetadata.java
+++ b/core/src/test/java/org/jclouds/apis/JcloudsTestYetAnotherComputeApiMetadata.java
@@ -48,7 +48,7 @@ public class JcloudsTestYetAnotherComputeApiMetadata extends BaseRestApiMetadata
       super(builder);
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder  {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder>  {
 
       protected Builder(){
          super(IntegrationTestClient.class, IntegrationTestAsyncClient.class);
@@ -65,6 +65,9 @@ public class JcloudsTestYetAnotherComputeApiMetadata extends BaseRestApiMetadata
          return new JcloudsTestYetAnotherComputeApiMetadata(this);
       }
 
+      @Override
+      protected Builder self() {
+         return this;
+      }
    }
-
 }

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/AbiquoApiMetadata.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/AbiquoApiMetadata.java
@@ -48,8 +48,7 @@ import com.google.inject.Module;
 public class AbiquoApiMetadata extends BaseRestApiMetadata {
 
    /** The token describing the rest api context. */
-   public static final TypeToken<RestContext<AbiquoApi, AbiquoAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<AbiquoApi, AbiquoAsyncApi>>() {
-
+   public static TypeToken<RestContext<AbiquoApi, AbiquoAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<AbiquoApi, AbiquoAsyncApi>>() {
       private static final long serialVersionUID = -2098594161943130770L;
    };
 
@@ -57,7 +56,12 @@ public class AbiquoApiMetadata extends BaseRestApiMetadata {
       this(new Builder());
    }
 
-   protected AbiquoApiMetadata(final Builder builder) {
+   @Override
+   public Builder toBuilder() {
+      return new Builder().fromApiMetadata(this);
+   }
+   
+   protected AbiquoApiMetadata(Builder builder) {
       super(builder);
    }
 
@@ -73,12 +77,7 @@ public class AbiquoApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   @Override
-   public Builder toBuilder() {
-      return new Builder().fromApiMetadata(this);
-   }
-
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
       private static final String DOCUMENTATION_ROOT = "http://community.abiquo.com/display/ABI"
             + CharMatcher.DIGIT.retainFrom(AbiquoAsyncApi.API_VERSION);
 
@@ -105,10 +104,10 @@ public class AbiquoApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(final ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
+
    }
 
 }

--- a/labs/azure-management/src/main/java/org/jclouds/azure/management/AzureManagementApiMetadata.java
+++ b/labs/azure-management/src/main/java/org/jclouds/azure/management/AzureManagementApiMetadata.java
@@ -44,6 +44,7 @@ import com.google.inject.Module;
 public class AzureManagementApiMetadata extends BaseRestApiMetadata {
 
    public static final TypeToken<RestContext<AzureManagementApi, AzureManagementAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<AzureManagementApi, AzureManagementAsyncApi>>() {
+      private static final long serialVersionUID = 1L;
    };
 
    private static Builder builder() {
@@ -69,7 +70,7 @@ public class AzureManagementApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
       protected Builder() {
          super(AzureManagementApi.class, AzureManagementAsyncApi.class);
          id("azure-management")
@@ -91,10 +92,8 @@ public class AzureManagementApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
    }
-
 }

--- a/labs/cdmi/src/main/java/org/jclouds/snia/cdmi/v1/CDMIApiMetadata.java
+++ b/labs/cdmi/src/main/java/org/jclouds/snia/cdmi/v1/CDMIApiMetadata.java
@@ -41,6 +41,7 @@ import com.google.inject.Module;
 public class CDMIApiMetadata extends BaseRestApiMetadata {
 
    public static final TypeToken<RestContext<CDMIApi, CDMIAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<CDMIApi, CDMIAsyncApi>>() {
+      private static final long serialVersionUID = 1L;
    };
 
    @Override
@@ -63,7 +64,7 @@ public class CDMIApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(CDMIApi.class, CDMIAsyncApi.class);
@@ -79,11 +80,8 @@ public class CDMIApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
-
 }

--- a/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/CloudStackEC2ApiMetadata.java
+++ b/labs/cloudstack-ec2/src/main/java/org/jclouds/cloudstack/ec2/CloudStackEC2ApiMetadata.java
@@ -42,17 +42,13 @@ import com.google.inject.Module;
  */
 public class CloudStackEC2ApiMetadata extends EC2ApiMetadata {
 
-   private static Builder builder() {
-      return new Builder();
-   }
-
    @Override
    public Builder toBuilder() {
-      return builder().fromApiMetadata(this);
+      return new Builder().fromApiMetadata(this);
    }
 
    public CloudStackEC2ApiMetadata() {
-      this(builder());
+      this(new Builder());
    }
 
    protected CloudStackEC2ApiMetadata(Builder builder) {
@@ -65,7 +61,7 @@ public class CloudStackEC2ApiMetadata extends EC2ApiMetadata {
       return properties;
    }
 
-   public static class Builder extends EC2ApiMetadata.Builder {
+   public static class Builder extends EC2ApiMetadata.Builder<Builder> {
       protected Builder(){
          super(EC2Client.class, EC2AsyncClient.class);
          id("cloudstack-ec2")
@@ -87,10 +83,8 @@ public class CloudStackEC2ApiMetadata extends EC2ApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
    }
-
 }

--- a/labs/elb/src/main/java/org/jclouds/elb/ELBApiMetadata.java
+++ b/labs/elb/src/main/java/org/jclouds/elb/ELBApiMetadata.java
@@ -45,6 +45,7 @@ import com.google.inject.Module;
 public class ELBApiMetadata extends BaseRestApiMetadata {
    
    public static final TypeToken<RestContext<ELBApi, ELBAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<ELBApi, ELBAsyncApi>>() {
+      private static final long serialVersionUID = 1L;
    };
 
    @Override
@@ -68,7 +69,7 @@ public class ELBApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
    
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder(Class<?> api, Class<?> asyncApi) {
          super(api, asyncApi);
@@ -88,12 +89,10 @@ public class ELBApiMetadata extends BaseRestApiMetadata {
       public ELBApiMetadata build() {
          return new ELBApiMetadata(this);
       }
-      
+
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
    }
-
 }

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/FGCPApiMetadata.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/FGCPApiMetadata.java
@@ -36,8 +36,7 @@ import com.google.common.reflect.TypeToken;
 import com.google.inject.Module;
 
 /**
- * Implementation of {@link ApiMetadata} for Fujitsu's Global Cloud Platform
- * (FGCP, FGCP/S5) provider in Australia.
+ * Implementation of {@link ApiMetadata} for Fujitsu's Global Cloud Platform (FGCP)
  * 
  * @author Dies Koper
  */
@@ -67,7 +66,7 @@ public class FGCPApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(FGCPApi.class, FGCPAsyncApi.class);
@@ -94,10 +93,8 @@ public class FGCPApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
 }

--- a/labs/google-compute/src/main/java/org/jclouds/googlecompute/GoogleComputeApiMetadata.java
+++ b/labs/google-compute/src/main/java/org/jclouds/googlecompute/GoogleComputeApiMetadata.java
@@ -45,8 +45,9 @@ import static org.jclouds.oauth.v2.config.OAuthProperties.SIGNATURE_OR_MAC_ALGOR
  */
 public class GoogleComputeApiMetadata extends BaseRestApiMetadata {
 
-   public static final TypeToken<RestContext<GoogleComputeApi, GoogleComputeAsyncApi>> CONTEXT_TOKEN = new
-           TypeToken<RestContext<GoogleComputeApi, GoogleComputeAsyncApi>>() {};
+   public static final TypeToken<RestContext<GoogleComputeApi, GoogleComputeAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<GoogleComputeApi, GoogleComputeAsyncApi>>() {
+      private static final long serialVersionUID = 1L;
+   };
 
    @Override
    public Builder toBuilder() {
@@ -71,7 +72,7 @@ public class GoogleComputeApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(GoogleComputeApi.class, GoogleComputeAsyncApi.class);
@@ -96,11 +97,8 @@ public class GoogleComputeApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
-
 }

--- a/labs/iam/src/main/java/org/jclouds/iam/IAMApiMetadata.java
+++ b/labs/iam/src/main/java/org/jclouds/iam/IAMApiMetadata.java
@@ -41,6 +41,7 @@ import com.google.common.reflect.TypeToken;
 public class IAMApiMetadata extends BaseRestApiMetadata {
 
    public static final TypeToken<RestContext<? extends IAMApi, ? extends IAMAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<? extends IAMApi, ? extends IAMAsyncApi>>() {
+      private static final long serialVersionUID = 1L;
    };
 
    @Override
@@ -64,7 +65,7 @@ public class IAMApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder(Class<?> api, Class<?> asyncApi) {
          super(api, asyncApi);
@@ -83,12 +84,10 @@ public class IAMApiMetadata extends BaseRestApiMetadata {
       public IAMApiMetadata build() {
          return new IAMApiMetadata(this);
       }
-      
+
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
    }
-
 }

--- a/labs/jenkins/src/main/java/org/jclouds/jenkins/v1/JenkinsApiMetadata.java
+++ b/labs/jenkins/src/main/java/org/jclouds/jenkins/v1/JenkinsApiMetadata.java
@@ -43,6 +43,7 @@ public class JenkinsApiMetadata extends BaseRestApiMetadata {
    public static final String ANONYMOUS_IDENTITY = "ANONYMOUS";
 
    public static final TypeToken<RestContext<JenkinsApi, JenkinsAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<JenkinsApi, JenkinsAsyncApi>>() {
+      private static final long serialVersionUID = 1L;
    };
 
    @Override
@@ -64,7 +65,7 @@ public class JenkinsApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(JenkinsApi.class, JenkinsAsyncApi.class);
@@ -87,11 +88,8 @@ public class JenkinsApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
-
 }

--- a/labs/joyent-cloudapi/src/main/java/org/jclouds/joyent/cloudapi/v6_5/JoyentCloudApiMetadata.java
+++ b/labs/joyent-cloudapi/src/main/java/org/jclouds/joyent/cloudapi/v6_5/JoyentCloudApiMetadata.java
@@ -45,6 +45,7 @@ import com.google.inject.Module;
 public class JoyentCloudApiMetadata extends BaseRestApiMetadata {
 
    public static final TypeToken<RestContext<JoyentCloudApi, JoyentCloudAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<JoyentCloudApi, JoyentCloudAsyncApi>>() {
+      private static final long serialVersionUID = 1L;
    };
 
    @Override
@@ -71,7 +72,7 @@ public class JoyentCloudApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(JoyentCloudApi.class, JoyentCloudAsyncApi.class);
@@ -93,11 +94,8 @@ public class JoyentCloudApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
-
 }

--- a/labs/nodepool/src/main/java/org/jclouds/nodepool/NodePoolApiMetadata.java
+++ b/labs/nodepool/src/main/java/org/jclouds/nodepool/NodePoolApiMetadata.java
@@ -41,17 +41,13 @@ import com.google.inject.Module;
 
 public class NodePoolApiMetadata extends BaseApiMetadata {
 
-   public static Builder builder() {
-      return new Builder();
-   }
-
    @Override
    public Builder toBuilder() {
-      return Builder.class.cast(builder().fromApiMetadata(this));
+      return new Builder().fromApiMetadata(this);
    }
 
    public NodePoolApiMetadata() {
-      super(builder());
+      super(new Builder());
    }
 
    protected NodePoolApiMetadata(Builder builder) {
@@ -76,7 +72,7 @@ public class NodePoolApiMetadata extends BaseApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseApiMetadata.Builder {
+   public static class Builder extends BaseApiMetadata.Builder<Builder> {
       protected Builder() {
          id("nodepool")
                   .name("node pool provider wrapper")
@@ -98,6 +94,9 @@ public class NodePoolApiMetadata extends BaseApiMetadata {
          return new NodePoolApiMetadata(this);
       }
 
+      @Override
+      protected Builder self() {
+         return this;
+      }
    }
-
 }

--- a/labs/oauth/src/main/java/org/jclouds/oauth/v2/OAuthApiMetadata.java
+++ b/labs/oauth/src/main/java/org/jclouds/oauth/v2/OAuthApiMetadata.java
@@ -42,8 +42,9 @@ import static org.jclouds.oauth.v2.config.OAuthProperties.SIGNATURE_OR_MAC_ALGOR
  */
 public class OAuthApiMetadata extends BaseRestApiMetadata {
 
-   public static final TypeToken<RestContext<OAuthApi, OAuthAsyncApi>> CONTEXT_TOKEN = new
-           TypeToken<RestContext<OAuthApi, OAuthAsyncApi>>() {};
+   public static final TypeToken<RestContext<OAuthApi, OAuthAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<OAuthApi, OAuthAsyncApi>>() {
+      private static final long serialVersionUID = 1L;
+   };
 
    @Override
    public Builder toBuilder() {
@@ -66,7 +67,7 @@ public class OAuthApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(OAuthApi.class, OAuthAsyncApi.class);
@@ -86,11 +87,8 @@ public class OAuthApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
-
 }

--- a/labs/openstack-glance/src/main/java/org/jclouds/openstack/glance/v1_0/GlanceApiMetadata.java
+++ b/labs/openstack-glance/src/main/java/org/jclouds/openstack/glance/v1_0/GlanceApiMetadata.java
@@ -47,6 +47,7 @@ import com.google.inject.Module;
 public class GlanceApiMetadata extends BaseRestApiMetadata {
 
    public static final TypeToken<RestContext<GlanceApi, GlanceAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<GlanceApi, GlanceAsyncApi>>() {
+      private static final long serialVersionUID = 1L;
    };
 
    @Override
@@ -70,7 +71,7 @@ public class GlanceApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(GlanceApi.class, GlanceAsyncApi.class);
@@ -95,11 +96,8 @@ public class GlanceApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
-
 }

--- a/labs/openstack-quantum/src/main/java/org/jclouds/openstack/quantum/v1_0/QuantumApiMetadata.java
+++ b/labs/openstack-quantum/src/main/java/org/jclouds/openstack/quantum/v1_0/QuantumApiMetadata.java
@@ -47,6 +47,7 @@ import com.google.inject.Module;
 public class QuantumApiMetadata extends BaseRestApiMetadata {
 
    public static final TypeToken<RestContext<QuantumApi, QuantumAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<QuantumApi, QuantumAsyncApi>>() {
+      private static final long serialVersionUID = 1L;
    };
 
    @Override
@@ -70,7 +71,7 @@ public class QuantumApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(QuantumApi.class, QuantumAsyncApi.class);
@@ -95,11 +96,8 @@ public class QuantumApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
-
 }

--- a/labs/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/SwiftApiMetadata.java
+++ b/labs/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/SwiftApiMetadata.java
@@ -47,6 +47,7 @@ import com.google.inject.Module;
 public class SwiftApiMetadata extends BaseRestApiMetadata {
 
    public static final TypeToken<RestContext<SwiftApi, SwiftAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<SwiftApi, SwiftAsyncApi>>() {
+      private static final long serialVersionUID = 1L;
    };
 
    @Override
@@ -70,7 +71,7 @@ public class SwiftApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(SwiftApi.class, SwiftAsyncApi.class);
@@ -95,11 +96,8 @@ public class SwiftApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
-
 }

--- a/labs/opsource-servers/src/main/java/org/jclouds/opsource/servers/OpSourceServersApiMetadata.java
+++ b/labs/opsource-servers/src/main/java/org/jclouds/opsource/servers/OpSourceServersApiMetadata.java
@@ -39,6 +39,7 @@ import com.google.common.reflect.TypeToken;
 public class OpSourceServersApiMetadata extends BaseRestApiMetadata {
    
    public static final TypeToken<RestContext<OpSourceServersApi, OpSourceServersAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<OpSourceServersApi, OpSourceServersAsyncApi>>() {
+      private static final long serialVersionUID = 1L;
    };
 
    @Override
@@ -60,9 +61,7 @@ public class OpSourceServersApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder
-         extends
-         BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(OpSourceServersApi.class, OpSourceServersAsyncApi.class);
@@ -75,8 +74,6 @@ public class OpSourceServersApiMetadata extends BaseRestApiMetadata {
          .defaultEndpoint("https://api.opsourcecloud.net/oec/${jclouds.api-version}")
          .defaultProperties(OpSourceServersApiMetadata.defaultProperties())
          .defaultModule(OpSourceServersRestClientModule.class);
-//         .view(TypeToken.of(ComputeServiceContext.class))
-//         .defaultModules(ImmutableSet.<Class<? extends Module>>of(OpSourceServersRestClientModule.class, OpSourceServersComputeServiceContextModule.class));
       }
 
       @Override
@@ -85,11 +82,8 @@ public class OpSourceServersApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
-
 }

--- a/labs/rds/src/main/java/org/jclouds/rds/RDSApiMetadata.java
+++ b/labs/rds/src/main/java/org/jclouds/rds/RDSApiMetadata.java
@@ -43,6 +43,7 @@ import com.google.inject.Module;
 public class RDSApiMetadata extends BaseRestApiMetadata {
    
    public static final TypeToken<RestContext<RDSApi, RDSAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<RDSApi, RDSAsyncApi>>() {
+      private static final long serialVersionUID = 1L;
    };
 
    @Override
@@ -66,7 +67,7 @@ public class RDSApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
    
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder(Class<?> api, Class<?> asyncApi) {
          super(api, asyncApi);
@@ -85,12 +86,10 @@ public class RDSApiMetadata extends BaseRestApiMetadata {
       public RDSApiMetadata build() {
          return new RDSApiMetadata(this);
       }
-      
+
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
    }
-
 }

--- a/labs/savvis-symphonyvpdc/src/main/java/org/jclouds/savvis/vpdc/VPDCApiMetadata.java
+++ b/labs/savvis-symphonyvpdc/src/main/java/org/jclouds/savvis/vpdc/VPDCApiMetadata.java
@@ -25,7 +25,6 @@ import static org.jclouds.savvis.vpdc.reference.VPDCConstants.PROPERTY_VPDC_TIME
 import java.net.URI;
 import java.util.Properties;
 
-import org.jclouds.apis.ApiMetadata;
 import org.jclouds.compute.ComputeServiceContext;
 import org.jclouds.rest.RestContext;
 import org.jclouds.rest.internal.BaseRestApiMetadata;
@@ -44,6 +43,7 @@ import com.google.inject.Module;
 public class VPDCApiMetadata extends BaseRestApiMetadata {
 
    public static final TypeToken<RestContext<VPDCApi, VPDCAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<VPDCApi, VPDCAsyncApi>>() {
+      private static final long serialVersionUID = 1L;
    };
    
    @Override
@@ -67,9 +67,7 @@ public class VPDCApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder
-         extends
-         BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(VPDCApi.class, VPDCAsyncApi.class);
@@ -93,11 +91,8 @@ public class VPDCApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
-
 }

--- a/labs/smartos-ssh/src/main/java/org/jclouds/smartos/SmartOSApiMetadata.java
+++ b/labs/smartos-ssh/src/main/java/org/jclouds/smartos/SmartOSApiMetadata.java
@@ -17,24 +17,20 @@ import com.google.inject.Module;
  */
 public class SmartOSApiMetadata extends BaseApiMetadata {
 
-   public static Builder builder() {
-      return new Builder();
-   }
-
    @Override
    public Builder toBuilder() {
-      return Builder.class.cast(builder().fromApiMetadata(this));
+      return new Builder().fromApiMetadata(this);
    }
 
    public SmartOSApiMetadata() {
-      super(builder());
+      super(new Builder());
    }
 
    protected SmartOSApiMetadata(Builder builder) {
       super(builder);
    }
 
-   public static class Builder extends BaseApiMetadata.Builder {
+   public static class Builder extends BaseApiMetadata.Builder<Builder> {
 
       protected Builder() {
          id("smartos-ssh")
@@ -55,5 +51,9 @@ public class SmartOSApiMetadata extends BaseApiMetadata {
          return new SmartOSApiMetadata(this);
       }
 
+      @Override
+      protected Builder self() {
+         return this;
+      }
    }
 }

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/VCloudDirectorApiMetadata.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/VCloudDirectorApiMetadata.java
@@ -77,9 +77,7 @@ public class VCloudDirectorApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder
-         extends
-       BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(VCloudDirectorApi.class, VCloudDirectorAsyncApi.class);
@@ -92,8 +90,6 @@ public class VCloudDirectorApiMetadata extends BaseRestApiMetadata {
          .defaultProperties(VCloudDirectorApiMetadata.defaultProperties())
          .context(TypeToken.of(VCloudDirectorContext.class))
          .defaultModule(VCloudDirectorRestClientModule.class);
-//         .view(TypeToken.of(ComputeServiceContext.class))
-//         .defaultModules(ImmutableSet.<Class<? extends Module>>of(VCloudDirectorRestClientModule.class, VCloudDirectorComputeServiceContextModule.class));
       }
 
       @Override
@@ -102,11 +98,8 @@ public class VCloudDirectorApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
-
 }

--- a/labs/virtualbox/src/main/java/org/jclouds/virtualbox/VirtualBoxApiMetadata.java
+++ b/labs/virtualbox/src/main/java/org/jclouds/virtualbox/VirtualBoxApiMetadata.java
@@ -85,7 +85,7 @@ public class VirtualBoxApiMetadata extends BaseApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseApiMetadata.Builder {
+   public static class Builder extends BaseApiMetadata.Builder<Builder> {
 
       protected Builder() {
          id("virtualbox")
@@ -110,11 +110,8 @@ public class VirtualBoxApiMetadata extends BaseApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
-
 }

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/AWSEC2ApiMetadata.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/AWSEC2ApiMetadata.java
@@ -46,19 +46,16 @@ import com.google.inject.Module;
 public class AWSEC2ApiMetadata extends EC2ApiMetadata {
    
    public static final TypeToken<RestContext<AWSEC2Client, AWSEC2AsyncClient>> CONTEXT_TOKEN = new TypeToken<RestContext<AWSEC2Client, AWSEC2AsyncClient>>() {
+      private static final long serialVersionUID = 1L;
    };
-   
-   private static Builder builder() {
-      return new Builder();
-   }
 
    @Override
    public Builder toBuilder() {
-      return builder().fromApiMetadata(this);
+      return new Builder().fromApiMetadata(this);
    }
 
    public AWSEC2ApiMetadata() {
-      this(builder());
+      this(new Builder());
    }
 
    protected AWSEC2ApiMetadata(Builder builder) {
@@ -79,7 +76,7 @@ public class AWSEC2ApiMetadata extends EC2ApiMetadata {
       return properties;
    }
 
-   public static class Builder extends EC2ApiMetadata.Builder {
+   public static class Builder extends EC2ApiMetadata.Builder<Builder> {
       protected Builder(){
          super(AWSEC2Client.class, AWSEC2AsyncClient.class);
          id("aws-ec2")
@@ -97,10 +94,8 @@ public class AWSEC2ApiMetadata extends EC2ApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
    }
-
 }

--- a/providers/aws-s3/src/main/java/org/jclouds/aws/s3/AWSS3ApiMetadata.java
+++ b/providers/aws-s3/src/main/java/org/jclouds/aws/s3/AWSS3ApiMetadata.java
@@ -42,19 +42,16 @@ import com.google.inject.Module;
 public class AWSS3ApiMetadata extends S3ApiMetadata {
    
    public static final TypeToken<RestContext<AWSS3Client, AWSS3AsyncClient>> CONTEXT_TOKEN = new TypeToken<RestContext<AWSS3Client, AWSS3AsyncClient>>() {
+      private static final long serialVersionUID = 1L;
    };
-   
-   private static Builder builder() {
-      return new Builder();
-   }
 
    @Override
    public Builder toBuilder() {
-      return builder().fromApiMetadata(this);
+      return new Builder().fromApiMetadata(this);
    }
 
    public AWSS3ApiMetadata() {
-      this(builder());
+      this(new Builder());
    }
 
    protected AWSS3ApiMetadata(Builder builder) {
@@ -68,7 +65,7 @@ public class AWSS3ApiMetadata extends S3ApiMetadata {
       return properties;
    }
 
-   public static class Builder extends S3ApiMetadata.Builder {
+   public static class Builder extends S3ApiMetadata.Builder<Builder> {
       protected Builder(){
          super(AWSS3Client.class, AWSS3AsyncClient.class);
          id("aws-s3")
@@ -85,10 +82,8 @@ public class AWSS3ApiMetadata extends S3ApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
    }
-
 }

--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/AzureBlobApiMetadata.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/AzureBlobApiMetadata.java
@@ -44,6 +44,7 @@ import com.google.inject.Module;
 public class AzureBlobApiMetadata extends BaseRestApiMetadata {
 
    public static final TypeToken<RestContext<AzureBlobClient, AzureBlobAsyncClient>> CONTEXT_TOKEN = new TypeToken<RestContext<AzureBlobClient, AzureBlobAsyncClient>>() {
+      private static final long serialVersionUID = 1L;
    };
    
    private static Builder builder() {
@@ -73,7 +74,7 @@ public class AzureBlobApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
    
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
       protected Builder(){
          super(AzureBlobClient.class, AzureBlobAsyncClient.class);
          id("azureblob")
@@ -94,10 +95,8 @@ public class AzureBlobApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
    }
-
 }

--- a/providers/glesys/src/main/java/org/jclouds/glesys/GleSYSApiMetadata.java
+++ b/providers/glesys/src/main/java/org/jclouds/glesys/GleSYSApiMetadata.java
@@ -44,6 +44,7 @@ import com.google.inject.Module;
 public class GleSYSApiMetadata extends BaseRestApiMetadata {
 
    public static final TypeToken<RestContext<GleSYSApi, GleSYSAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<GleSYSApi, GleSYSAsyncApi>>() {
+      private static final long serialVersionUID = 1L;
    };
    
    @Override
@@ -69,9 +70,7 @@ public class GleSYSApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder
-         extends
-         BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(GleSYSApi.class, GleSYSAsyncApi.class);
@@ -94,11 +93,8 @@ public class GleSYSApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
-
 }

--- a/providers/gogrid/src/main/java/org/jclouds/gogrid/GoGridApiMetadata.java
+++ b/providers/gogrid/src/main/java/org/jclouds/gogrid/GoGridApiMetadata.java
@@ -43,6 +43,7 @@ import com.google.inject.Module;
 public class GoGridApiMetadata extends BaseRestApiMetadata {
 
    public static final TypeToken<RestContext<GoGridClient, GoGridAsyncClient>> CONTEXT_TOKEN = new TypeToken<RestContext<GoGridClient, GoGridAsyncClient>>() {
+      private static final long serialVersionUID = 1L;
    };
    
    @Override
@@ -66,7 +67,7 @@ public class GoGridApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder extends BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(GoGridClient.class, GoGridAsyncClient.class);
@@ -88,11 +89,8 @@ public class GoGridApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
-
 }

--- a/providers/hpcloud-objectstorage/src/main/java/org/jclouds/hpcloud/objectstorage/HPCloudObjectStorageApiMetadata.java
+++ b/providers/hpcloud-objectstorage/src/main/java/org/jclouds/hpcloud/objectstorage/HPCloudObjectStorageApiMetadata.java
@@ -23,7 +23,6 @@ import static org.jclouds.rest.config.BinderUtils.bindClientAndAsyncClient;
 import java.net.URI;
 import java.util.Properties;
 
-import org.jclouds.apis.ApiMetadata;
 import org.jclouds.blobstore.BlobRequestSigner;
 import org.jclouds.hpcloud.objectstorage.blobstore.HPCloudObjectStorageBlobRequestSigner;
 import org.jclouds.hpcloud.objectstorage.blobstore.config.HPCloudObjectStorageBlobStoreContextModule;
@@ -47,19 +46,16 @@ import com.google.inject.Module;
 public class HPCloudObjectStorageApiMetadata extends SwiftKeystoneApiMetadata {
 
    public static final TypeToken<RestContext<HPCloudObjectStorageApi, HPCloudObjectStorageAsyncApi>> CONTEXT_TOKEN = new TypeToken<RestContext<HPCloudObjectStorageApi, HPCloudObjectStorageAsyncApi>>() {
+      private static final long serialVersionUID = 1L;
    };
-
-   private static Builder builder() {
-      return new Builder();
-   }
 
    @Override
    public Builder toBuilder() {
-      return builder().fromApiMetadata(this);
+      return new Builder().fromApiMetadata(this);
    }
 
    public HPCloudObjectStorageApiMetadata() {
-      this(builder());
+      this(new Builder());
    }
 
    protected HPCloudObjectStorageApiMetadata(Builder builder) {
@@ -71,7 +67,7 @@ public class HPCloudObjectStorageApiMetadata extends SwiftKeystoneApiMetadata {
       return properties;
    }
 
-   public static class Builder extends SwiftKeystoneApiMetadata.Builder {
+   public static class Builder extends SwiftKeystoneApiMetadata.Builder<Builder> {
       protected Builder(){
          super(HPCloudObjectStorageApi.class, HPCloudObjectStorageAsyncApi.class);
          id("hpcloud-objectstorage")
@@ -95,28 +91,23 @@ public class HPCloudObjectStorageApiMetadata extends SwiftKeystoneApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
    }
 
    /**
     * Ensures keystone auth is used instead of swift auth
-    *
     */
    public static class HPCloudObjectStorageTemporaryUrlExtensionModule extends
          TemporaryUrlExtensionModule<HPCloudObjectStorageAsyncApi> {
-
       @Override
       protected void bindRequestSigner() {
          bind(BlobRequestSigner.class).to(HPCloudObjectStorageBlobRequestSigner.class);
       }
-
       @Override
       protected void bindTemporaryUrlKeyApi() {
          bindClientAndAsyncClient(binder(), TemporaryUrlKeyApi.class, KeystoneTemporaryUrlKeyAsyncApi.class);
       }
-
    }
 }

--- a/providers/softlayer/src/main/java/org/jclouds/softlayer/SoftLayerApiMetadata.java
+++ b/providers/softlayer/src/main/java/org/jclouds/softlayer/SoftLayerApiMetadata.java
@@ -44,6 +44,7 @@ import com.google.inject.Module;
 public class SoftLayerApiMetadata extends BaseRestApiMetadata {
 
    public static final TypeToken<RestContext<SoftLayerClient, SoftLayerAsyncClient>> CONTEXT_TOKEN = new TypeToken<RestContext<SoftLayerClient, SoftLayerAsyncClient>>() {
+      private static final long serialVersionUID = 1L;
    };
    
    @Override
@@ -68,9 +69,7 @@ public class SoftLayerApiMetadata extends BaseRestApiMetadata {
       return properties;
    }
 
-   public static class Builder
-         extends
-         BaseRestApiMetadata.Builder {
+   public static class Builder extends BaseRestApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(SoftLayerClient.class, SoftLayerAsyncClient.class);
@@ -92,11 +91,8 @@ public class SoftLayerApiMetadata extends BaseRestApiMetadata {
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
-
    }
-
 }

--- a/providers/trmk-ecloud/src/main/java/org/jclouds/trmk/ecloud/TerremarkECloudApiMetadata.java
+++ b/providers/trmk-ecloud/src/main/java/org/jclouds/trmk/ecloud/TerremarkECloudApiMetadata.java
@@ -24,6 +24,7 @@ import com.google.inject.Module;
 public class TerremarkECloudApiMetadata extends TerremarkVCloudApiMetadata {
 
    public static final TypeToken<RestContext<TerremarkECloudClient, TerremarkECloudAsyncClient>> CONTEXT_TOKEN = new TypeToken<RestContext<TerremarkECloudClient, TerremarkECloudAsyncClient>>() {
+      private static final long serialVersionUID = 1L;
    };
    
    @Override
@@ -46,7 +47,7 @@ public class TerremarkECloudApiMetadata extends TerremarkVCloudApiMetadata {
       return properties;
    }
 
-   public static class Builder extends TerremarkVCloudApiMetadata.Builder {
+   public static class Builder extends TerremarkVCloudApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(TerremarkECloudClient.class, TerremarkECloudAsyncClient.class);
@@ -63,12 +64,10 @@ public class TerremarkECloudApiMetadata extends TerremarkVCloudApiMetadata {
       public TerremarkECloudApiMetadata build() {
          return new TerremarkECloudApiMetadata(this);
       }
-
+      
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
    }
-
 }

--- a/providers/trmk-vcloudexpress/src/main/java/org/jclouds/trmk/vcloudexpress/TerremarkVCloudExpressApiMetadata.java
+++ b/providers/trmk-vcloudexpress/src/main/java/org/jclouds/trmk/vcloudexpress/TerremarkVCloudExpressApiMetadata.java
@@ -42,6 +42,7 @@ import com.google.inject.Module;
 public class TerremarkVCloudExpressApiMetadata extends TerremarkVCloudApiMetadata {
 
    public static final TypeToken<RestContext<TerremarkVCloudExpressClient, TerremarkVCloudExpressAsyncClient>> CONTEXT_TOKEN = new TypeToken<RestContext<TerremarkVCloudExpressClient, TerremarkVCloudExpressAsyncClient>>() {
+      private static final long serialVersionUID = 1L;
    };
    
    @Override
@@ -64,9 +65,7 @@ public class TerremarkVCloudExpressApiMetadata extends TerremarkVCloudApiMetadat
       return properties;
    }
 
-   public static class Builder
-         extends
-         TerremarkVCloudApiMetadata.Builder {
+   public static class Builder extends TerremarkVCloudApiMetadata.Builder<Builder> {
 
       protected Builder() {
          super(TerremarkVCloudExpressClient.class, TerremarkVCloudExpressAsyncClient.class);
@@ -87,10 +86,8 @@ public class TerremarkVCloudExpressApiMetadata extends TerremarkVCloudApiMetadat
       }
 
       @Override
-      public Builder fromApiMetadata(ApiMetadata in) {
-         super.fromApiMetadata(in);
+      protected Builder self() {
          return this;
       }
    }
-
 }

--- a/skeletons/standalone-compute/src/main/java/org/jclouds/servermanager/ServerManagerApiMetadata.java
+++ b/skeletons/standalone-compute/src/main/java/org/jclouds/servermanager/ServerManagerApiMetadata.java
@@ -13,24 +13,20 @@ import org.jclouds.servermanager.compute.config.ServerManagerComputeServiceConte
  */
 public class ServerManagerApiMetadata extends BaseApiMetadata {
 
-   public static Builder builder() {
-      return new Builder();
-   }
-
    @Override
    public Builder toBuilder() {
-      return Builder.class.cast(builder().fromApiMetadata(this));
+      return new Builder().fromApiMetadata(this);
    }
 
    public ServerManagerApiMetadata() {
-      super(builder());
+      super(new Builder());
    }
 
    protected ServerManagerApiMetadata(Builder builder) {
       super(builder);
    }
 
-   public static class Builder extends BaseApiMetadata.Builder {
+   public static class Builder extends BaseApiMetadata.Builder<Builder> {
 
       protected Builder(){
          id("servermanager")
@@ -49,5 +45,9 @@ public class ServerManagerApiMetadata extends BaseApiMetadata {
          return new ServerManagerApiMetadata(this);
       }
 
+      @Override
+      protected Builder self() {
+         return this;
+      }
    }
 }


### PR DESCRIPTION
fixed builder covariance so that subclass types are correct.  also fixed serialization warnings.

when this is merged, please merge the following: cc @nacx
https://github.com/jclouds/jclouds-chef/tree/apimetadatabuilder-covariance
