### PR TITLE
centralize TypeToken creation

### DIFF
--- a/apis/atmos/src/main/java/org/jclouds/atmos/AtmosApiMetadata.java
+++ b/apis/atmos/src/main/java/org/jclouds/atmos/AtmosApiMetadata.java
@@ -22,6 +22,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.jclouds.Constants.PROPERTY_TIMEOUTS_PREFIX;
 import static org.jclouds.blobstore.reference.BlobStoreConstants.PROPERTY_USER_METADATA_PREFIX;
 import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGIONS;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import java.net.URI;
 import java.util.Properties;
@@ -87,7 +88,7 @@ public class AtmosApiMetadata extends BaseRestApiMetadata {
          .version("1.4.0")
          .defaultEndpoint("https://accesspoint.atmosonline.com")
          .defaultProperties(AtmosApiMetadata.defaultProperties())
-         .view(TypeToken.of(BlobStoreContext.class))
+         .view(typeTokenOf(BlobStoreContext.class))
          .defaultModules(ImmutableSet.<Class<? extends Module>>of(AtmosRestClientModule.class, AtmosBlobStoreContextModule.class));
       }
 

--- a/apis/cloudfiles/src/main/java/org/jclouds/cloudfiles/config/CloudFilesRestClientModule.java
+++ b/apis/cloudfiles/src/main/java/org/jclouds/cloudfiles/config/CloudFilesRestClientModule.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.cloudfiles.config;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import java.net.URI;
 import java.util.Map;
 
