### PR TITLE
Making core tests run on Windows

### DIFF
--- a/core/src/test/java/org/jclouds/concurrent/config/ExecutorServiceModuleTest.java
+++ b/core/src/test/java/org/jclouds/concurrent/config/ExecutorServiceModuleTest.java
@@ -20,6 +20,7 @@ package org.jclouds.concurrent.config;
 
 import static com.google.common.base.Throwables.getStackTraceAsString;
 import static com.google.inject.name.Names.named;
+import static java.lang.String.format;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -49,6 +50,7 @@ import com.google.inject.Key;
  */
 @Test
 public class ExecutorServiceModuleTest {
+   private static final String LINE_SEPARATOR = System.getProperty("line.separator");
 
    private Injector injector;
 
@@ -107,7 +109,7 @@ public class ExecutorServiceModuleTest {
          try {
             // this is sensitive to formatting as we are looking for the stack traces to match. if you wrap the below
             // line again, you'll need to change incrementInitialElement to 3 line numbers instead of 2.
-            submission = getStackTraceAsString(incrementInitialElement(new RuntimeException(), 2)).replaceFirst(".*\n",
+            submission = getStackTraceAsString(incrementInitialElement(new RuntimeException(), 2)).replaceFirst(format(".*%s", LINE_SEPARATOR),
                   "");
             exec.submit(runnableThrowsRTE()).get();
          } catch (ExecutionException e) {

--- a/core/src/test/java/org/jclouds/concurrent/config/ScheduledExecutorServiceModuleTest.java
+++ b/core/src/test/java/org/jclouds/concurrent/config/ScheduledExecutorServiceModuleTest.java
@@ -19,6 +19,7 @@
 package org.jclouds.concurrent.config;
 import static com.google.common.base.Throwables.getStackTraceAsString;
 import static com.google.inject.name.Names.named;
+import static java.lang.String.format;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -50,6 +51,7 @@ import com.google.inject.Key;
  */
 @Test
 public class ScheduledExecutorServiceModuleTest {
+   private static final String LINE_SEPARATOR = System.getProperty("line.separator");
 
    private Injector injector;
 
@@ -99,7 +101,7 @@ public class ScheduledExecutorServiceModuleTest {
          // this is sensitive to formatting as we are looking for the stack traces to match. if you wrap the below
          // line again, you'll need to change incrementInitialElement to 3 line numbers instead of 2.
          submission = getStackTraceAsString(incrementInitialElement(new RuntimeException(), 2))
-               .replaceFirst(".*\n", "");
+               .replaceFirst(format(".*%s", LINE_SEPARATOR), "");
          sched.submit(runnableThrowsRTE()).get();
       } catch (ExecutionException e) {
          assertTraceHasSubmission(getStackTraceAsString(e), submission);
@@ -116,7 +118,7 @@ public class ScheduledExecutorServiceModuleTest {
          // this is sensitive to formatting as we are looking for the stack traces to match. if you wrap the below
          // line again, you'll need to change incrementInitialElement to 3 line numbers instead of 2.
          submission = getStackTraceAsString(incrementInitialElement(new RuntimeException(), 2))
-               .replaceFirst(".*\n", "");
+               .replaceFirst(format(".*%s", LINE_SEPARATOR), "");
          sched.scheduleWithFixedDelay(runnableThrowsRTE(), 0, 1, TimeUnit.MICROSECONDS).get();
       } catch (ExecutionException e) {
          assertTraceHasSubmission(getStackTraceAsString(e), submission);


### PR DESCRIPTION
By making test assertions use the system line separator rather than always `\n`
