### PR TITLE
Ignore ETags with non-hex suffixes

### DIFF
--- a/apis/s3/src/main/java/org/jclouds/s3/xml/ListBucketHandler.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/xml/ListBucketHandler.java
@@ -21,6 +21,7 @@ package org.jclouds.s3.xml;
 import static org.jclouds.http.Uris.uriBuilder;
 import static org.jclouds.util.SaxUtils.currentOrNull;
 
+import java.util.regex.Pattern;
 import javax.inject.Inject;
 
 import org.jclouds.crypto.CryptoStreams;
@@ -64,6 +65,9 @@ public class ListBucketHandler extends ParseSax.HandlerWithResult<ListBucketResp
    private String delimiter;
    private boolean isTruncated;
 
+   /** Some blobs have a non-hex suffix when created by multi-part uploads such Amazon S3. */
+   private static final Pattern MULTIPART_BLOB_ETAG = Pattern.compile("[0-9a-f]+-[0-9]+");
+
    @Inject
    public ListBucketHandler(DateService dateParser) {
       this.dateParser = dateParser;
@@ -99,7 +103,10 @@ public class ListBucketHandler extends ParseSax.HandlerWithResult<ListBucketResp
       } else if (qName.equals("ETag")) {
          String currentETag = currentOrNull(currentText);
          builder.eTag(currentETag);
-         builder.contentMD5(CryptoStreams.hex(Strings2.replaceAll(currentETag, '"', "")));
+         currentETag = Strings2.replaceAll(currentETag, '"', "");
+         if (!MULTIPART_BLOB_ETAG.matcher(currentETag).matches()) {
+            builder.contentMD5(CryptoStreams.hex(currentETag));
+         }
       } else if (qName.equals("Size")) {
          builder.contentLength(Long.valueOf(currentOrNull(currentText)));
       } else if (qName.equals("Owner")) {


### PR DESCRIPTION
Amazon S3 blobs created via multi-part uploads have these suffixes.
Reference:

https://forums.aws.amazon.com/thread.jspa?messageID=203510