@@ -38,7 +40,6 @@ import org.jclouds.rest.ConfiguresRestClient;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 
@@ -49,7 +50,7 @@ import com.google.inject.Scopes;
 @ConfiguresRestClient
 public class CloudFilesRestClientModule extends SwiftRestClientModule<CloudFilesClient, CloudFilesAsyncClient> {
    public CloudFilesRestClientModule() {
-      super(TypeToken.of(CloudFilesClient.class), TypeToken.of(CloudFilesAsyncClient.class), ImmutableMap
+      super(typeTokenOf(CloudFilesClient.class), typeTokenOf(CloudFilesAsyncClient.class), ImmutableMap
                .<Class<?>, Class<?>> of());
    }
 

--- a/apis/cloudservers/src/main/java/org/jclouds/cloudservers/CloudServersApiMetadata.java
+++ b/apis/cloudservers/src/main/java/org/jclouds/cloudservers/CloudServersApiMetadata.java
@@ -21,6 +21,7 @@ package org.jclouds.cloudservers;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.jclouds.Constants.PROPERTY_TIMEOUTS_PREFIX;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import java.net.URI;
 import java.util.Properties;
@@ -79,7 +80,7 @@ public class CloudServersApiMetadata extends BaseRestApiMetadata {
          .version("1.0")
          .defaultEndpoint("https://auth.api.rackspacecloud.com")
          .defaultProperties(CloudServersApiMetadata.defaultProperties())
-         .view(TypeToken.of(ComputeServiceContext.class))
+         .view(typeTokenOf(ComputeServiceContext.class))
          .defaultModules(ImmutableSet.<Class<? extends Module>>of(CloudServersRestClientModule.class, CloudServersComputeServiceContextModule.class));
       }
 

--- a/apis/cloudsigma/src/main/java/org/jclouds/cloudsigma/CloudSigmaApiMetadata.java
+++ b/apis/cloudsigma/src/main/java/org/jclouds/cloudsigma/CloudSigmaApiMetadata.java
@@ -22,6 +22,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.jclouds.Constants.PROPERTY_TIMEOUTS_PREFIX;
 import static org.jclouds.cloudsigma.reference.CloudSigmaConstants.PROPERTY_VNC_PASSWORD;
 import static org.jclouds.compute.config.ComputeServiceProperties.TEMPLATE;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import java.net.URI;
 import java.util.Properties;
@@ -86,7 +87,7 @@ public class CloudSigmaApiMetadata extends BaseRestApiMetadata {
          .version("1.0")
          .defaultEndpoint("https://api.cloudsigma.com")
          .defaultProperties(CloudSigmaApiMetadata.defaultProperties())
-         .view(TypeToken.of(ComputeServiceContext.class))
+         .view(typeTokenOf(ComputeServiceContext.class))
          .defaultModules(ImmutableSet.<Class<? extends Module>>of(CloudSigmaRestClientModule.class, CloudSigmaComputeServiceContextModule.class));
       }
 

--- a/apis/cloudstack/src/main/java/org/jclouds/cloudstack/CloudStackApiMetadata.java
+++ b/apis/cloudstack/src/main/java/org/jclouds/cloudstack/CloudStackApiMetadata.java
@@ -20,6 +20,7 @@ package org.jclouds.cloudstack;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.jclouds.Constants.PROPERTY_TIMEOUTS_PREFIX;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import java.net.URI;
 import java.util.Properties;
@@ -80,7 +81,7 @@ public class CloudStackApiMetadata extends BaseRestApiMetadata {
          .documentation(URI.create("http://download.cloud.com/releases/2.2.0/api_2.2.12/TOC_User.html"))
          .defaultEndpoint("http://localhost:8080/client/api")
          .version("2.2")
-         .view(TypeToken.of(CloudStackContext.class))
+         .view(typeTokenOf(CloudStackContext.class))
          .defaultProperties(CloudStackApiMetadata.defaultProperties())
          .defaultModules(ImmutableSet.<Class<? extends Module>> builder()
                                      .add(CloudStackParserModule.class)

--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/internal/BaseCloudStackClientLiveTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/internal/BaseCloudStackClientLiveTest.java
@@ -21,6 +21,7 @@ package org.jclouds.cloudstack.internal;
 import static com.google.common.collect.Iterables.filter;
 import static com.google.common.collect.Iterables.get;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 import static org.jclouds.util.Predicates2.retry;
 import static org.testng.Assert.assertEquals;
 
@@ -85,7 +86,7 @@ public class BaseCloudStackClientLiveTest extends BaseGenericComputeServiceConte
    
    @Override
    protected TypeToken<CloudStackContext> viewType() {
-      return TypeToken.of(CloudStackContext.class);
+      return typeTokenOf(CloudStackContext.class);
    }
    
    @Override

--- a/apis/cloudwatch/src/main/java/org/jclouds/cloudwatch/config/CloudWatchRestClientModule.java
+++ b/apis/cloudwatch/src/main/java/org/jclouds/cloudwatch/config/CloudWatchRestClientModule.java
@@ -18,17 +18,18 @@
  */
 package org.jclouds.cloudwatch.config;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import java.util.Map;
 
 import org.jclouds.aws.config.FormSigningRestClientModule;
-import org.jclouds.cloudwatch.CloudWatchAsyncApi;
 import org.jclouds.cloudwatch.CloudWatchApi;
-import org.jclouds.cloudwatch.features.MetricAsyncApi;
+import org.jclouds.cloudwatch.CloudWatchAsyncApi;
 import org.jclouds.cloudwatch.features.MetricApi;
+import org.jclouds.cloudwatch.features.MetricAsyncApi;
 import org.jclouds.rest.ConfiguresRestClient;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 /**
  * Configures the Monitoring connection.
@@ -42,7 +43,7 @@ public class CloudWatchRestClientModule extends FormSigningRestClientModule<Clou
          .build();
    
    public CloudWatchRestClientModule() {
-      super(TypeToken.of(CloudWatchApi.class), TypeToken.of(CloudWatchAsyncApi.class), DELEGATE_MAP);
+      super(typeTokenOf(CloudWatchApi.class), typeTokenOf(CloudWatchAsyncApi.class), DELEGATE_MAP);
    }
 
 }

--- a/apis/ec2/src/main/java/org/jclouds/ec2/config/EC2RestClientModule.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/config/EC2RestClientModule.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.ec2.config;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import java.util.Map;
 
 import javax.inject.Singleton;
@@ -90,7 +92,7 @@ public class EC2RestClientModule<S extends EC2Api, A extends EC2AsyncApi> extend
    @SuppressWarnings("unchecked")
    public EC2RestClientModule() {
       // retaining top-level type of EC2Client vs EC2Api until we migrate all functionality up
-      super(TypeToken.class.cast(TypeToken.of(EC2Client.class)), TypeToken.class.cast(TypeToken.of(EC2AsyncClient.class)), DELEGATE_MAP);
+      super(TypeToken.class.cast(typeTokenOf(EC2Client.class)), TypeToken.class.cast(typeTokenOf(EC2AsyncClient.class)), DELEGATE_MAP);
    }
 
    protected EC2RestClientModule(TypeToken<S> syncClientType, TypeToken<A> asyncClientType,

--- a/apis/elasticstack/src/main/java/org/jclouds/elasticstack/ElasticStackApiMetadata.java
+++ b/apis/elasticstack/src/main/java/org/jclouds/elasticstack/ElasticStackApiMetadata.java
@@ -21,6 +21,7 @@ package org.jclouds.elasticstack;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.jclouds.Constants.PROPERTY_TIMEOUTS_PREFIX;
 import static org.jclouds.elasticstack.reference.ElasticStackConstants.PROPERTY_VNC_PASSWORD;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import java.net.URI;
 import java.util.Properties;
@@ -86,7 +87,7 @@ public class ElasticStackApiMetadata extends BaseRestApiMetadata {
          .version("1.0")
          .defaultEndpoint("https://api-lon-p.elastichosts.com")
          .defaultProperties(ElasticStackApiMetadata.defaultProperties())
-         .view(TypeToken.of(ComputeServiceContext.class))
+         .view(typeTokenOf(ComputeServiceContext.class))
          .defaultModules(ImmutableSet.<Class<? extends Module>>of(ElasticStackRestClientModule.class, ElasticStackComputeServiceContextModule.class));
       }
 

--- a/apis/openstack-cinder/src/main/java/org/jclouds/openstack/cinder/v1/config/CinderRestClientModule.java
+++ b/apis/openstack-cinder/src/main/java/org/jclouds/openstack/cinder/v1/config/CinderRestClientModule.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.openstack.cinder.v1.config;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import java.net.URI;
 import java.util.Map;
 
@@ -66,7 +68,7 @@ public class CinderRestClientModule<S extends CinderApi, A extends CinderAsyncAp
 
    @SuppressWarnings("unchecked")
    public CinderRestClientModule() {
-      super(TypeToken.class.cast(TypeToken.of(CinderApi.class)), TypeToken.class.cast(TypeToken.of(CinderAsyncApi.class)), DELEGATE_MAP);
+      super(TypeToken.class.cast(typeTokenOf(CinderApi.class)), TypeToken.class.cast(typeTokenOf(CinderAsyncApi.class)), DELEGATE_MAP);
    }
 
    protected CinderRestClientModule(TypeToken<S> syncClientType, TypeToken<A> asyncClientType, Map<Class<?>, Class<?>> sync2Async) {

--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/KeystoneRestClientModule.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/keystone/v2_0/config/KeystoneRestClientModule.java
@@ -18,6 +18,7 @@
  */
 package org.jclouds.openstack.keystone.v2_0.config;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 import static org.jclouds.util.Suppliers2.getLastValueInMap;
 
 import java.net.URI;
@@ -90,7 +91,7 @@ public class KeystoneRestClientModule<S extends KeystoneApi, A extends KeystoneA
 
    @SuppressWarnings("unchecked")
    public KeystoneRestClientModule() {
-      super(TypeToken.class.cast(TypeToken.of(KeystoneApi.class)), TypeToken.class.cast(TypeToken.of(KeystoneAsyncApi.class)), DELEGATE_MAP);
+      super(TypeToken.class.cast(typeTokenOf(KeystoneApi.class)), TypeToken.class.cast(typeTokenOf(KeystoneAsyncApi.class)), DELEGATE_MAP);
    }
 
    protected KeystoneRestClientModule(TypeToken<S> syncApiType, TypeToken<A> asyncApiType, Map<Class<?>, Class<?>> sync2Async) {

--- a/apis/openstack-nova-ec2/src/main/java/org/jclouds/openstack/nova/ec2/config/NovaEC2RestClientModule.java
+++ b/apis/openstack-nova-ec2/src/main/java/org/jclouds/openstack/nova/ec2/config/NovaEC2RestClientModule.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.openstack.nova.ec2.config;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import java.util.Map;
 
 import javax.inject.Singleton;
@@ -55,7 +57,6 @@ import org.jclouds.openstack.nova.ec2.xml.NovaDescribeImagesResponseHandler;
 import org.jclouds.rest.ConfiguresRestClient;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 
@@ -78,7 +79,7 @@ public class NovaEC2RestClientModule extends EC2RestClientModule<NovaEC2Client, 
          .build();
 
    public NovaEC2RestClientModule() {
-      super(TypeToken.of(NovaEC2Client.class), TypeToken.of(NovaEC2AsyncClient.class), DELEGATE_MAP);
+      super(typeTokenOf(NovaEC2Client.class), typeTokenOf(NovaEC2AsyncClient.class), DELEGATE_MAP);
    }
    
    @Override

--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/NovaApiMetadata.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/NovaApiMetadata.java
@@ -25,6 +25,7 @@ import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.SERV
 import static org.jclouds.openstack.nova.v2_0.config.NovaProperties.AUTO_ALLOCATE_FLOATING_IPS;
 import static org.jclouds.openstack.nova.v2_0.config.NovaProperties.AUTO_GENERATE_KEYPAIRS;
 import static org.jclouds.openstack.nova.v2_0.config.NovaProperties.TIMEOUT_SECURITYGROUP_PRESENT;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import java.net.URI;
 import java.util.Properties;
@@ -97,7 +98,7 @@ public class NovaApiMetadata extends BaseRestApiMetadata {
          .version("1.1")
          .defaultEndpoint("http://localhost:5000/v2.0/")
          .defaultProperties(NovaApiMetadata.defaultProperties())
-         .view(TypeToken.of(ComputeServiceContext.class))
+         .view(typeTokenOf(ComputeServiceContext.class))
          .defaultModules(ImmutableSet.<Class<? extends Module>>builder()
                                      .add(KeystoneAuthenticationModule.class)
                                      .add(ZoneModule.class)

--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/config/NovaRestClientModule.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/config/NovaRestClientModule.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.openstack.nova.v2_0.config;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import java.net.URI;
 import java.util.Map;
 import java.util.Set;
@@ -119,7 +121,7 @@ public class NovaRestClientModule<S extends NovaApi, A extends NovaAsyncApi> ext
    
    @SuppressWarnings("unchecked")
    public NovaRestClientModule() {
-      super(TypeToken.class.cast(TypeToken.of(NovaApi.class)), TypeToken.class.cast(TypeToken.of(NovaAsyncApi.class)), DELEGATE_MAP);
+      super(TypeToken.class.cast(typeTokenOf(NovaApi.class)), TypeToken.class.cast(typeTokenOf(NovaAsyncApi.class)), DELEGATE_MAP);
    }
 
    protected NovaRestClientModule(TypeToken<S> syncClientType, TypeToken<A> asyncClientType,

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/CloudLoadBalancersApiMetadata.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/CloudLoadBalancersApiMetadata.java
@@ -22,6 +22,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.jclouds.Constants.PROPERTY_TIMEOUTS_PREFIX;
 import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
 import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.SERVICE_TYPE;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import java.net.URI;
 import java.util.Properties;
@@ -40,7 +41,6 @@ import org.jclouds.rest.internal.BaseRestApiMetadata;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.TypeToken;
 import com.google.inject.Module;
-
 /**
  * Implementation of {@link ApiMetadata} for CloudLoadBalancers 1.0 API
  * 
@@ -86,7 +86,7 @@ public class CloudLoadBalancersApiMetadata extends BaseRestApiMetadata {
                .version("1.0")
                .defaultEndpoint("https://identity.api.rackspacecloud.com/v2.0/")
                .defaultProperties(CloudLoadBalancersApiMetadata.defaultProperties())
-               .view(TypeToken.of(LoadBalancerServiceContext.class))
+               .view(typeTokenOf(LoadBalancerServiceContext.class))
                .defaultModules(
                      ImmutableSet.<Class<? extends Module>> of(
                            CloudIdentityAuthenticationModule.class,

--- a/apis/s3/src/main/java/org/jclouds/s3/S3ApiMetadata.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/S3ApiMetadata.java
@@ -27,6 +27,7 @@ import static org.jclouds.aws.reference.AWSConstants.PROPERTY_HEADER_TAG;
 import static org.jclouds.blobstore.reference.BlobStoreConstants.DIRECTORY_SUFFIX_FOLDER;
 import static org.jclouds.blobstore.reference.BlobStoreConstants.PROPERTY_BLOBSTORE_DIRECTORY_SUFFIX;
 import static org.jclouds.blobstore.reference.BlobStoreConstants.PROPERTY_USER_METADATA_PREFIX;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 import static org.jclouds.s3.reference.S3Constants.PROPERTY_S3_SERVICE_PATH;
 import static org.jclouds.s3.reference.S3Constants.PROPERTY_S3_VIRTUAL_HOST_BUCKETS;
 
@@ -115,7 +116,7 @@ public class S3ApiMetadata extends BaseRestApiMetadata {
          .version(S3AsyncClient.VERSION)
          .defaultProperties(S3ApiMetadata.defaultProperties())
          .context(CONTEXT_TOKEN)
-         .view(TypeToken.of(S3BlobStoreContext.class))
+         .view(typeTokenOf(S3BlobStoreContext.class))
          .defaultModules(ImmutableSet.<Class<? extends Module>>of(S3RestClientModule.class, S3BlobStoreContextModule.class));
       }
 

--- a/apis/s3/src/main/java/org/jclouds/s3/blobstore/S3BlobRequestSigner.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/blobstore/S3BlobRequestSigner.java
@@ -20,6 +20,7 @@ package org.jclouds.s3.blobstore;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.jclouds.blobstore.util.BlobStoreUtils.cleanRequest;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -61,7 +62,7 @@ public class S3BlobRequestSigner<T extends S3AsyncClient> implements BlobRequest
       this.processor = checkNotNull(processor, "processor");
       this.blobToObject = checkNotNull(blobToObject, "blobToObject");
       this.blob2HttpGetOptions = checkNotNull(blob2HttpGetOptions, "blob2HttpGetOptions");
-      TypeToken<T> interfaceType = TypeToken.of(interfaceClass);
+      TypeToken<T> interfaceType = typeTokenOf(interfaceClass);
       this.getMethod = interfaceType.method(interfaceClass.getMethod("getObject", String.class, String.class,
             GetOptions[].class));
       this.deleteMethod = interfaceType.method(interfaceClass.getMethod("deleteObject", String.class, String.class));

--- a/apis/s3/src/main/java/org/jclouds/s3/config/S3RestClientModule.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/config/S3RestClientModule.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.s3.config;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import java.net.URI;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -75,7 +77,7 @@ public class S3RestClientModule<S extends S3Client, A extends S3AsyncClient> ext
 
    @SuppressWarnings("unchecked")
    public S3RestClientModule() {
-      this(TypeToken.class.cast(TypeToken.of(S3Client.class)), TypeToken.class.cast(TypeToken.of(S3AsyncClient.class)));
+      this(TypeToken.class.cast(typeTokenOf(S3Client.class)), TypeToken.class.cast(typeTokenOf(S3AsyncClient.class)));
    }
 
    protected S3RestClientModule(TypeToken<S> syncClientType, TypeToken<A> asyncClientType) {

--- a/apis/sqs/src/main/java/org/jclouds/sqs/config/SQSRestClientModule.java
+++ b/apis/sqs/src/main/java/org/jclouds/sqs/config/SQSRestClientModule.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.sqs.config;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import java.util.Map;
 
 import org.jclouds.aws.config.FormSigningRestClientModule;
@@ -39,7 +41,6 @@ import org.jclouds.sqs.handlers.ParseSQSErrorFromXmlContent;
 import org.jclouds.sqs.handlers.SQSErrorRetryHandler;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 /**
  * Configures the SQS connection.
@@ -55,7 +56,7 @@ public class SQSRestClientModule extends FormSigningRestClientModule<SQSApi, SQS
          .build();
 
    public SQSRestClientModule() {
-      super(TypeToken.of(SQSApi.class), TypeToken.of(SQSAsyncApi.class), DELEGATE_MAP);
+      super(typeTokenOf(SQSApi.class), typeTokenOf(SQSAsyncApi.class), DELEGATE_MAP);
    }
    
    @Override

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/SwiftApiMetadata.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/SwiftApiMetadata.java
@@ -23,6 +23,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.jclouds.Constants.PROPERTY_TIMEOUTS_PREFIX;
 import static org.jclouds.blobstore.reference.BlobStoreConstants.PROPERTY_USER_METADATA_PREFIX;
 import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGIONS;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import java.net.URI;
 import java.util.Properties;
@@ -91,7 +92,7 @@ public class SwiftApiMetadata extends BaseRestApiMetadata {
          .documentation(URI.create("http://api.openstack.org/"))
          .version("1.0")
          .defaultProperties(SwiftApiMetadata.defaultProperties())
-         .view(TypeToken.of(BlobStoreContext.class))
+         .view(typeTokenOf(BlobStoreContext.class))
          .context(CONTEXT_TOKEN)
          .defaultModules(ImmutableSet.<Class<? extends Module>>builder()
                                      .add(StorageEndpointModule.class)

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/blobstore/SwiftBlobSigner.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/blobstore/SwiftBlobSigner.java
@@ -25,6 +25,7 @@ import static com.google.common.io.BaseEncoding.base16;
 import static com.google.common.io.ByteStreams.readBytes;
 import static org.jclouds.blobstore.util.BlobStoreUtils.cleanRequest;
 import static org.jclouds.crypto.Macs.asByteProcessor;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 import static org.jclouds.util.Strings2.toInputStream;
 
 import java.io.IOException;
@@ -98,7 +99,7 @@ public class SwiftBlobSigner<T extends CommonSwiftAsyncClient> implements BlobRe
       this.blobToObject = checkNotNull(blobToObject, "blobToObject");
       this.blob2HttpGetOptions = checkNotNull(blob2HttpGetOptions, "blob2HttpGetOptions");
 
-      TypeToken<?> owner = TypeToken.of(interfaceType.getType());
+      TypeToken<?> owner = typeTokenOf(interfaceType.getType());
       this.getMethod = owner.method(interfaceType.getRawType().getMethod("getObject", String.class, String.class,
             GetOptions[].class));
       this.deleteMethod = owner

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/config/SwiftKeystoneRestClientModule.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/config/SwiftKeystoneRestClientModule.java
@@ -1,5 +1,7 @@
 package org.jclouds.openstack.swift.config;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import org.jclouds.openstack.swift.CommonSwiftAsyncClient;
 import org.jclouds.openstack.swift.CommonSwiftClient;
 import org.jclouds.openstack.swift.SwiftKeystoneAsyncClient;
@@ -7,7 +9,6 @@ import org.jclouds.openstack.swift.SwiftKeystoneClient;
 import org.jclouds.rest.ConfiguresRestClient;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 import com.google.inject.Scopes;
 
 /**
@@ -18,7 +19,7 @@ import com.google.inject.Scopes;
 public class SwiftKeystoneRestClientModule extends SwiftRestClientModule<SwiftKeystoneClient, SwiftKeystoneAsyncClient> {
 
    public SwiftKeystoneRestClientModule() {
-      super(TypeToken.of(SwiftKeystoneClient.class), TypeToken.of(SwiftKeystoneAsyncClient.class), ImmutableMap
+      super(typeTokenOf(SwiftKeystoneClient.class), typeTokenOf(SwiftKeystoneAsyncClient.class), ImmutableMap
                .<Class<?>, Class<?>> of());
    }
 

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/config/SwiftRestClientModule.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/config/SwiftRestClientModule.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 package org.jclouds.openstack.swift.config;
-
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 import static org.jclouds.util.Suppliers2.getLastValueInMap;
 
 import java.net.URI;
@@ -63,7 +63,7 @@ public class SwiftRestClientModule<S extends CommonSwiftClient, A extends Common
 
    @SuppressWarnings("unchecked")
    public SwiftRestClientModule() {
-      this(TypeToken.class.cast(TypeToken.of(SwiftClient.class)), TypeToken.class.cast(TypeToken
+      this(TypeToken.class.cast(typeTokenOf(SwiftClient.class)), TypeToken.class.cast(TypeToken
             .of(SwiftAsyncClient.class)), ImmutableMap.<Class<?>, Class<?>> of());
    }
 

--- a/apis/vcloud/src/main/java/org/jclouds/vcloud/VCloudApiMetadata.java
+++ b/apis/vcloud/src/main/java/org/jclouds/vcloud/VCloudApiMetadata.java
@@ -22,6 +22,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.jclouds.Constants.PROPERTY_SESSION_INTERVAL;
 import static org.jclouds.Constants.PROPERTY_TIMEOUTS_PREFIX;
 import static org.jclouds.compute.config.ComputeServiceProperties.TEMPLATE;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 import static org.jclouds.vcloud.reference.VCloudConstants.PROPERTY_VCLOUD_DEFAULT_FENCEMODE;
 import static org.jclouds.vcloud.reference.VCloudConstants.PROPERTY_VCLOUD_TIMEOUT_TASK_COMPLETED;
 import static org.jclouds.vcloud.reference.VCloudConstants.PROPERTY_VCLOUD_VERSION_SCHEMA;
@@ -101,7 +102,7 @@ public class VCloudApiMetadata extends BaseRestApiMetadata {
          .documentation(URI.create("http://www.vmware.com/support/pubs/vcd_pubs.html"))
          .version("1.0")
          .defaultProperties(VCloudApiMetadata.defaultProperties())
-         .view(TypeToken.of(ComputeServiceContext.class))
+         .view(typeTokenOf(ComputeServiceContext.class))
          .defaultModules(ImmutableSet.<Class<? extends Module>>of(VCloudRestClientModule.class, VCloudComputeServiceContextModule.class));
       }
 

--- a/blobstore/src/main/java/org/jclouds/blobstore/util/BlobStoreUtils.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/util/BlobStoreUtils.java
@@ -19,6 +19,7 @@
 package org.jclouds.blobstore.util;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import java.util.List;
 import java.util.Map;

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobStoreIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobStoreIntegrationTest.java
@@ -20,6 +20,7 @@ package org.jclouds.blobstore.integration.internal;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Throwables.propagateIfPossible;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
@@ -523,7 +524,7 @@ public class BaseBlobStoreIntegrationTest extends BaseViewLiveTest<BlobStoreCont
 
    @Override
    protected TypeToken<BlobStoreContext> viewType() {
-      return TypeToken.of(BlobStoreContext.class);
+      return typeTokenOf(BlobStoreContext.class);
    }
 
 }

--- a/blobstore/src/test/java/org/jclouds/blobstore/internal/BaseBlobStoreApiMetadataTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/internal/BaseBlobStoreApiMetadataTest.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.blobstore.internal;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import org.jclouds.View;
 import org.jclouds.apis.ApiMetadata;
 import org.jclouds.apis.internal.BaseApiMetadataTest;
@@ -35,7 +37,7 @@ import com.google.common.reflect.TypeToken;
 public abstract class BaseBlobStoreApiMetadataTest extends BaseApiMetadataTest {
 
    public BaseBlobStoreApiMetadataTest(ApiMetadata toTest) {
-      super(toTest, ImmutableSet.<TypeToken<? extends View>>of(TypeToken.of(BlobStoreContext.class)));
+      super(toTest, ImmutableSet.<TypeToken<? extends View>>of(typeTokenOf(BlobStoreContext.class)));
     }
 
 }

--- a/common/azure/src/test/java/org/jclouds/azure/storage/filters/SharedKeyLiteAuthenticationTest.java
+++ b/common/azure/src/test/java/org/jclouds/azure/storage/filters/SharedKeyLiteAuthenticationTest.java
@@ -18,6 +18,7 @@
  */
 package org.jclouds.azure.storage.filters;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
@@ -141,7 +142,7 @@ public class SharedKeyLiteAuthenticationTest {
             .modules(
                   ImmutableSet.<Module> of(new MockModule(), new NullLoggingModule(),
                         new AzureStorageRestClientModule<IntegrationTestClient, IntegrationTestAsyncClient>(TypeToken
-                                 .of(IntegrationTestClient.class), TypeToken.of(IntegrationTestAsyncClient.class))))
+                                 .of(IntegrationTestClient.class), typeTokenOf(IntegrationTestAsyncClient.class))))
                .buildInjector();
       filter = injector.getInstance(SharedKeyLiteAuthentication.class);
    }

--- a/compute/src/test/java/org/jclouds/compute/internal/BaseComputeServiceApiMetadataTest.java
+++ b/compute/src/test/java/org/jclouds/compute/internal/BaseComputeServiceApiMetadataTest.java
@@ -1,5 +1,7 @@
 package org.jclouds.compute.internal;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import org.jclouds.View;
 import org.jclouds.apis.ApiMetadata;
 import org.jclouds.apis.internal.BaseApiMetadataTest;
@@ -17,7 +19,7 @@ import com.google.common.reflect.TypeToken;
 public abstract class BaseComputeServiceApiMetadataTest extends BaseApiMetadataTest {
 
    public BaseComputeServiceApiMetadataTest(ApiMetadata toTest) {
-     super(toTest, ImmutableSet.<TypeToken<? extends View>>of(TypeToken.of(ComputeServiceContext.class)));
+     super(toTest, ImmutableSet.<TypeToken<? extends View>>of(typeTokenOf(ComputeServiceContext.class)));
    }
 
 }

--- a/compute/src/test/java/org/jclouds/compute/internal/BaseComputeServiceContextLiveTest.java
+++ b/compute/src/test/java/org/jclouds/compute/internal/BaseComputeServiceContextLiveTest.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.compute.internal;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import org.jclouds.compute.ComputeServiceContext;
 
 import com.google.common.reflect.TypeToken;
@@ -29,7 +31,7 @@ public abstract class BaseComputeServiceContextLiveTest extends BaseGenericCompu
 
    @Override
    protected TypeToken<ComputeServiceContext> viewType() {
-      return TypeToken.of(ComputeServiceContext.class);
+      return typeTokenOf(ComputeServiceContext.class);
    }
    
 }

--- a/core/src/main/java/org/jclouds/ContextBuilder.java
+++ b/core/src/main/java/org/jclouds/ContextBuilder.java
@@ -42,6 +42,7 @@ import static org.jclouds.Constants.PROPERTY_ENDPOINT;
 import static org.jclouds.Constants.PROPERTY_IDENTITY;
 import static org.jclouds.Constants.PROPERTY_ISO3166_CODES;
 import static org.jclouds.Constants.PROPERTY_PROVIDER;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 import static org.jclouds.util.Throwables2.propagateAuthorizationOrOriginalException;
 
 import java.util.List;
@@ -485,12 +486,12 @@ public class ContextBuilder {
       return any(modules, configuresRest);
    }
 
-   @SuppressWarnings("unchecked")
+   @SuppressWarnings({ "unchecked", "rawtypes" })
    static void addClientModule(ApiMetadata apiMetadata, List<Module> modules) {
       // TODO: move this up
       if (apiMetadata instanceof RestApiMetadata) {
          RestApiMetadata rest = RestApiMetadata.class.cast(apiMetadata);
-         modules.add(new RestClientModule(TypeToken.of(rest.getApi()), TypeToken.of(rest.getAsyncApi())));
+         modules.add(new RestClientModule(typeTokenOf(rest.getApi()), typeTokenOf(rest.getAsyncApi())));
       } else {
          modules.add(new RestModule());
       }
@@ -567,7 +568,7 @@ public class ContextBuilder {
     * @see #buildView(TypeToken)
     */
    public <V extends View> V buildView(Class<V> viewType) {
-     return buildView(TypeToken.of(checkNotNull(viewType, "viewType")));
+     return buildView(typeTokenOf(viewType));
    }
    
    /**

--- a/core/src/main/java/org/jclouds/apis/Apis.java
+++ b/core/src/main/java/org/jclouds/apis/Apis.java
@@ -21,6 +21,7 @@ package org.jclouds.apis;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Iterables.filter;
 import static com.google.common.collect.Iterables.find;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import java.util.NoSuchElementException;
 import java.util.ServiceLoader;
@@ -115,7 +116,7 @@ public class Apis {
    }
    
    public static Iterable<ApiMetadata> viewableAs(Class<? extends View> type) {
-      return filter(all(), ApiPredicates.viewableAs(TypeToken.of(type)));
+      return filter(all(), ApiPredicates.viewableAs(typeTokenOf(type)));
    }
 
    /**

--- a/core/src/main/java/org/jclouds/apis/internal/BaseApiMetadata.java
+++ b/core/src/main/java/org/jclouds/apis/internal/BaseApiMetadata.java
@@ -32,6 +32,7 @@ import static org.jclouds.Constants.PROPERTY_SCHEDULER_THREADS;
 import static org.jclouds.Constants.PROPERTY_SESSION_INTERVAL;
 import static org.jclouds.Constants.PROPERTY_SO_TIMEOUT;
 import static org.jclouds.Constants.PROPERTY_USER_THREADS;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import java.net.URI;
 import java.util.Properties;
@@ -92,7 +93,7 @@ public abstract class BaseApiMetadata implements ApiMetadata {
       private Optional<String> defaultCredential = Optional.absent();
       private Properties defaultProperties = BaseApiMetadata.defaultProperties();
       private URI documentation;
-      private TypeToken<? extends Context> context = TypeToken.of(Context.class);
+      private TypeToken<? extends Context> context = typeTokenOf(Context.class);
       private Set<Class<? extends Module>> defaultModules = ImmutableSet.of();
 
       /**
@@ -118,7 +119,7 @@ public abstract class BaseApiMetadata implements ApiMetadata {
        */
       @Override
       public T view(Class<? extends View> view) {
-         return view(TypeToken.of(checkNotNull(view, "view")));
+         return view(typeTokenOf(checkNotNull(view, "view")));
       }
       
       /**

--- a/core/src/main/java/org/jclouds/config/BindRestContextWithWildcardExtendsExplicitAndRawType.java
+++ b/core/src/main/java/org/jclouds/config/BindRestContextWithWildcardExtendsExplicitAndRawType.java
@@ -20,6 +20,7 @@ package org.jclouds.config;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import org.jclouds.rest.RestApiMetadata;
 import org.jclouds.rest.RestContext;
@@ -49,7 +50,7 @@ public class BindRestContextWithWildcardExtendsExplicitAndRawType extends Abstra
    @SuppressWarnings("unchecked")
    @Override
    protected void configure() {
-      TypeToken<?> concreteType = BaseRestApiMetadata.contextToken(TypeToken.of(restApiMetadata.getApi()), TypeToken
+      TypeToken<?> concreteType = BaseRestApiMetadata.contextToken(typeTokenOf(restApiMetadata.getApi()), TypeToken
                .of(restApiMetadata.getAsyncApi()));
       // bind explicit type
       bind(TypeLiteral.get(concreteType.getType())).to(

--- a/core/src/main/java/org/jclouds/http/HttpException.java
+++ b/core/src/main/java/org/jclouds/http/HttpException.java
@@ -25,15 +25,17 @@ package org.jclouds.http;
  */
 public class HttpException extends RuntimeException {
 
-    public HttpException(String s) {
-	super(s);
-    }
+   private static final long serialVersionUID = 1L;
 
-    public HttpException(String s, Throwable throwable) {
-	super(s, throwable);
-    }
+   public HttpException(String s) {
+      super(s);
+   }
 
-    public HttpException(Throwable throwable) {
-	super(throwable);
-    }
+   public HttpException(String s, Throwable throwable) {
+      super(s, throwable);
+   }
+
+   public HttpException(Throwable throwable) {
+      super(throwable);
+   }
 }

--- a/core/src/main/java/org/jclouds/http/HttpResponseException.java
+++ b/core/src/main/java/org/jclouds/http/HttpResponseException.java
@@ -32,6 +32,8 @@ import org.jclouds.util.Strings2;
  */
 public class HttpResponseException extends RuntimeException {
 
+   private static final long serialVersionUID = 1L;
+
    protected final HttpCommand command;
    protected final HttpResponse response;
    private String content;

--- a/core/src/main/java/org/jclouds/http/internal/BaseHttpCommandExecutorService.java
+++ b/core/src/main/java/org/jclouds/http/internal/BaseHttpCommandExecutorService.java
@@ -20,6 +20,7 @@ package org.jclouds.http.internal;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.io.ByteStreams.copy;
+import static com.google.common.io.ByteStreams.nullOutputStream;
 import static org.jclouds.http.HttpUtils.checkRequestHasContentLengthOrChunkedEncoding;
 import static org.jclouds.http.HttpUtils.wirePayloadIfEnabled;
 
@@ -47,7 +48,6 @@ import org.jclouds.io.ContentMetadataCodec;
 import org.jclouds.logging.Logger;
 import org.jclouds.util.Throwables2;
 
-import com.google.common.io.NullOutputStream;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 
@@ -106,7 +106,7 @@ public abstract class BaseHttpCommandExecutorService<Q> implements HttpCommandEx
       public void close() throws IOException {
          if (!closed) {
             try {
-               copy(this, new NullOutputStream());
+               copy(this, nullOutputStream());
             } catch (IOException e) {
             } finally {
                closed = true;

--- a/core/src/main/java/org/jclouds/providers/Providers.java
+++ b/core/src/main/java/org/jclouds/providers/Providers.java
@@ -20,6 +20,7 @@ package org.jclouds.providers;
 
 import static com.google.common.collect.Iterables.filter;
 import static com.google.common.collect.Iterables.find;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import java.util.NoSuchElementException;
 import java.util.ServiceLoader;
@@ -116,7 +117,7 @@ public class Providers {
    }
 
    public static Iterable<ProviderMetadata> viewableAs(Class<? extends View> viewableAs) {
-      return filter(all(), ProviderPredicates.viewableAs(TypeToken.of(viewableAs)));
+      return filter(all(), ProviderPredicates.viewableAs(typeTokenOf(viewableAs)));
    }
 
    /**
@@ -178,7 +179,7 @@ public class Providers {
 
    public static Iterable<ProviderMetadata> boundedByIso3166Code(String iso3166Code,
             Class<? extends View> viewableAs) {
-      return boundedByIso3166Code(iso3166Code, TypeToken.of(viewableAs));
+      return boundedByIso3166Code(iso3166Code, typeTokenOf(viewableAs));
    }
 
    /**
@@ -214,6 +215,6 @@ public class Providers {
 
    public static Iterable<ProviderMetadata> collocatedWith(ProviderMetadata providerMetadata,
             Class<? extends View> viewableAs) {
-      return collocatedWith(providerMetadata, TypeToken.of(viewableAs));
+      return collocatedWith(providerMetadata, typeTokenOf(viewableAs));
    }
 }

--- a/core/src/main/java/org/jclouds/reflect/FunctionalReflection.java
+++ b/core/src/main/java/org/jclouds/reflect/FunctionalReflection.java
@@ -24,6 +24,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Predicates.notNull;
 import static com.google.common.base.Throwables.propagate;
 import static com.google.common.collect.Iterables.all;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 import static org.jclouds.util.Throwables2.propagateIfPossible;
 
 import java.lang.reflect.Method;
@@ -84,7 +85,7 @@ public final class FunctionalReflection {
    public static <T> T newProxy(Class<T> enclosingType, Function<Invocation, Object> invocationFunction) {
       checkNotNull(invocationFunction, "invocationFunction");
       return newProxy(enclosingType,
-            new FunctionalInvocationHandler<T>(TypeToken.of(enclosingType), invocationFunction));
+            new FunctionalInvocationHandler<T>(typeTokenOf(enclosingType), invocationFunction));
    }
 
    @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/jclouds/reflect/Reflection2.java
+++ b/core/src/main/java/org/jclouds/reflect/Reflection2.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.reflect;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.lang.reflect.Type;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Function;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.reflect.TypeToken;
+
+/**
+ * Invokable utilities
+ * 
+ * @since 1.6
+ */
+@Beta
+public final class Reflection2 {
+   private static final LoadingCache<Class<?>, TypeToken<?>> typeTokenForClass = CacheBuilder.newBuilder().build(
+         new CacheLoader<Class<?>, TypeToken<?>>() {
+            public TypeToken<?> load(final Class<?> key) throws Exception {
+               return TypeToken.of(key);
+            }
+         });
+
+   /**
+    * Cache of type tokens for the supplied class.
+    */
+   public static Function<Class<?>, TypeToken<?>> typeTokenForClass() {
+      return typeTokenForClass;
+   }
+
+   /**
+    * Cache of type tokens for the supplied class.
+    */
+   @SuppressWarnings("unchecked")
+   public static <T> TypeToken<T> typeTokenOf(Class<T> in) {
+      return (TypeToken<T>) typeTokenForClass.apply(checkNotNull(in, "class"));
+   }
+
+   private static final LoadingCache<Type, TypeToken<?>> typeTokenForType = CacheBuilder.newBuilder().build(
+         new CacheLoader<Type, TypeToken<?>>() {
+            public TypeToken<?> load(final Type key) throws Exception {
+               return TypeToken.of(key);
+            }
+         });
+
+   /**
+    * Cache of type tokens for the supplied class.
+    */
+   public static Function<Type, TypeToken<?>> typeTokenForType() {
+      return typeTokenForType;
+   }
+
+   /**
+    * Cache of type tokens for the supplied type.
+    */
+   @SuppressWarnings("unchecked")
+   public static <T> TypeToken<T> typeTokenOf(Type in) {
+      return (TypeToken<T>) typeTokenForType.apply(checkNotNull(in, "class"));
+   }
+
+}

--- a/core/src/main/java/org/jclouds/rest/config/CallGetOnFuturesProvider.java
+++ b/core/src/main/java/org/jclouds/rest/config/CallGetOnFuturesProvider.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.rest.config;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import java.lang.reflect.Proxy;
 
 import javax.inject.Inject;
@@ -28,7 +30,6 @@ import org.jclouds.rest.internal.InvokeAndCallGetOnFutures;
 
 import com.google.common.cache.Cache;
 import com.google.common.reflect.Invokable;
-import com.google.common.reflect.TypeToken;
 import com.google.inject.Provider;
 
 /**
@@ -46,7 +47,7 @@ public class CallGetOnFuturesProvider<S, A> implements Provider<S> {
          Class<A> asyncApiType) {
       this.syncInvoker = syncInvoker;
       this.apiType = apiType;
-      RestModule.putInvokables(TypeToken.of(apiType), TypeToken.of(asyncApiType), invokables);
+      RestModule.putInvokables(typeTokenOf(apiType), typeTokenOf(asyncApiType), invokables);
    }
 
    @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/jclouds/rest/config/HttpApiProvider.java
+++ b/core/src/main/java/org/jclouds/rest/config/HttpApiProvider.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.rest.config;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import java.lang.reflect.Proxy;
 
 import javax.inject.Inject;
@@ -28,7 +30,6 @@ import org.jclouds.rest.internal.InvokeHttpMethod;
 
 import com.google.common.cache.Cache;
 import com.google.common.reflect.Invokable;
-import com.google.common.reflect.TypeToken;
 import com.google.inject.Provider;
 
 /**
@@ -45,7 +46,7 @@ public class HttpApiProvider<S, A> implements Provider<S> {
          DelegatesToInvocationFunction<S, InvokeHttpMethod> httpInvoker, Class<S> apiType, Class<A> asyncApiType) {
       this.httpInvoker = httpInvoker;
       this.apiType = apiType;
-      RestModule.putInvokables(TypeToken.of(apiType), TypeToken.of(asyncApiType), invokables);
+      RestModule.putInvokables(typeTokenOf(apiType), typeTokenOf(asyncApiType), invokables);
    }
 
    @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/jclouds/rest/config/RestModule.java
+++ b/core/src/main/java/org/jclouds/rest/config/RestModule.java
@@ -23,6 +23,7 @@ import static com.google.common.base.Throwables.propagate;
 import static com.google.common.collect.Maps.transformValues;
 import static com.google.common.util.concurrent.Atomics.newReference;
 import static org.jclouds.Constants.PROPERTY_TIMEOUTS_PREFIX;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 import static org.jclouds.rest.config.BinderUtils.bindHttpApi;
 import static org.jclouds.util.Maps2.transformKeys;
 import static org.jclouds.util.Predicates2.startsWith;
@@ -42,7 +43,6 @@ import org.jclouds.http.functions.config.SaxParserModule;
 import org.jclouds.internal.FilterStringsBoundToInjectorByName;
 import org.jclouds.json.config.GsonModule;
 import org.jclouds.location.config.LocationModule;
-import com.google.common.reflect.Invokable;
 import org.jclouds.rest.AuthorizationException;
 import org.jclouds.rest.HttpAsyncClient;
 import org.jclouds.rest.HttpClient;
@@ -56,6 +56,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.reflect.Invokable;
 import com.google.common.reflect.TypeToken;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
@@ -87,9 +88,9 @@ public class RestModule extends AbstractModule {
    @Singleton
    protected Cache<Invokable<?, ?>, Invokable<?, ?>> seedKnownSync2AsyncInvokables() {
       Cache<Invokable<?, ?>, Invokable<?, ?>> sync2AsyncBuilder = CacheBuilder.newBuilder().build();
-      putInvokables(TypeToken.of(HttpClient.class), TypeToken.of(HttpAsyncClient.class), sync2AsyncBuilder);
+      putInvokables(typeTokenOf(HttpClient.class), typeTokenOf(HttpAsyncClient.class), sync2AsyncBuilder);
       for (Class<?> s : sync2Async.keySet()) {
-         putInvokables(TypeToken.of(s), TypeToken.of(sync2Async.get(s)), sync2AsyncBuilder);
+         putInvokables(typeTokenOf(s), typeTokenOf(sync2Async.get(s)), sync2AsyncBuilder);
       }
       return sync2AsyncBuilder;
    }

--- a/core/src/main/java/org/jclouds/rest/internal/BaseRestApiMetadata.java
+++ b/core/src/main/java/org/jclouds/rest/internal/BaseRestApiMetadata.java
@@ -19,6 +19,7 @@
 package org.jclouds.rest.internal;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import java.util.Properties;
 
@@ -71,7 +72,7 @@ public abstract class BaseRestApiMetadata extends BaseApiMetadata implements Res
          checkNotNull(asyncApi, "asyncApi");
          javaApi(api, asyncApi)
          .name(String.format("%s->%s", api.getSimpleName(), asyncApi.getSimpleName()))
-         .context(contextToken(TypeToken.of(api), TypeToken.of(asyncApi)))
+         .context(contextToken(typeTokenOf(api), typeTokenOf(asyncApi)))
          .defaultProperties(BaseRestApiMetadata.defaultProperties());
       }
 

--- a/core/src/main/java/org/jclouds/rest/internal/DelegatesToInvocationFunction.java
+++ b/core/src/main/java/org/jclouds/rest/internal/DelegatesToInvocationFunction.java
@@ -17,13 +17,13 @@
  * under the License.
  */
 package org.jclouds.rest.internal;
-
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Predicates.notNull;
 import static com.google.common.base.Throwables.propagate;
 import static com.google.common.collect.Iterables.all;
 import static com.google.common.collect.Iterables.find;
 import static com.google.inject.util.Types.newParameterizedType;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 import static org.jclouds.util.Optionals2.isReturnTypeOptional;
 import static org.jclouds.util.Optionals2.unwrapIfOptional;
 import static org.jclouds.util.Throwables2.getFirstThrowableOfType;
@@ -148,7 +148,7 @@ public final class DelegatesToInvocationFunction<S, F extends Function<Invocatio
    DelegatesToInvocationFunction(Injector injector, SetCaller setCaller, Map<Class<?>, Class<?>> syncToAsync,
          TypeLiteral<S> enclosingType, Function<InvocationSuccess, Optional<Object>> optionalConverter, F methodInvoker) {
       this.injector = checkNotNull(injector, "injector");
-      this.enclosingType = (TypeToken<S>) TypeToken.of(checkNotNull(enclosingType, "enclosingType").getType());
+      this.enclosingType = (TypeToken<S>) typeTokenOf(checkNotNull(enclosingType, "enclosingType").getType());
       this.setCaller = checkNotNull(setCaller, "setCaller");
       this.syncToAsync = checkNotNull(syncToAsync, "syncToAsync");
       this.optionalConverter = checkNotNull(optionalConverter, "optionalConverter");

--- a/core/src/test/java/org/jclouds/apis/BaseViewLiveTest.java
+++ b/core/src/test/java/org/jclouds/apis/BaseViewLiveTest.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.apis;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import java.util.Properties;
 
 import org.jclouds.Context;
@@ -46,7 +48,7 @@ public abstract class BaseViewLiveTest<V extends View> extends BaseContextLiveTe
    
    @Override
    protected TypeToken<Context> contextType() {
-     return TypeToken.of(Context.class);
+     return typeTokenOf(Context.class);
    }
    
    protected V createView(Properties props, Iterable<Module> modules) {

--- a/core/src/test/java/org/jclouds/internal/BaseViewTest.java
+++ b/core/src/test/java/org/jclouds/internal/BaseViewTest.java
@@ -19,6 +19,7 @@
 package org.jclouds.internal;
 
 import static org.easymock.EasyMock.createMock;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.fail;
@@ -31,7 +32,6 @@ import org.testng.annotations.Test;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
-import com.google.common.reflect.TypeToken;
 
 /** 
  * @author Adrian Cole
@@ -64,22 +64,22 @@ public class BaseViewTest {
    private static class Wine extends BaseView {
 
       protected Wine() {
-         super(new Water(), TypeToken.of(Water.class));
+         super(new Water(), typeTokenOf(Water.class));
       }
    }
 
    public void testWaterTurnedIntoWine() {
       Wine wine = new Wine();
-      assertEquals(wine.getBackendType(), TypeToken.of(Water.class));
-      assertEquals(wine.unwrap(TypeToken.of(Water.class)).getClass(), Water.class);
+      assertEquals(wine.getBackendType(), typeTokenOf(Water.class));
+      assertEquals(wine.unwrap(typeTokenOf(Water.class)).getClass(), Water.class);
       assertEquals(wine.unwrap().getClass(), Water.class);
    }
 
    public void testPeanutButterDidntTurnIntoWine() {
       Wine wine = new Wine();
-      assertNotEquals(wine.getBackendType(), TypeToken.of(PeanutButter.class));
+      assertNotEquals(wine.getBackendType(), typeTokenOf(PeanutButter.class));
       try {
-         wine.unwrap(TypeToken.of(PeanutButter.class));
+         wine.unwrap(typeTokenOf(PeanutButter.class));
          fail();
       } catch (IllegalArgumentException e) {
          assertEquals(e.getMessage(), "backend type: org.jclouds.internal.BaseViewTest$Water not assignable from org.jclouds.internal.BaseViewTest$PeanutButter");

--- a/core/src/test/java/org/jclouds/providers/internal/BaseProviderMetadataTest.java
+++ b/core/src/test/java/org/jclouds/providers/internal/BaseProviderMetadataTest.java
@@ -19,6 +19,7 @@
 package org.jclouds.providers.internal;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 import static org.testng.Assert.assertEquals;
 
 import java.util.Set;
@@ -62,7 +63,7 @@ public abstract class BaseProviderMetadataTest {
    public void testOfApiContains() {
       if (expectedApi == null)
          Logger.getAnonymousLogger().warning("please update your test class");
-      ImmutableSet<ProviderMetadata> ofApi = ImmutableSet.copyOf(Providers.apiMetadataAssignableFrom(TypeToken.of(expectedApi.getClass())));
+      ImmutableSet<ProviderMetadata> ofApi = ImmutableSet.copyOf(Providers.apiMetadataAssignableFrom(typeTokenOf(expectedApi.getClass())));
       assert ofApi.contains(toTest) : String.format("%s not found in %s", toTest, ofApi);
    }
 

--- a/core/src/test/java/org/jclouds/rest/internal/BaseRestApiMetadataTest.java
+++ b/core/src/test/java/org/jclouds/rest/internal/BaseRestApiMetadataTest.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.rest.internal;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import java.util.Set;
 
 import org.jclouds.View;
@@ -44,7 +46,7 @@ public abstract class BaseRestApiMetadataTest extends BaseApiMetadataTest {
 
    @Test
    public void testContextAssignableFromRestContext() {
-      Set<ApiMetadata> all = ImmutableSet.copyOf(Apis.contextAssignableFrom(TypeToken.of(RestContext.class)));
+      Set<ApiMetadata> all = ImmutableSet.copyOf(Apis.contextAssignableFrom(typeTokenOf(RestContext.class)));
       assert all.contains(toTest) : String.format("%s not found in %s", toTest, all);
    }
 

--- a/core/src/test/java/org/jclouds/rest/internal/BlockOnFutureTest.java
+++ b/core/src/test/java/org/jclouds/rest/internal/BlockOnFutureTest.java
@@ -22,6 +22,7 @@ import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 import static org.testng.Assert.assertEquals;
 
 import java.util.concurrent.ExecutionException;
@@ -67,7 +68,7 @@ public class BlockOnFutureTest {
 
    @BeforeClass
    void setupInvocations() throws SecurityException, NoSuchMethodException {
-      enclosingType = TypeToken.of(ThingAsyncApi.class);
+      enclosingType = typeTokenOf(ThingAsyncApi.class);
       get = Invocation.create(enclosingType.method(ThingAsyncApi.class.getDeclaredMethod("get")), ImmutableList.of());
       namedGet = Invocation.create(enclosingType.method(ThingAsyncApi.class.getDeclaredMethod("namedGet")),
             ImmutableList.of());

--- a/core/src/test/java/org/jclouds/util/Throwables2Test.java
+++ b/core/src/test/java/org/jclouds/util/Throwables2Test.java
@@ -20,6 +20,7 @@ package org.jclouds.util;
 
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.createNiceMock;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 import static org.jclouds.util.Throwables2.getFirstThrowableOfType;
 import static org.jclouds.util.Throwables2.propagateIfPossible;
 import static org.testng.Assert.assertEquals;
@@ -147,14 +148,14 @@ public class Throwables2Test {
    @Test(expectedExceptions = TestException.class)
    public void testPropagateExceptionThatsInList() throws Throwable {
       Exception e = new TestException();
-      propagateIfPossible(e, ImmutableSet.<TypeToken<? extends Throwable>> of(TypeToken.of(TestException.class)));
+      propagateIfPossible(e, ImmutableSet.<TypeToken<? extends Throwable>> of(typeTokenOf(TestException.class)));
    }
 
    @Test(expectedExceptions = TestException.class)
    public void testPropagateWrappedExceptionThatsInList() throws Throwable {
       Exception e = new TestException();
       propagateIfPossible(new RuntimeException(e),
-            ImmutableSet.<TypeToken<? extends Throwable>> of(TypeToken.of(TestException.class)));
+            ImmutableSet.<TypeToken<? extends Throwable>> of(typeTokenOf(TestException.class)));
    }
 
    public void testPropagateIfPossibleDoesnThrowExceptionNotInList() throws Throwable {

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/AbiquoApiMetadata.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/AbiquoApiMetadata.java
@@ -18,12 +18,12 @@
  */
 
 package org.jclouds.abiquo;
-
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.jclouds.Constants.PROPERTY_MAX_REDIRECTS;
 import static org.jclouds.Constants.PROPERTY_TIMEOUTS_PREFIX;
 import static org.jclouds.abiquo.config.AbiquoProperties.ASYNC_TASK_MONITOR_DELAY;
 import static org.jclouds.abiquo.config.AbiquoProperties.CREDENTIAL_IS_TOKEN;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import java.net.URI;
 import java.util.Properties;
@@ -91,7 +91,7 @@ public class AbiquoApiMetadata extends BaseRestApiMetadata {
                .defaultEndpoint("http://localhost/api")
                .version(AbiquoAsyncApi.API_VERSION)
                .buildVersion(AbiquoAsyncApi.BUILD_VERSION)
-               .view(TypeToken.of(AbiquoContext.class))
+               .view(typeTokenOf(AbiquoContext.class))
                .defaultProperties(AbiquoApiMetadata.defaultProperties())
                .defaultModules(
                      ImmutableSet.<Class<? extends Module>> of(AbiquoRestClientModule.class,

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/internal/BaseAbiquoLiveApiTest.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/internal/BaseAbiquoLiveApiTest.java
@@ -16,8 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.jclouds.abiquo.internal;
+
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import java.util.Properties;
 
@@ -58,7 +59,7 @@ public abstract class BaseAbiquoLiveApiTest extends BaseViewLiveTest<AbiquoConte
 
    @Override
    protected TypeToken<AbiquoContext> viewType() {
-      return TypeToken.of(AbiquoContext.class);
+      return typeTokenOf(AbiquoContext.class);
    }
 
 }

--- a/labs/azure-management/src/main/java/org/jclouds/azure/management/AzureManagementApiMetadata.java
+++ b/labs/azure-management/src/main/java/org/jclouds/azure/management/AzureManagementApiMetadata.java
@@ -21,6 +21,7 @@ package org.jclouds.azure.management;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.jclouds.Constants.PROPERTY_TIMEOUTS_PREFIX;
 import static org.jclouds.azure.management.config.AzureManagementProperties.SUBSCRIPTION_ID;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import java.net.URI;
 import java.util.Properties;
@@ -82,7 +83,7 @@ public class AzureManagementApiMetadata extends BaseRestApiMetadata {
          .endpointName("Service Management Endpoint ending in your Subscription Id")
          .documentation(URI.create("http://msdn.microsoft.com/en-us/library/ee460799"))
          .defaultProperties(AzureManagementApiMetadata.defaultProperties())
-         .view(TypeToken.of(ComputeServiceContext.class))
+         .view(typeTokenOf(ComputeServiceContext.class))
          .defaultModules(ImmutableSet.<Class<? extends Module>> of(AzureManagementComputeServiceContextModule.class, AzureManagementRestClientModule.class));
       }
 

--- a/labs/elb/src/main/java/org/jclouds/elb/config/ELBRestClientModule.java
+++ b/labs/elb/src/main/java/org/jclouds/elb/config/ELBRestClientModule.java
@@ -18,23 +18,24 @@
  */
 package org.jclouds.elb.config;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import java.util.Map;
 
 import org.jclouds.aws.config.FormSigningRestClientModule;
-import org.jclouds.elb.ELBAsyncApi;
 import org.jclouds.elb.ELBApi;
-import org.jclouds.elb.features.InstanceAsyncApi;
-import org.jclouds.elb.features.InstanceApi;
-import org.jclouds.elb.features.LoadBalancerAsyncApi;
-import org.jclouds.elb.features.LoadBalancerApi;
-import org.jclouds.elb.features.PolicyAsyncApi;
-import org.jclouds.elb.features.PolicyApi;
-import org.jclouds.elb.features.AvailabilityZoneAsyncApi;
+import org.jclouds.elb.ELBAsyncApi;
 import org.jclouds.elb.features.AvailabilityZoneApi;
+import org.jclouds.elb.features.AvailabilityZoneAsyncApi;
+import org.jclouds.elb.features.InstanceApi;
+import org.jclouds.elb.features.InstanceAsyncApi;
+import org.jclouds.elb.features.LoadBalancerApi;
+import org.jclouds.elb.features.LoadBalancerAsyncApi;
+import org.jclouds.elb.features.PolicyApi;
+import org.jclouds.elb.features.PolicyAsyncApi;
 import org.jclouds.rest.ConfiguresRestClient;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 /**
  * Configures the ELB connection.
@@ -51,6 +52,6 @@ public class ELBRestClientModule extends FormSigningRestClientModule<ELBApi, ELB
             .build();
 
    public ELBRestClientModule() {
-      super(TypeToken.of(ELBApi.class), TypeToken.of(ELBAsyncApi.class), DELEGATE_MAP);
+      super(typeTokenOf(ELBApi.class), typeTokenOf(ELBAsyncApi.class), DELEGATE_MAP);
    }
 }

--- a/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/FGCPApiMetadata.java
+++ b/labs/fgcp/src/main/java/org/jclouds/fujitsu/fgcp/FGCPApiMetadata.java
@@ -20,6 +20,7 @@ package org.jclouds.fujitsu.fgcp;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.jclouds.Constants.PROPERTY_TIMEOUTS_PREFIX;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import java.net.URI;
 import java.util.Properties;
@@ -32,7 +33,6 @@ import org.jclouds.fujitsu.fgcp.compute.config.FGCPComputeServiceContextModule;
 import org.jclouds.rest.internal.BaseRestApiMetadata;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.reflect.TypeToken;
 import com.google.inject.Module;
 
 /**
@@ -80,7 +80,7 @@ public class FGCPApiMetadata extends BaseRestApiMetadata {
                .defaultEndpoint(
                      "https://api.globalcloud.fujitsu.com.au/ovissapi/endpoint")
                .defaultProperties(FGCPApiMetadata.defaultProperties())
-               .view(TypeToken.of(ComputeServiceContext.class))
+               .view(typeTokenOf(ComputeServiceContext.class))
                .defaultModules(
                      ImmutableSet.<Class<? extends Module>> of(
                            FGCPComputeServiceContextModule.class,

--- a/labs/iam/src/main/java/org/jclouds/iam/config/IAMRestClientModule.java
+++ b/labs/iam/src/main/java/org/jclouds/iam/config/IAMRestClientModule.java
@@ -18,17 +18,18 @@
  */
 package org.jclouds.iam.config;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import java.util.Map;
 
 import org.jclouds.aws.config.FormSigningRestClientModule;
-import org.jclouds.iam.IAMAsyncApi;
 import org.jclouds.iam.IAMApi;
-import org.jclouds.iam.features.UserAsyncApi;
+import org.jclouds.iam.IAMAsyncApi;
 import org.jclouds.iam.features.UserApi;
+import org.jclouds.iam.features.UserAsyncApi;
 import org.jclouds.rest.ConfiguresRestClient;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 /**
  * Configures the Monitoring connection.
@@ -42,7 +43,7 @@ public class IAMRestClientModule extends FormSigningRestClientModule<IAMApi, IAM
          .build();
    
    public IAMRestClientModule() {
-      super(TypeToken.of(IAMApi.class), TypeToken.of(IAMAsyncApi.class), DELEGATE_MAP);
+      super(typeTokenOf(IAMApi.class), typeTokenOf(IAMAsyncApi.class), DELEGATE_MAP);
    }
 
 }

--- a/labs/joyent-cloudapi/src/main/java/org/jclouds/joyent/cloudapi/v6_5/JoyentCloudApiMetadata.java
+++ b/labs/joyent-cloudapi/src/main/java/org/jclouds/joyent/cloudapi/v6_5/JoyentCloudApiMetadata.java
@@ -20,6 +20,7 @@ package org.jclouds.joyent.cloudapi.v6_5;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.jclouds.Constants.PROPERTY_TIMEOUTS_PREFIX;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import java.net.URI;
 import java.util.Properties;
@@ -84,7 +85,7 @@ public class JoyentCloudApiMetadata extends BaseRestApiMetadata {
          .version("~6.5")
          .defaultEndpoint("https://api.joyentcloud.com")
          .defaultProperties(JoyentCloudApiMetadata.defaultProperties())
-         .view(TypeToken.of(ComputeServiceContext.class))
+         .view(typeTokenOf(ComputeServiceContext.class))
          .defaultModules(ImmutableSet.<Class<? extends Module>> of(DatacentersAreZonesModule.class, JoyentCloudRestClientModule.class, JoyentCloudComputeServiceContextModule.class));
       }
 

--- a/labs/joyent-cloudapi/src/main/java/org/jclouds/joyent/cloudapi/v6_5/reference/Metadata.java
+++ b/labs/joyent-cloudapi/src/main/java/org/jclouds/joyent/cloudapi/v6_5/reference/Metadata.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.joyent.cloudapi.v6_5.reference;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import java.lang.reflect.Type;
 import java.util.Map;
 
@@ -30,7 +32,7 @@ import com.google.common.reflect.TypeToken;
  * @author Adrian Cole
  */
 public enum Metadata {
-   ROOT_AUTHORIZED_KEYS(TypeToken.of(String.class).getType()),
+   ROOT_AUTHORIZED_KEYS(typeTokenOf(String.class).getType()),
    /**
     * If the dataset you create a machine from is set to generate passwords for
     * you, the username/password pairs will be returned in the metadata response

--- a/labs/oauth/src/main/java/org/jclouds/oauth/v2/config/OAuthRestClientModule.java
+++ b/labs/oauth/src/main/java/org/jclouds/oauth/v2/config/OAuthRestClientModule.java
@@ -1,17 +1,21 @@
 package org.jclouds.oauth.v2.config;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
-import com.google.common.reflect.TypeToken;
-import com.google.inject.Provides;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
+import java.net.URI;
+
+import javax.inject.Singleton;
+
 import org.jclouds.oauth.v2.OAuthApi;
 import org.jclouds.oauth.v2.OAuthAsyncApi;
 import org.jclouds.providers.ProviderMetadata;
 import org.jclouds.rest.ConfiguresRestClient;
 import org.jclouds.rest.config.RestClientModule;
 
-import javax.inject.Singleton;
-import java.net.URI;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.reflect.TypeToken;
+import com.google.inject.Provides;
 
 /**
  * OAuth module to when accessing OAuth stand-alone.
@@ -22,7 +26,7 @@ import java.net.URI;
 public class OAuthRestClientModule extends RestClientModule<OAuthApi, OAuthAsyncApi> {
 
    public OAuthRestClientModule() {
-      super(TypeToken.class.cast(TypeToken.of(OAuthApi.class)), TypeToken.class.cast(TypeToken.of(OAuthAsyncApi
+      super(TypeToken.class.cast(typeTokenOf(OAuthApi.class)), TypeToken.class.cast(typeTokenOf(OAuthAsyncApi
               .class)));
    }
 

--- a/labs/openstack-glance/src/main/java/org/jclouds/openstack/glance/v1_0/config/GlanceRestClientModule.java
+++ b/labs/openstack-glance/src/main/java/org/jclouds/openstack/glance/v1_0/config/GlanceRestClientModule.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.openstack.glance.v1_0.config;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import java.net.URI;
 import java.util.Map;
 import java.util.Set;
@@ -68,7 +70,7 @@ public class GlanceRestClientModule<S extends GlanceApi, A extends GlanceAsyncAp
          .build();
 
    public GlanceRestClientModule() {
-      super(TypeToken.class.cast(TypeToken.of(GlanceApi.class)), TypeToken.class.cast(TypeToken.of(GlanceAsyncApi.class)), DELEGATE_MAP);
+      super(TypeToken.class.cast(typeTokenOf(GlanceApi.class)), TypeToken.class.cast(typeTokenOf(GlanceAsyncApi.class)), DELEGATE_MAP);
    }
 
    protected GlanceRestClientModule(TypeToken<S> syncClientType, TypeToken<A> asyncClientType, Map<Class<?>, Class<?>> sync2Async) {

--- a/labs/openstack-quantum/src/main/java/org/jclouds/openstack/quantum/v1_0/config/QuantumRestClientModule.java
+++ b/labs/openstack-quantum/src/main/java/org/jclouds/openstack/quantum/v1_0/config/QuantumRestClientModule.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.openstack.quantum.v1_0.config;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import java.net.URI;
 import java.util.Map;
 import java.util.Set;
@@ -72,7 +74,7 @@ public class QuantumRestClientModule<S extends QuantumApi, A extends QuantumAsyn
 
    @SuppressWarnings("unchecked")
    public QuantumRestClientModule() {
-      super(TypeToken.class.cast(TypeToken.of(QuantumApi.class)), TypeToken.class.cast(TypeToken.of(QuantumAsyncApi.class)), DELEGATE_MAP);
+      super(TypeToken.class.cast(typeTokenOf(QuantumApi.class)), TypeToken.class.cast(typeTokenOf(QuantumAsyncApi.class)), DELEGATE_MAP);
    }
 
    protected QuantumRestClientModule(TypeToken<S> syncClientType, TypeToken<A> asyncClientType, Map<Class<?>, Class<?>> sync2Async) {

--- a/labs/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/config/SwiftRestClientModule.java
+++ b/labs/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/config/SwiftRestClientModule.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.openstack.swift.v1.config;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import java.net.URI;
 import java.util.Map;
 import java.util.Set;
@@ -75,7 +77,7 @@ public class SwiftRestClientModule<S extends SwiftApi, A extends SwiftAsyncApi> 
 
    @SuppressWarnings("unchecked")
    public SwiftRestClientModule() {
-      super(TypeToken.class.cast(TypeToken.of(SwiftApi.class)), TypeToken.class.cast(TypeToken.of(SwiftAsyncApi.class)), DELEGATE_MAP);
+      super(TypeToken.class.cast(typeTokenOf(SwiftApi.class)), TypeToken.class.cast(typeTokenOf(SwiftAsyncApi.class)), DELEGATE_MAP);
    }
 
    protected SwiftRestClientModule(TypeToken<S> syncClientType, TypeToken<A> asyncClientType, Map<Class<?>, Class<?>> sync2Async) {

--- a/labs/rds/src/main/java/org/jclouds/rds/config/RDSRestClientModule.java
+++ b/labs/rds/src/main/java/org/jclouds/rds/config/RDSRestClientModule.java
@@ -18,21 +18,22 @@
  */
 package org.jclouds.rds.config;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import java.util.Map;
 
 import org.jclouds.aws.config.FormSigningRestClientModule;
-import org.jclouds.rds.RDSAsyncApi;
 import org.jclouds.rds.RDSApi;
-import org.jclouds.rds.features.InstanceAsyncApi;
+import org.jclouds.rds.RDSAsyncApi;
 import org.jclouds.rds.features.InstanceApi;
-import org.jclouds.rds.features.SecurityGroupAsyncApi;
+import org.jclouds.rds.features.InstanceAsyncApi;
 import org.jclouds.rds.features.SecurityGroupApi;
-import org.jclouds.rds.features.SubnetGroupAsyncApi;
+import org.jclouds.rds.features.SecurityGroupAsyncApi;
 import org.jclouds.rds.features.SubnetGroupApi;
+import org.jclouds.rds.features.SubnetGroupAsyncApi;
 import org.jclouds.rest.ConfiguresRestClient;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 /**
  * Configures the RDS connection.
@@ -48,6 +49,6 @@ public class RDSRestClientModule extends FormSigningRestClientModule<RDSApi, RDS
             .build();
 
    public RDSRestClientModule() {
-      super(TypeToken.of(RDSApi.class), TypeToken.of(RDSAsyncApi.class), DELEGATE_MAP);
+      super(typeTokenOf(RDSApi.class), typeTokenOf(RDSAsyncApi.class), DELEGATE_MAP);
    }
 }

--- a/labs/savvis-symphonyvpdc/src/main/java/org/jclouds/savvis/vpdc/VPDCApiMetadata.java
+++ b/labs/savvis-symphonyvpdc/src/main/java/org/jclouds/savvis/vpdc/VPDCApiMetadata.java
@@ -20,6 +20,7 @@ package org.jclouds.savvis.vpdc;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.jclouds.Constants.PROPERTY_TIMEOUTS_PREFIX;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 import static org.jclouds.savvis.vpdc.reference.VPDCConstants.PROPERTY_VPDC_TIMEOUT_TASK_COMPLETED;
 
 import java.net.URI;
@@ -80,7 +81,7 @@ public class VPDCApiMetadata extends BaseRestApiMetadata {
          .buildVersion("2.3")
          .defaultEndpoint("https://api.savvis.net/vpdc")
          .defaultProperties(VPDCApiMetadata.defaultProperties())
-         .view(TypeToken.of(ComputeServiceContext.class))
+         .view(typeTokenOf(ComputeServiceContext.class))
          .defaultModules(ImmutableSet.<Class<? extends Module>>of(VPDCRestClientModule.class, VPDCComputeServiceContextModule.class));
 
       }

--- a/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/VCloudDirectorApiMetadata.java
+++ b/labs/vcloud-director/src/main/java/org/jclouds/vcloud/director/v1_5/VCloudDirectorApiMetadata.java
@@ -21,6 +21,7 @@ package org.jclouds.vcloud.director.v1_5;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.jclouds.Constants.PROPERTY_SESSION_INTERVAL;
 import static org.jclouds.Constants.PROPERTY_TIMEOUTS_PREFIX;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 import static org.jclouds.vcloud.director.v1_5.VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_TIMEOUT_TASK_COMPLETED;
 import static org.jclouds.vcloud.director.v1_5.VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_VERSION_SCHEMA;
 import static org.jclouds.vcloud.director.v1_5.VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_XML_NAMESPACE;
@@ -32,8 +33,8 @@ import java.util.Properties;
 import org.jclouds.apis.ApiMetadata;
 import org.jclouds.rest.internal.BaseRestApiMetadata;
 import org.jclouds.vcloud.director.v1_5.config.VCloudDirectorRestClientModule;
-import org.jclouds.vcloud.director.v1_5.user.VCloudDirectorAsyncApi;
 import org.jclouds.vcloud.director.v1_5.user.VCloudDirectorApi;
+import org.jclouds.vcloud.director.v1_5.user.VCloudDirectorAsyncApi;
 
 import com.google.common.reflect.TypeToken;
 
@@ -44,7 +45,7 @@ import com.google.common.reflect.TypeToken;
  */
 public class VCloudDirectorApiMetadata extends BaseRestApiMetadata {
 
-   public static final TypeToken<VCloudDirectorContext> CONTEXT_TOKEN = TypeToken.of(VCloudDirectorContext.class);
+   public static final TypeToken<VCloudDirectorContext> CONTEXT_TOKEN = typeTokenOf(VCloudDirectorContext.class);
    
    @Override
    public Builder toBuilder() {
@@ -88,7 +89,7 @@ public class VCloudDirectorApiMetadata extends BaseRestApiMetadata {
          .documentation(URI.create("http://www.vmware.com/support/pubs/vcd_pubs.html"))
          .version("1.5")
          .defaultProperties(VCloudDirectorApiMetadata.defaultProperties())
-         .context(TypeToken.of(VCloudDirectorContext.class))
+         .context(typeTokenOf(VCloudDirectorContext.class))
          .defaultModule(VCloudDirectorRestClientModule.class);
       }
 

--- a/loadbalancer/src/test/java/org/jclouds/loadbalancer/BaseLoadBalancerServiceLiveTest.java
+++ b/loadbalancer/src/test/java/org/jclouds/loadbalancer/BaseLoadBalancerServiceLiveTest.java
@@ -20,6 +20,7 @@ package org.jclouds.loadbalancer;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 import static org.jclouds.util.Predicates2.retry;
 import static org.testng.Assert.assertNotNull;
 
@@ -183,6 +184,6 @@ public abstract class BaseLoadBalancerServiceLiveTest extends BaseViewLiveTest<L
 
    @Override
    protected TypeToken<LoadBalancerServiceContext> viewType() {
-      return TypeToken.of(LoadBalancerServiceContext.class);
+      return typeTokenOf(LoadBalancerServiceContext.class);
    }
 }

--- a/loadbalancer/src/test/java/org/jclouds/loadbalancer/internal/BaseLoadBalancerServiceApiMetadataTest.java
+++ b/loadbalancer/src/test/java/org/jclouds/loadbalancer/internal/BaseLoadBalancerServiceApiMetadataTest.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.loadbalancer.internal;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import org.jclouds.View;
 import org.jclouds.apis.ApiMetadata;
 import org.jclouds.apis.internal.BaseApiMetadataTest;
@@ -35,7 +37,7 @@ import com.google.common.reflect.TypeToken;
 public abstract class BaseLoadBalancerServiceApiMetadataTest extends BaseApiMetadataTest {
 
    public BaseLoadBalancerServiceApiMetadataTest(ApiMetadata toTest) {
-     super(toTest, ImmutableSet.<TypeToken<? extends View>>of(TypeToken.of(LoadBalancerServiceContext.class)));
+     super(toTest, ImmutableSet.<TypeToken<? extends View>>of(typeTokenOf(LoadBalancerServiceContext.class)));
    }
 
 }

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/config/AWSEC2RestClientModule.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/config/AWSEC2RestClientModule.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.aws.ec2.config;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import java.util.Map;
 
 import javax.inject.Singleton;
@@ -68,7 +70,6 @@ import org.jclouds.rest.ConfiguresRestClient;
 
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
 
@@ -97,7 +98,7 @@ public class AWSEC2RestClientModule extends EC2RestClientModule<AWSEC2Client, AW
          .build();
 
    public AWSEC2RestClientModule() {
-      super(TypeToken.of(AWSEC2Client.class), TypeToken.of(AWSEC2AsyncClient.class), DELEGATE_MAP);
+      super(typeTokenOf(AWSEC2Client.class), typeTokenOf(AWSEC2AsyncClient.class), DELEGATE_MAP);
    }
 
    @Singleton

--- a/providers/aws-s3/src/main/java/org/jclouds/aws/s3/AWSS3ApiMetadata.java
+++ b/providers/aws-s3/src/main/java/org/jclouds/aws/s3/AWSS3ApiMetadata.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.aws.s3;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
+
 import java.util.Properties;
 
 import org.jclouds.apis.ApiMetadata;
@@ -67,7 +69,7 @@ public class AWSS3ApiMetadata extends S3ApiMetadata {
          .name("Amazon-specific S3 API")
          .defaultProperties(AWSS3ApiMetadata.defaultProperties())
          .context(CONTEXT_TOKEN)
-         .view(TypeToken.of(AWSS3BlobStoreContext.class))
+         .view(typeTokenOf(AWSS3BlobStoreContext.class))
          .defaultModules(ImmutableSet.<Class<? extends Module>>of(AWSS3RestClientModule.class, AWSS3BlobStoreContextModule.class));
       }
       

--- a/providers/aws-s3/src/main/java/org/jclouds/aws/s3/config/AWSS3RestClientModule.java
+++ b/providers/aws-s3/src/main/java/org/jclouds/aws/s3/config/AWSS3RestClientModule.java
@@ -19,6 +19,7 @@
 package org.jclouds.aws.s3.config;
 
 import static org.jclouds.aws.domain.Region.US_STANDARD;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import javax.inject.Singleton;
 
@@ -35,7 +36,6 @@ import org.jclouds.s3.predicates.validators.BucketNameValidator;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
-import com.google.common.reflect.TypeToken;
 import com.google.inject.Provides;
 
 /**
@@ -47,7 +47,7 @@ import com.google.inject.Provides;
 public class AWSS3RestClientModule extends S3RestClientModule<AWSS3Client, AWSS3AsyncClient> {
    
    public AWSS3RestClientModule() {
-      super(TypeToken.of(AWSS3Client.class), TypeToken.of(AWSS3AsyncClient.class));
+      super(typeTokenOf(AWSS3Client.class), typeTokenOf(AWSS3AsyncClient.class));
    }
    
    @Override

--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/AzureBlobApiMetadata.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/AzureBlobApiMetadata.java
@@ -21,6 +21,7 @@ package org.jclouds.azureblob;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.jclouds.Constants.PROPERTY_TIMEOUTS_PREFIX;
 import static org.jclouds.blobstore.reference.BlobStoreConstants.PROPERTY_USER_METADATA_PREFIX;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import java.net.URI;
 import java.util.Properties;
@@ -85,7 +86,7 @@ public class AzureBlobApiMetadata extends BaseRestApiMetadata {
          .defaultEndpoint("https://${jclouds.identity}.blob.core.windows.net")
          .documentation(URI.create("http://msdn.microsoft.com/en-us/library/dd135733.aspx"))
          .defaultProperties(AzureBlobApiMetadata.defaultProperties())
-         .view(TypeToken.of(BlobStoreContext.class))
+         .view(typeTokenOf(BlobStoreContext.class))
          .defaultModules(ImmutableSet.<Class<? extends Module>>of(AzureBlobRestClientModule.class, AzureBlobStoreContextModule.class));
       }
       

--- a/providers/glesys/src/main/java/org/jclouds/glesys/GleSYSApiMetadata.java
+++ b/providers/glesys/src/main/java/org/jclouds/glesys/GleSYSApiMetadata.java
@@ -21,6 +21,7 @@ package org.jclouds.glesys;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.jclouds.Constants.PROPERTY_TIMEOUTS_PREFIX;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import java.net.URI;
 import java.util.Properties;
@@ -83,7 +84,7 @@ public class GleSYSApiMetadata extends BaseRestApiMetadata {
          .buildVersion("3.5.0")
          .defaultEndpoint("https://api.glesys.com")
          .defaultProperties(GleSYSApiMetadata.defaultProperties())
-         .view(TypeToken.of(ComputeServiceContext.class))
+         .view(typeTokenOf(ComputeServiceContext.class))
          .defaultModules(ImmutableSet.<Class<? extends Module>>of(GleSYSComputeServiceContextModule.class, GleSYSRestClientModule.class));
       }
 

--- a/providers/gogrid/src/main/java/org/jclouds/gogrid/GoGridApiMetadata.java
+++ b/providers/gogrid/src/main/java/org/jclouds/gogrid/GoGridApiMetadata.java
@@ -20,6 +20,7 @@ package org.jclouds.gogrid;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.jclouds.Constants.PROPERTY_TIMEOUTS_PREFIX;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import java.net.URI;
 import java.util.Properties;
@@ -79,7 +80,7 @@ public class GoGridApiMetadata extends BaseRestApiMetadata {
          .version(GoGridAsyncClient.VERSION)
          .defaultEndpoint("https://api.gogrid.com/api")
          .defaultProperties(GoGridApiMetadata.defaultProperties())
-         .view(TypeToken.of(ComputeServiceContext.class))
+         .view(typeTokenOf(ComputeServiceContext.class))
          .defaultModules(ImmutableSet.<Class<? extends Module>>of(GoGridRestClientModule.class, GoGridComputeServiceContextModule.class));
       }
 

--- a/providers/hpcloud-objectstorage/src/main/java/org/jclouds/hpcloud/objectstorage/blobstore/HPCloudObjectStorageBlobRequestSigner.java
+++ b/providers/hpcloud-objectstorage/src/main/java/org/jclouds/hpcloud/objectstorage/blobstore/HPCloudObjectStorageBlobRequestSigner.java
@@ -28,6 +28,7 @@ import static com.google.common.io.BaseEncoding.base16;
 import static com.google.common.io.ByteStreams.readBytes;
 import static org.jclouds.blobstore.util.BlobStoreUtils.cleanRequest;
 import static org.jclouds.crypto.Macs.asByteProcessor;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 import static org.jclouds.util.Strings2.toInputStream;
 
 import java.io.IOException;
@@ -100,8 +101,7 @@ public class HPCloudObjectStorageBlobRequestSigner implements BlobRequestSigner 
       this.blob2HttpGetOptions = checkNotNull(blob2HttpGetOptions, "blob2HttpGetOptions");
 
       Class<?> interfaceClass = HPCloudObjectStorageAsyncApi.class;
-      TypeToken<?> interfaceType = TypeToken.of(HPCloudObjectStorageAsyncApi.class);
-
+      TypeToken<?> interfaceType = typeTokenOf(HPCloudObjectStorageAsyncApi.class);
       this.getMethod = interfaceType.method(interfaceClass.getMethod("getObject", String.class, String.class,
             GetOptions[].class));
       this.deleteMethod = interfaceType.method(interfaceClass.getMethod("removeObject", String.class, String.class));

--- a/providers/hpcloud-objectstorage/src/main/java/org/jclouds/hpcloud/objectstorage/config/HPCloudObjectStorageRestClientModule.java
+++ b/providers/hpcloud-objectstorage/src/main/java/org/jclouds/hpcloud/objectstorage/config/HPCloudObjectStorageRestClientModule.java
@@ -18,6 +18,7 @@
  */
 package org.jclouds.hpcloud.objectstorage.config;
 
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 import static org.jclouds.util.Suppliers2.getLastValueInMap;
 
 import java.net.URI;
@@ -40,7 +41,6 @@ import org.jclouds.rest.annotations.ApiVersion;
 
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 
@@ -55,7 +55,7 @@ public class HPCloudObjectStorageRestClientModule extends
             CDNContainerApi.class, CDNContainerAsyncApi.class).build();
 
    public HPCloudObjectStorageRestClientModule() {
-      super(TypeToken.of(HPCloudObjectStorageApi.class), TypeToken.of(HPCloudObjectStorageAsyncApi.class),
+      super(typeTokenOf(HPCloudObjectStorageApi.class), typeTokenOf(HPCloudObjectStorageAsyncApi.class),
                DELEGATE_MAP);
    }
 

--- a/providers/softlayer/src/main/java/org/jclouds/softlayer/SoftLayerApiMetadata.java
+++ b/providers/softlayer/src/main/java/org/jclouds/softlayer/SoftLayerApiMetadata.java
@@ -21,6 +21,7 @@ package org.jclouds.softlayer;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.jclouds.Constants.PROPERTY_TIMEOUTS_PREFIX;
+import static org.jclouds.reflect.Reflection2.typeTokenOf;
 
 import java.net.URI;
 import java.util.Properties;
@@ -81,7 +82,7 @@ public class SoftLayerApiMetadata extends BaseRestApiMetadata {
          .version("3")
          .defaultEndpoint("https://api.softlayer.com/rest")
          .defaultProperties(SoftLayerApiMetadata.defaultProperties())
-         .view(TypeToken.of(ComputeServiceContext.class))
+         .view(typeTokenOf(ComputeServiceContext.class))
          .defaultModules(ImmutableSet.<Class<? extends Module>>of(SoftLayerRestClientModule.class, SoftLayerComputeServiceContextModule.class));
       }
 


### PR DESCRIPTION
this ensures TypeTokens are created properly and reduces thrashing.  Next step is to avail a function to get a type-aware method directly, 

ex. `Invokable<T,R> Reflection2.getMethod(TypeToken<T> owner, String method, Class<?> ... params);` 
