### PR TITLE
Issue #1240: Improved handling of /etc/hosts updates by ensure_hostname_in_hosts

### DIFF
--- a/compute/src/test/resources/initscript_with_java.sh
+++ b/compute/src/test/resources/initscript_with_java.sh
@@ -115,7 +115,10 @@ function ensure_netutils_yum() {
 # most network services require that the hostname is in
 # the /etc/hosts file, or they won't operate
 function ensure_hostname_in_hosts() {
-  egrep -q `hostname` /etc/hosts || awk -v hostname=`hostname` 'END { print $1" "hostname }' /proc/net/arp >> /etc/hosts
+  # NOTE: 
+  # 1. We blindly trust existing hostname settings in /etc/hosts
+  # 2. We assume hostname supports the -i option to return the default NICs IP address
+  egrep -q `hostname` /etc/hosts || echo "`hostname -i` `hostname`" >> /etc/hosts
 }
 
 # download locations for many services are at public dns

--- a/compute/src/test/resources/initscript_with_jetty.sh
+++ b/compute/src/test/resources/initscript_with_jetty.sh
@@ -115,7 +115,10 @@ function ensure_netutils_yum() {
 # most network services require that the hostname is in
 # the /etc/hosts file, or they won't operate
 function ensure_hostname_in_hosts() {
-  egrep -q `hostname` /etc/hosts || awk -v hostname=`hostname` 'END { print $1" "hostname }' /proc/net/arp >> /etc/hosts
+  # NOTE: 
+  # 1. We blindly trust existing hostname settings in /etc/hosts
+  # 2. We assume hostname supports the -i option to return the default NICs IP address
+  egrep -q `hostname` /etc/hosts || echo "`hostname -i` `hostname`" >> /etc/hosts
 }
 
 # download locations for many services are at public dns

--- a/compute/src/test/resources/runscript.sh
+++ b/compute/src/test/resources/runscript.sh
@@ -115,7 +115,10 @@ function ensure_netutils_yum() {
 # most network services require that the hostname is in
 # the /etc/hosts file, or they won't operate
 function ensure_hostname_in_hosts() {
-  egrep -q `hostname` /etc/hosts || awk -v hostname=`hostname` 'END { print $1" "hostname }' /proc/net/arp >> /etc/hosts
+  # NOTE: 
+  # 1. We blindly trust existing hostname settings in /etc/hosts
+  # 2. We assume hostname supports the -i option to return the default NICs IP address
+  egrep -q `hostname` /etc/hosts || echo "`hostname -i` `hostname`" >> /etc/hosts
 }
 
 # download locations for many services are at public dns

--- a/labs/virtualbox/src/test/resources/test_guest_additions_installer_init.sh
+++ b/labs/virtualbox/src/test/resources/test_guest_additions_installer_init.sh
@@ -112,7 +112,10 @@ function ensure_netutils_yum() {
 # most network services require that the hostname is in
 # the /etc/hosts file, or they won't operate
 function ensure_hostname_in_hosts() {
-  egrep -q `hostname` /etc/hosts || awk -v hostname=`hostname` 'END { print $1" "hostname }' /proc/net/arp >> /etc/hosts
+  # NOTE: 
+  # 1. We blindly trust existing hostname settings in /etc/hosts
+  # 2. We assume hostname supports the -i option to return the default NICs IP address
+  egrep -q `hostname` /etc/hosts || echo "`hostname -i` `hostname`" >> /etc/hosts
 }
 
 # download locations for many services are at public dns

--- a/scriptbuilder/src/main/resources/functions/setupPublicCurl.sh
+++ b/scriptbuilder/src/main/resources/functions/setupPublicCurl.sh
@@ -30,7 +30,10 @@ function ensure_netutils_yum() {
 # most network services require that the hostname is in
 # the /etc/hosts file, or they won't operate
 function ensure_hostname_in_hosts() {
-  egrep -q `hostname` /etc/hosts || awk -v hostname=`hostname` 'END { print $1" "hostname }' /proc/net/arp >> /etc/hosts
+  # NOTE: 
+  # 1. We blindly trust existing hostname settings in /etc/hosts
+  # 2. We assume hostname supports the -i option to return the default NICs IP address
+  egrep -q `hostname` /etc/hosts || echo "`hostname -i` `hostname`" >> /etc/hosts
 }
 
 # download locations for many services are at public dns

--- a/scriptbuilder/src/test/resources/test_install_chef_gems_scriptbuilder.sh
+++ b/scriptbuilder/src/test/resources/test_install_chef_gems_scriptbuilder.sh
@@ -115,7 +115,10 @@ function ensure_netutils_yum() {
 # most network services require that the hostname is in
 # the /etc/hosts file, or they won't operate
 function ensure_hostname_in_hosts() {
-  egrep -q `hostname` /etc/hosts || awk -v hostname=`hostname` 'END { print $1" "hostname }' /proc/net/arp >> /etc/hosts
+  # NOTE: 
+  # 1. We blindly trust existing hostname settings in /etc/hosts
+  # 2. We assume hostname supports the -i option to return the default NICs IP address
+  egrep -q `hostname` /etc/hosts || echo "`hostname -i` `hostname`" >> /etc/hosts
 }
 
 # download locations for many services are at public dns

--- a/scriptbuilder/src/test/resources/test_install_git_scriptbuilder.sh
+++ b/scriptbuilder/src/test/resources/test_install_git_scriptbuilder.sh
@@ -115,7 +115,10 @@ function ensure_netutils_yum() {
 # most network services require that the hostname is in
 # the /etc/hosts file, or they won't operate
 function ensure_hostname_in_hosts() {
-  egrep -q `hostname` /etc/hosts || awk -v hostname=`hostname` 'END { print $1" "hostname }' /proc/net/arp >> /etc/hosts
+  # NOTE: 
+  # 1. We blindly trust existing hostname settings in /etc/hosts
+  # 2. We assume hostname supports the -i option to return the default NICs IP address
+  egrep -q `hostname` /etc/hosts || echo "`hostname -i` `hostname`" >> /etc/hosts
 }
 
 # download locations for many services are at public dns

--- a/scriptbuilder/src/test/resources/test_install_jdk_scriptbuilder.sh
+++ b/scriptbuilder/src/test/resources/test_install_jdk_scriptbuilder.sh
@@ -115,7 +115,10 @@ function ensure_netutils_yum() {
 # most network services require that the hostname is in
 # the /etc/hosts file, or they won't operate
 function ensure_hostname_in_hosts() {
-  egrep -q `hostname` /etc/hosts || awk -v hostname=`hostname` 'END { print $1" "hostname }' /proc/net/arp >> /etc/hosts
+  # NOTE: 
+  # 1. We blindly trust existing hostname settings in /etc/hosts
+  # 2. We assume hostname supports the -i option to return the default NICs IP address
+  egrep -q `hostname` /etc/hosts || echo "`hostname -i` `hostname`" >> /etc/hosts
 }
 
 # download locations for many services are at public dns

--- a/scriptbuilder/src/test/resources/test_install_ruby_scriptbuilder.sh
+++ b/scriptbuilder/src/test/resources/test_install_ruby_scriptbuilder.sh
@@ -115,7 +115,10 @@ function ensure_netutils_yum() {
 # most network services require that the hostname is in
 # the /etc/hosts file, or they won't operate
 function ensure_hostname_in_hosts() {
-  egrep -q `hostname` /etc/hosts || awk -v hostname=`hostname` 'END { print $1" "hostname }' /proc/net/arp >> /etc/hosts
+  # NOTE: 
+  # 1. We blindly trust existing hostname settings in /etc/hosts
+  # 2. We assume hostname supports the -i option to return the default NICs IP address
+  egrep -q `hostname` /etc/hosts || echo "`hostname -i` `hostname`" >> /etc/hosts
 }
 
 # download locations for many services are at public dns


### PR DESCRIPTION
Assuming that `ensure_hostname_in_hosts` should be altering `/etc/hosts`, here are some proposed changes.
