### PR TITLE
openstack-nova: NPE in SecurityGroupApi.delete()

### DIFF
--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/extensions/SecurityGroupAsyncApi.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/extensions/SecurityGroupAsyncApi.java
@@ -102,7 +102,7 @@ public interface SecurityGroupAsyncApi {
     */
    @DELETE
    @Path("/os-security-groups/{id}")
-   @Fallback(NullOnNotFoundOr404.class)
+   @Fallback(FalseOnNotFoundOr404.class)
    @Consumes(MediaType.APPLICATION_JSON)
    ListenableFuture<Boolean> delete(@PathParam("id") String id);
 


### PR DESCRIPTION
Note that this also occurs in 1.5.x, where delete() should be annotated:
@ExceptionParser(ReturnFalseOnNotFoundOr404.class)
