### PR TITLE
Rename methods for consistency with other Rackspace/OpenStack APIs. 

### DIFF
--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/AccessRuleApi.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/AccessRuleApi.java
@@ -46,23 +46,23 @@ public interface AccessRuleApi {
    Iterable<AccessRuleWithId> list();
    
    /**
-    * Remove an access rule from the access list.
+    * Delete an access rule from the access list.
     * 
-    * @return true on a successful removal, false if the access rule was not found
+    * @return true on a successful delete, false if the access rule was not found
     */
-   boolean remove(int id);
+   boolean delete(int id);
    
    /**
     * Batch delete the access rules given the specified ids.
     * 
-    * @return true on a successful removal, false if the access rule was not found
+    * @return true on a successful delete, false if the access rule was not found
     */
-   boolean remove(Iterable<Integer> ids);
+   boolean delete(Iterable<Integer> ids);
    
    /**
-    * Remove the entire access list.
+    * Delete the entire access list.
     * 
-    * @return true on a successful removal, false if the access rule was not found
+    * @return true on a successful delete, false if the access rule was not found
     */
-   boolean removeAll();
+   boolean deleteAll();
 }

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/AccessRuleAsyncApi.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/AccessRuleAsyncApi.java
@@ -73,32 +73,32 @@ public interface AccessRuleAsyncApi {
    ListenableFuture<Iterable<AccessRuleWithId>> list();
 
    /**
-    * @see AccessRuleApi#remove(int)
+    * @see AccessRuleApi#delete(int)
     */
-   @Named("accessrule:remove")
+   @Named("accessrule:delete")
    @DELETE
    @Fallback(FalseOnNotFoundOr404.class)
    @Path("/accesslist/{id}")
    @Consumes("*/*")
-   ListenableFuture<Boolean> remove(@PathParam("id") int id);
+   ListenableFuture<Boolean> delete(@PathParam("id") int id);
 
    /**
-    * @see AccessRuleApi#remove(Iterable)
+    * @see AccessRuleApi#delete(Iterable)
     */
-   @Named("accessrule:remove")
+   @Named("accessrule:delete")
    @DELETE
    @Fallback(FalseOnNotFoundOr404.class)
    @Path("/accesslist")
    @Consumes("*/*")
-   ListenableFuture<Boolean> remove(@QueryParam("id") Iterable<Integer> ids);
+   ListenableFuture<Boolean> delete(@QueryParam("id") Iterable<Integer> ids);
 
    /**
-    * @see AccessRuleApi#removeAll()
+    * @see AccessRuleApi#deleteAll()
     */
-   @Named("accessrule:remove")
+   @Named("accessrule:delete")
    @DELETE
    @Fallback(FalseOnNotFoundOr404.class)
    @Path("/accesslist")
    @Consumes("*/*")
-   ListenableFuture<Boolean> removeAll();
+   ListenableFuture<Boolean> deleteAll();
 }

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/ConnectionApi.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/ConnectionApi.java
@@ -41,11 +41,11 @@ public interface ConnectionApi {
    ConnectionThrottle getConnectionThrottle();
    
    /**
-    * Remove connection throttle.
+    * Delete connection throttle.
     * 
-    * @return true on a successful removal, false if the connection throttle was not found
+    * @return true on a successful delete, false if the connection throttle was not found
     */
-   boolean removeConnectionThrottle();
+   boolean deleteConnectionThrottle();
    
    /**
     * Determine if the load balancer is logging connections.

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/ConnectionAsyncApi.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/ConnectionAsyncApi.java
@@ -76,14 +76,14 @@ public interface ConnectionAsyncApi {
    ListenableFuture<ConnectionThrottle> getConnectionThrottle();
 
    /**
-    * @see ConnectionApi#removeConnectionThrottle()
+    * @see ConnectionApi#deleteConnectionThrottle()
     */
-   @Named("connectionthrottle:remove")
+   @Named("connectionthrottle:delete")
    @DELETE
    @Fallback(FalseOnNotFoundOr422.class)
    @Path("/connectionthrottle")
    @Consumes("*/*")
-   ListenableFuture<Boolean> removeConnectionThrottle();
+   ListenableFuture<Boolean> deleteConnectionThrottle();
 
    /**
     * @see ConnectionApi#isConnectionLogging()

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/ErrorPageApi.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/ErrorPageApi.java
@@ -43,5 +43,5 @@ public interface ErrorPageApi {
     * If a custom error page is deleted, or the load balancer is changed to a non-HTTP protocol, the default error 
     * page will be restored.
     */
-   boolean remove();
+   boolean delete();
 }

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/ErrorPageAsyncApi.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/ErrorPageAsyncApi.java
@@ -73,12 +73,12 @@ public interface ErrorPageAsyncApi {
    ListenableFuture<String> get();
 
    /**
-    * @see ErrorPageApi#remove()
+    * @see ErrorPageApi#delete()
     */
-   @Named("errorpage:remove")
+   @Named("errorpage:delete")
    @DELETE
    @Consumes(MediaType.WILDCARD)
    @Fallback(FalseOnNotFoundOr404.class)
    @Path("/errorpage")
-   ListenableFuture<Boolean> remove();
+   ListenableFuture<Boolean> delete();
 }

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/HealthMonitorApi.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/HealthMonitorApi.java
@@ -46,9 +46,9 @@ public interface HealthMonitorApi {
    HealthMonitor get();
    
    /**
-    * Remove health monitor.
+    * Delete health monitor.
     * 
-    * @return true on a successful removal, false if the health monitor was not found
+    * @return true on a successful delete, false if the health monitor was not found
     */
-   boolean remove();
+   boolean delete();
 }

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/HealthMonitorAsyncApi.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/HealthMonitorAsyncApi.java
@@ -70,12 +70,12 @@ public interface HealthMonitorAsyncApi {
    ListenableFuture<HealthMonitor> get();
 
    /**
-    * @see HealthMonitorApi#remove()
+    * @see HealthMonitorApi#delete()
     */
-   @Named("healthmonitor:remove")
+   @Named("healthmonitor:delete")
    @DELETE
    @Fallback(FalseOnNotFoundOr422.class)
    @Path("/healthmonitor")
    @Consumes("*/*")
-   ListenableFuture<Boolean> remove();
+   ListenableFuture<Boolean> delete();
 }

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/LoadBalancerApi.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/LoadBalancerApi.java
@@ -88,7 +88,7 @@ public interface LoadBalancerApi {
    IterableWithMarker<LoadBalancer> list(PaginationOptions options);
 
    /**
-    * 
+    * Get a load balancer.
     * 
     * @param id
     *           id of the loadbalancer to retrieve
@@ -97,16 +97,15 @@ public interface LoadBalancerApi {
    LoadBalancer get(int id);
 
    /**
-    * Remove a load balancer from the account.
+    * Delete a load balancer.
     * <p/>
-    * The remove load balancer function removes the specified load balancer and its associated
-    * configuration from the account. Any and all configuration data is immediately purged and is
-    * not recoverable.
+    * Delete the specified load balancer and its associated configuration from the account. Any and all configuration 
+    * data is immediately purged and isnot recoverable.
     * 
     * @param id
     *           to remove
     */
-   void remove(int id);
+   void delete(int id);
    
    /**
     * When a metadata item is added, it is assigned a unique identifier that can be used for mutating operations such
@@ -128,13 +127,13 @@ public interface LoadBalancerApi {
    boolean updateMetadatum(int id, int metadatumId, String value);
 
    /**
-    * Remove metadatum.
+    * Delete metadatum.
     * 
-    * @see LoadBalancerApi#remove(int, Iterable)
+    * @see LoadBalancerApi#deleteMetadata(int, Iterable)
     * 
     * @return true on a successful removal, false if the metadatum was not found
     */
-   boolean removeMetadatum(int id, int metadatumId);
+   boolean deleteMetadatum(int id, int metadatumId);
    
    /**
     * Batch delete metadata given the specified ids.
@@ -145,5 +144,5 @@ public interface LoadBalancerApi {
     * 
     * @return true on a successful removal, false if the metadata was not found
     */
-   boolean removeMetadata(int id, Iterable<Integer> metadataIds);
+   boolean deleteMetadata(int id, Iterable<Integer> metadataIds);
 }

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/LoadBalancerAsyncApi.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/LoadBalancerAsyncApi.java
@@ -127,14 +127,14 @@ public interface LoadBalancerAsyncApi {
    ListenableFuture<LoadBalancer> get(@PathParam("id") int id);
 
    /**
-    * @see LoadBalancerApi#remove(int)
+    * @see LoadBalancerApi#delete(int)
     */
-   @Named("lb:remove")
+   @Named("lb:delete")
    @DELETE
    @Fallback(VoidOnNotFoundOr404.class)
    @Path("/loadbalancers/{id}")
    @Consumes("*/*")
-   ListenableFuture<Void> remove(@PathParam("id") int id);
+   ListenableFuture<Void> delete(@PathParam("id") int id);
 
    /**
     * @see LoadBalancerApi#createMetadata(int, Iterable)
@@ -175,23 +175,23 @@ public interface LoadBalancerAsyncApi {
                                              @PayloadParam("value") String value);
 
    /**
-    * @see LoadBalancerApi#removeMetadatum(int, int)
+    * @see LoadBalancerApi#deleteMetadatum(int, int)
     */
-   @Named("lb:removemetadatum")
+   @Named("lb:deletemetadatum")
    @DELETE
    @Fallback(FalseOnNotFoundOr404.class)
    @Consumes("*/*")
    @Path("/loadbalancers/{id}/metadata/{metadatumId}")
-   ListenableFuture<Boolean> removeMetadatum(@PathParam("id") int id, @PathParam("metadatumId") int metadatumId);
+   ListenableFuture<Boolean> deleteMetadatum(@PathParam("id") int id, @PathParam("metadatumId") int metadatumId);
 
    /**
-    * @see LoadBalancerApi#removeMetadata(int, Iterable)
+    * @see LoadBalancerApi#deleteMetadata(int, Iterable)
     */
-   @Named("lb:removemetadata")
+   @Named("lb:deletemetadata")
    @DELETE
    @Fallback(FalseOnNotFoundOr404.class)
    @Consumes("*/*")
    @Path("/loadbalancers/{id}/metadata")
-   ListenableFuture<Boolean> removeMetadata(@PathParam("id") int id, 
+   ListenableFuture<Boolean> deleteMetadata(@PathParam("id") int id, 
                                             @QueryParam("id") Iterable<Integer> metadataIds);
 }

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/NodeApi.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/NodeApi.java
@@ -134,13 +134,13 @@ public interface NodeApi {
    boolean updateMetadatum(int id, int metadatumId, String value);
 
    /**
-    * Remove metadatum.
+    * Delete metadatum.
     * 
-    * @see NodeApi#remove(int, Iterable)
+    * @see NodeApi#deleteMetadata(int, Iterable)
     * 
     * @return true on a successful removal, false if the metadatum was not found
     */
-   boolean removeMetadatum(int id, int metadatumId);
+   boolean deleteMetadatum(int id, int metadatumId);
    
    /**
     * Batch delete metadata given the specified ids.
@@ -151,5 +151,5 @@ public interface NodeApi {
     * 
     * @return true on a successful removal, false if the metadata was not found
     */
-   boolean removeMetadata(int id, Iterable<Integer> metadataIds);
+   boolean deleteMetadata(int id, Iterable<Integer> metadataIds);
 }

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/NodeAsyncApi.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/NodeAsyncApi.java
@@ -187,23 +187,23 @@ public interface NodeAsyncApi {
                                              @PayloadParam("value") String value);
 
    /**
-    * @see NodeApi#removeMetadatum(int, int)
+    * @see NodeApi#deleteMetadatum(int, int)
     */
-   @Named("node:removemetadatum")
+   @Named("node:deletemetadatum")
    @DELETE
    @Fallback(FalseOnNotFoundOr404.class)
    @Consumes("*/*")
    @Path("/nodes/{id}/metadata/{metadatumId}")
-   ListenableFuture<Boolean> removeMetadatum(@PathParam("id") int id, @PathParam("metadatumId") int metadatumId);
+   ListenableFuture<Boolean> deleteMetadatum(@PathParam("id") int id, @PathParam("metadatumId") int metadatumId);
 
    /**
-    * @see NodeApi#removeMetadata(int, Iterable)
+    * @see NodeApi#deleteMetadata(int, Iterable)
     */
-   @Named("node:removemetadata")
+   @Named("node:deletemetadata")
    @DELETE
    @Fallback(FalseOnNotFoundOr404.class)
    @Consumes("*/*")
    @Path("/nodes/{id}/metadata")
-   ListenableFuture<Boolean> removeMetadata(@PathParam("id") int id, 
+   ListenableFuture<Boolean> deleteMetadata(@PathParam("id") int id, 
                                             @QueryParam("id") Iterable<Integer> metadataIds);
 }

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/SSLTerminationApi.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/SSLTerminationApi.java
@@ -79,9 +79,9 @@ public interface SSLTerminationApi {
    SSLTermination get();
    
    /**
-    * Remove SSL termination.
+    * Delete SSL termination.
     * 
-    * @return true on a successful removal, false if the SSL termination was not found
+    * @return true on a successful delete, false if the SSL termination was not found
     */
-   boolean remove();
+   boolean delete();
 }

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/SSLTerminationAsyncApi.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/SSLTerminationAsyncApi.java
@@ -70,12 +70,12 @@ public interface SSLTerminationAsyncApi {
    ListenableFuture<SSLTermination> get();
 
    /**
-    * @see SSLTerminationApi#remove()
+    * @see SSLTerminationApi#delete()
     */
-   @Named("ssltermination:remove")
+   @Named("ssltermination:delete")
    @DELETE
    @Fallback(FalseOnNotFoundOr422.class)
    @Path("/ssltermination")
    @Consumes("*/*")
-   ListenableFuture<Boolean> remove();
+   ListenableFuture<Boolean> delete();
 }

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/SessionPersistenceApi.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/SessionPersistenceApi.java
@@ -45,9 +45,9 @@ public interface SessionPersistenceApi {
    void create(SessionPersistence sessionPersistence);
    
    /**
-    * Remove session persistence.
+    * Delete session persistence.
     * 
     * @see SessionPersistence
     */
-   void remove();
+   void delete();
 }

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/SessionPersistenceAsyncApi.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/SessionPersistenceAsyncApi.java
@@ -53,7 +53,7 @@ public interface SessionPersistenceAsyncApi {
    /**
     * @see SessionPersistenceApi#get()
     */
-   @Named("sessionpersistence:state")
+   @Named("sessionpersistence:get")
    @GET
    @Consumes(MediaType.APPLICATION_JSON)
    @ResponseParser(ParseSessionPersistence.class)
@@ -64,7 +64,7 @@ public interface SessionPersistenceAsyncApi {
    /**
     * @see SessionPersistenceApi#create(SessionPersistence)
     */
-   @Named("sessionpersistence:state")
+   @Named("sessionpersistence:create")
    @PUT
    @Produces(MediaType.APPLICATION_JSON)
    @Consumes(MediaType.APPLICATION_JSON)
@@ -74,12 +74,12 @@ public interface SessionPersistenceAsyncApi {
    ListenableFuture<Void> create(@PayloadParam("sessionPersistence") SessionPersistence sessionPersistence);
 
    /**
-    * @see SessionPersistenceApi#remove()
+    * @see SessionPersistenceApi#delete()
     */
-   @Named("sessionpersistence:state")
+   @Named("sessionpersistence:delete")
    @DELETE
    @Consumes(MediaType.APPLICATION_JSON)
    @Fallback(VoidOnNotFoundOr404.class)
    @Path("/sessionpersistence")
-   ListenableFuture<Void> remove();
+   ListenableFuture<Void> delete();
 }

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/VirtualIPApi.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/VirtualIPApi.java
@@ -42,13 +42,13 @@ public interface VirtualIPApi {
    Iterable<VirtualIPWithId> list();
    
    /**
-    * Remove a virtual IP.
+    * Delete a virtual IP.
     * 
-    * @see VirtualIPApi#remove(Iterable)
+    * @see VirtualIPApi#delete(Iterable)
     * 
-    * @return true on a successful removal, false if the virtual IP was not found
+    * @return true on a successful delete, false if the virtual IP was not found
     */
-   boolean remove(int id);
+   boolean delete(int id);
    
    /**
     * Batch delete virtual IPs given the specified ids.
@@ -59,7 +59,7 @@ public interface VirtualIPApi {
     * cannot be removed due to its current status, an exception is thrown along with the ids of the ones the 
     * system identified as potential failures for this request.
     * 
-    * @return true on a successful removal, false if the virtual IP was not found
+    * @return true on a successful delete, false if the virtual IP was not found
     */
-   boolean remove(Iterable<Integer> ids);
+   boolean delete(Iterable<Integer> ids);
 }

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/VirtualIPAsyncApi.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/features/VirtualIPAsyncApi.java
@@ -74,22 +74,22 @@ public interface VirtualIPAsyncApi {
    ListenableFuture<Iterable<VirtualIPWithId>> list();
 
    /**
-    * @see VirtualIPApi#remove(int)
+    * @see VirtualIPApi#delete(int)
     */
-   @Named("virtualip:remove")
+   @Named("virtualip:delete")
    @DELETE
    @Fallback(FalseOnNotFoundOr404.class)
    @Path("/virtualips/{id}")
    @Consumes("*/*")
-   ListenableFuture<Boolean> remove(@PathParam("id") int id);
+   ListenableFuture<Boolean> delete(@PathParam("id") int id);
 
    /**
-    * @see VirtualIPApi#remove(Iterable)
+    * @see VirtualIPApi#delete(Iterable)
     */
-   @Named("virtualip:remove")
+   @Named("virtualip:delete")
    @DELETE
    @Fallback(FalseOnNotFoundOr404.class)
    @Path("/virtualips")
    @Consumes("*/*")
-   ListenableFuture<Boolean> remove(@QueryParam("id") Iterable<Integer> ids);
+   ListenableFuture<Boolean> delete(@QueryParam("id") Iterable<Integer> ids);
 }

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/loadbalancer/strategy/CloudLoadBalancersDestroyLoadBalancerStrategy.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/loadbalancer/strategy/CloudLoadBalancersDestroyLoadBalancerStrategy.java
@@ -57,7 +57,7 @@ public class CloudLoadBalancersDestroyLoadBalancerStrategy implements DestroyLoa
       String[] parts = checkNotNull(id, "id").split("/");
       String region = parts[0];
       int lbId = Integer.parseInt(parts[1]);
-      client.getLoadBalancerApiForZone(region).remove(lbId);
+      client.getLoadBalancerApiForZone(region).delete(lbId);
       return getLoadBalancer.getLoadBalancer(id);
    }
 }

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/AccessRuleApiExpectTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/AccessRuleApiExpectTest.java
@@ -79,7 +79,7 @@ public class AccessRuleApiExpectTest extends BaseCloudLoadBalancerApiExpectTest<
             HttpResponse.builder().statusCode(200).build()
       ).getAccessRuleApiForZoneAndLoadBalancer("DFW", 2000);
 
-      assertTrue(api.remove(23));
+      assertTrue(api.delete(23));
    }
 
    public void testRemoveManyAccessRules() {
@@ -92,7 +92,7 @@ public class AccessRuleApiExpectTest extends BaseCloudLoadBalancerApiExpectTest<
       ).getAccessRuleApiForZoneAndLoadBalancer("DFW", 2000);
 
       List<Integer> accessRuleIds = ImmutableList.<Integer> of(23, 24);
-      assertTrue(api.remove(accessRuleIds));
+      assertTrue(api.delete(accessRuleIds));
    }
 
    public void testRemoveAllAccessRules() {
@@ -104,7 +104,7 @@ public class AccessRuleApiExpectTest extends BaseCloudLoadBalancerApiExpectTest<
             HttpResponse.builder().statusCode(200).build()
       ).getAccessRuleApiForZoneAndLoadBalancer("DFW", 2000);
 
-      assertTrue(api.removeAll());
+      assertTrue(api.deleteAll());
    }
 
    private Iterable<AccessRuleWithId> getAccessRules() {

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/AccessRuleApiLiveTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/AccessRuleApiLiveTest.java
@@ -96,7 +96,7 @@ public class AccessRuleApiLiveTest extends BaseCloudLoadBalancersApiLiveTest {
       AccessRuleWithId removedAccessRule = Iterables.getFirst(actualAccessList, null);
       accessRules.remove(removedAccessRule.getAddress());
       
-      assertTrue(clbApi.getAccessRuleApiForZoneAndLoadBalancer(zone, lb.getId()).remove(removedAccessRule.getId()));
+      assertTrue(clbApi.getAccessRuleApiForZoneAndLoadBalancer(zone, lb.getId()).delete(removedAccessRule.getId()));
       assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
       
       assertExpectedAccessRules(accessRules);
@@ -111,7 +111,7 @@ public class AccessRuleApiLiveTest extends BaseCloudLoadBalancersApiLiveTest {
       accessRules.remove(removedAccessRule1.getAddress());
       accessRules.remove(removedAccessRule2.getAddress());
       
-      assertTrue(clbApi.getAccessRuleApiForZoneAndLoadBalancer(zone, lb.getId()).remove(removedAccessRuleIds));
+      assertTrue(clbApi.getAccessRuleApiForZoneAndLoadBalancer(zone, lb.getId()).delete(removedAccessRuleIds));
       assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
       
       assertExpectedAccessRules(accessRules);
@@ -119,7 +119,7 @@ public class AccessRuleApiLiveTest extends BaseCloudLoadBalancersApiLiveTest {
    
    @Test(dependsOnMethods = "testRemoveManyAccessRules")
    public void testRemoveAllAccessRules() throws Exception {
-      assertTrue(clbApi.getAccessRuleApiForZoneAndLoadBalancer(zone, lb.getId()).removeAll());
+      assertTrue(clbApi.getAccessRuleApiForZoneAndLoadBalancer(zone, lb.getId()).deleteAll());
       assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
       
       assertExpectedAccessRules(new HashMap<String, AccessRule>());
@@ -138,7 +138,7 @@ public class AccessRuleApiLiveTest extends BaseCloudLoadBalancersApiLiveTest {
    @AfterGroups(groups = "live")
    protected void tearDownContext() {
       assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
-      clbApi.getLoadBalancerApiForZone(zone).remove(lb.getId());
+      clbApi.getLoadBalancerApiForZone(zone).delete(lb.getId());
       assertTrue(awaitDeleted(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
       super.tearDownContext();
    }

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/ConnectionApiExpectTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/ConnectionApiExpectTest.java
@@ -93,7 +93,7 @@ public class ConnectionApiExpectTest extends BaseCloudLoadBalancerApiExpectTest<
             HttpResponse.builder().statusCode(200).build()
       ).getConnectionApiForZoneAndLoadBalancer("DFW", 2000);
 
-      assertTrue(api.removeConnectionThrottle());
+      assertTrue(api.deleteConnectionThrottle());
    }
    
    public void testIsConnectionLogging() {

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/ConnectionApiLiveTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/ConnectionApiLiveTest.java
@@ -69,7 +69,7 @@ public class ConnectionApiLiveTest extends BaseCloudLoadBalancersApiLiveTest {
    
    @Test(dependsOnMethods = "testCreateAndGetConnectionThrottling")
    public void testRemoveAndGetConnectionThrottle() throws Exception {
-      assertTrue(clbApi.getConnectionApiForZoneAndLoadBalancer(zone, lb.getId()).removeConnectionThrottle());
+      assertTrue(clbApi.getConnectionApiForZoneAndLoadBalancer(zone, lb.getId()).deleteConnectionThrottle());
       assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
       
       ConnectionThrottle connectionThrottle = 
@@ -104,7 +104,7 @@ public class ConnectionApiLiveTest extends BaseCloudLoadBalancersApiLiveTest {
    @AfterGroups(groups = "live")
    protected void tearDownContext() {
       assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
-      clbApi.getLoadBalancerApiForZone(zone).remove(lb.getId());
+      clbApi.getLoadBalancerApiForZone(zone).delete(lb.getId());
       assertTrue(awaitDeleted(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
       super.tearDownContext();
    }

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/ContentCachingApiLiveTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/ContentCachingApiLiveTest.java
@@ -78,7 +78,7 @@ public class ContentCachingApiLiveTest extends BaseCloudLoadBalancersApiLiveTest
    @AfterGroups(groups = "live")
    protected void tearDownContext() {
       assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
-      clbApi.getLoadBalancerApiForZone(zone).remove(lb.getId());
+      clbApi.getLoadBalancerApiForZone(zone).delete(lb.getId());
       assertTrue(awaitDeleted(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
       super.tearDownContext();
    }

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/ErrorPageApiExpectTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/ErrorPageApiExpectTest.java
@@ -89,7 +89,7 @@ public class ErrorPageApiExpectTest extends BaseCloudLoadBalancerApiExpectTest<C
             HttpResponse.builder().statusCode(200).build()
       ).getErrorPageApiForZoneAndLoadBalancer("DFW", 2000);
 
-      assertTrue(api.remove());
+      assertTrue(api.delete());
    }
    
    public static String getContentExpected() {

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/ErrorPageApiLiveTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/ErrorPageApiLiveTest.java
@@ -76,7 +76,7 @@ public class ErrorPageApiLiveTest extends BaseCloudLoadBalancersApiLiveTest {
    
    @Test(dependsOnMethods = "testCreateAndGetErrorPage")
    public void testRemoveAndGetErrorPage() throws Exception {
-      assertTrue(clbApi.getErrorPageApiForZoneAndLoadBalancer(zone, lb.getId()).remove());
+      assertTrue(clbApi.getErrorPageApiForZoneAndLoadBalancer(zone, lb.getId()).delete());
       assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
       
       String content = clbApi.getErrorPageApiForZoneAndLoadBalancer(zone, lb.getId()).get();
@@ -88,7 +88,7 @@ public class ErrorPageApiLiveTest extends BaseCloudLoadBalancersApiLiveTest {
    @AfterGroups(groups = "live")
    protected void tearDownContext() {
       assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
-      clbApi.getLoadBalancerApiForZone(zone).remove(lb.getId());
+      clbApi.getLoadBalancerApiForZone(zone).delete(lb.getId());
       assertTrue(awaitDeleted(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
       super.tearDownContext();
    }

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/HealthMonitorApiExpectTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/HealthMonitorApiExpectTest.java
@@ -84,7 +84,7 @@ public class HealthMonitorApiExpectTest extends BaseCloudLoadBalancerApiExpectTe
             HttpResponse.builder().statusCode(200).build()
       ).getHealthMonitorApiForZoneAndLoadBalancer("DFW", 2000);
 
-      assertTrue(api.remove());
+      assertTrue(api.delete());
    }
 
    public void testValidConnectHealthMonitor() {

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/HealthMonitorApiLiveTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/HealthMonitorApiLiveTest.java
@@ -68,7 +68,7 @@ public class HealthMonitorApiLiveTest extends BaseCloudLoadBalancersApiLiveTest 
    
    @Test(dependsOnMethods = "testCreateAndGetHealthMonitor")
    public void testRemoveAndGetHealthMonitor() throws Exception {
-      assertTrue(clbApi.getHealthMonitorApiForZoneAndLoadBalancer(zone, lb.getId()).remove());
+      assertTrue(clbApi.getHealthMonitorApiForZoneAndLoadBalancer(zone, lb.getId()).delete());
       assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
       
       HealthMonitor healthMonitor = 
@@ -81,7 +81,7 @@ public class HealthMonitorApiLiveTest extends BaseCloudLoadBalancersApiLiveTest 
    @AfterGroups(groups = "live")
    protected void tearDownContext() {
       assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
-      clbApi.getLoadBalancerApiForZone(zone).remove(lb.getId());
+      clbApi.getLoadBalancerApiForZone(zone).delete(lb.getId());
       assertTrue(awaitDeleted(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
       super.tearDownContext();
    }

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/LoadBalancerApiExpectTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/LoadBalancerApiExpectTest.java
@@ -146,7 +146,7 @@ public class LoadBalancerApiExpectTest extends BaseCloudLoadBalancerApiExpectTes
             HttpResponse.builder().statusCode(202).payload("").build()
       ).getLoadBalancerApiForZone("DFW");
       
-      api.remove(2000);
+      api.delete(2000);
    }
 
    public void testListMetadata() {
@@ -187,7 +187,7 @@ public class LoadBalancerApiExpectTest extends BaseCloudLoadBalancerApiExpectTes
             HttpResponse.builder().statusCode(200).build()
       ).getLoadBalancerApiForZone("DFW");
 
-      assertTrue(api.removeMetadatum(2000, 23));
+      assertTrue(api.deleteMetadatum(2000, 23));
    }
 
    public void testRemoveManyMetadata() {
@@ -201,7 +201,7 @@ public class LoadBalancerApiExpectTest extends BaseCloudLoadBalancerApiExpectTes
       
       
       
-      assertTrue(api.removeMetadata(2000, ImmutableList.<Integer> of(23, 24)));
+      assertTrue(api.deleteMetadata(2000, ImmutableList.<Integer> of(23, 24)));
    }
 
    private Object getExpectedLoadBalancer() {

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/LoadBalancerApiLiveTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/LoadBalancerApiLiveTest.java
@@ -56,7 +56,7 @@ public class LoadBalancerApiLiveTest extends BaseCloudLoadBalancersApiLiveTest {
    protected void tearDownContext() {
       for (LoadBalancer lb: lbs) {
          assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(lb.getRegion())).apply(lb));
-         clbApi.getLoadBalancerApiForZone(lb.getRegion()).remove(lb.getId());
+         clbApi.getLoadBalancerApiForZone(lb.getRegion()).delete(lb.getId());
          assertTrue(awaitDeleted(clbApi.getLoadBalancerApiForZone(lb.getRegion())).apply(lb));
       }
       super.tearDownContext();
@@ -172,12 +172,12 @@ public class LoadBalancerApiLiveTest extends BaseCloudLoadBalancersApiLiveTest {
          metadata = clbApi.getLoadBalancerApiForZone(lb.getRegion()).getMetadata(lb.getId());
          assertEquals(metadata.get("key1"), "key1-updated");
 
-         assertTrue(clbApi.getLoadBalancerApiForZone(lb.getRegion()).removeMetadatum(lb.getId(), metadata.getId("key1")));
+         assertTrue(clbApi.getLoadBalancerApiForZone(lb.getRegion()).deleteMetadatum(lb.getId(), metadata.getId("key1")));
          assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(lb.getRegion())).apply(lb));
          metadata = clbApi.getLoadBalancerApiForZone(lb.getRegion()).getMetadata(lb.getId());
          assertNull(metadata.get("key1"));
 
-         assertTrue(clbApi.getLoadBalancerApiForZone(lb.getRegion()).removeMetadata(lb.getId(), 
+         assertTrue(clbApi.getLoadBalancerApiForZone(lb.getRegion()).deleteMetadata(lb.getId(), 
                ImmutableList.<Integer> of(metadata.getId("key2"), metadata.getId("key3"))));
          assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(lb.getRegion())).apply(lb));
          metadata = clbApi.getLoadBalancerApiForZone(lb.getRegion()).getMetadata(lb.getId());

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/NodeApiExpectTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/NodeApiExpectTest.java
@@ -192,7 +192,7 @@ public class NodeApiExpectTest extends BaseCloudLoadBalancerApiExpectTest<CloudL
             HttpResponse.builder().statusCode(200).build()
       ).getNodeApiForZoneAndLoadBalancer("DFW", 2000);
 
-      assertTrue(api.removeMetadatum(410, 23));
+      assertTrue(api.deleteMetadatum(410, 23));
    }
 
    public void testRemoveManyMetadata() {
@@ -206,7 +206,7 @@ public class NodeApiExpectTest extends BaseCloudLoadBalancerApiExpectTest<CloudL
       
       
       
-      assertTrue(api.removeMetadata(410, ImmutableList.<Integer> of(23, 24)));
+      assertTrue(api.deleteMetadata(410, ImmutableList.<Integer> of(23, 24)));
    }
 
    private Metadata getExpectedMetadata() {

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/NodeApiLiveTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/NodeApiLiveTest.java
@@ -163,12 +163,12 @@ public class NodeApiLiveTest extends BaseCloudLoadBalancersApiLiveTest {
          metadata = clbApi.getNodeApiForZoneAndLoadBalancer(lb.getRegion(), lb.getId()).getMetadata(node.getId());
          assertEquals(metadata.get("key1"), "key1-updated");
 
-         assertTrue(clbApi.getNodeApiForZoneAndLoadBalancer(lb.getRegion(), lb.getId()).removeMetadatum(node.getId(), metadata.getId("key1")));
+         assertTrue(clbApi.getNodeApiForZoneAndLoadBalancer(lb.getRegion(), lb.getId()).deleteMetadatum(node.getId(), metadata.getId("key1")));
          assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(lb.getRegion())).apply(lb));
          metadata = clbApi.getNodeApiForZoneAndLoadBalancer(lb.getRegion(), lb.getId()).getMetadata(node.getId());
          assertNull(metadata.get("key1"));
 
-         assertTrue(clbApi.getNodeApiForZoneAndLoadBalancer(lb.getRegion(), lb.getId()).removeMetadata(node.getId(), 
+         assertTrue(clbApi.getNodeApiForZoneAndLoadBalancer(lb.getRegion(), lb.getId()).deleteMetadata(node.getId(), 
                ImmutableList.<Integer> of(metadata.getId("key2"), metadata.getId("key3"))));
          assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(lb.getRegion())).apply(lb));
          metadata = clbApi.getNodeApiForZoneAndLoadBalancer(lb.getRegion(), lb.getId()).getMetadata(node.getId());
@@ -185,7 +185,7 @@ public class NodeApiLiveTest extends BaseCloudLoadBalancersApiLiveTest {
 
          if (lbClient.get(lb.getId()).getStatus() != Status.DELETED) {
             assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(lb.getRegion())).apply(lb));
-            lbClient.remove(lb.getId());
+            lbClient.delete(lb.getId());
          }
          assertTrue(awaitDeleted(clbApi.getLoadBalancerApiForZone(lb.getRegion())).apply(lb));
       }

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/ReportApiLiveTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/ReportApiLiveTest.java
@@ -103,7 +103,7 @@ public class ReportApiLiveTest extends BaseCloudLoadBalancersApiLiveTest {
    @AfterGroups(groups = "live")
    protected void tearDownContext() {
       assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
-      clbApi.getLoadBalancerApiForZone(zone).remove(lb.getId());
+      clbApi.getLoadBalancerApiForZone(zone).delete(lb.getId());
       assertTrue(awaitDeleted(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
       super.tearDownContext();
    }

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/SSLTerminationApiExpectTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/SSLTerminationApiExpectTest.java
@@ -91,7 +91,7 @@ public class SSLTerminationApiExpectTest extends BaseCloudLoadBalancerApiExpectT
             HttpResponse.builder().statusCode(200).build()
       ).getSSLTerminationApiForZoneAndLoadBalancer("DFW", 2000);
 
-      assertTrue(api.remove());
+      assertTrue(api.delete());
    }
 
    public static SSLTermination getSSLTermination() throws IOException {

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/SSLTerminationApiLiveTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/SSLTerminationApiLiveTest.java
@@ -68,7 +68,7 @@ public class SSLTerminationApiLiveTest extends BaseCloudLoadBalancersApiLiveTest
    
    @Test(dependsOnMethods = "testCreateAndGetSSLTermination")
    public void testRemoveAndGetSSLTermination() throws Exception {
-      assertTrue(clbApi.getSSLTerminationApiForZoneAndLoadBalancer(zone, lb.getId()).remove());
+      assertTrue(clbApi.getSSLTerminationApiForZoneAndLoadBalancer(zone, lb.getId()).delete());
       assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
       
       SSLTermination sslTermination = 
@@ -81,7 +81,7 @@ public class SSLTerminationApiLiveTest extends BaseCloudLoadBalancersApiLiveTest
    @AfterGroups(groups = "live")
    protected void tearDownContext() {
       assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
-      clbApi.getLoadBalancerApiForZone(zone).remove(lb.getId());
+      clbApi.getLoadBalancerApiForZone(zone).delete(lb.getId());
       assertTrue(awaitDeleted(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
       super.tearDownContext();
    }

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/SessionPersistenceApiExpectTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/SessionPersistenceApiExpectTest.java
@@ -81,6 +81,6 @@ public class SessionPersistenceApiExpectTest extends BaseCloudLoadBalancerApiExp
             HttpResponse.builder().statusCode(200).build()
       ).getSessionPersistenceApiForZoneAndLoadBalancer("DFW", 2000);
       
-      api.remove();
+      api.delete();
    }   
 }

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/SessionPersistenceApiLiveTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/SessionPersistenceApiLiveTest.java
@@ -67,7 +67,7 @@ public class SessionPersistenceApiLiveTest extends BaseCloudLoadBalancersApiLive
    
    @Test(dependsOnMethods = "testCreateAndGetSessionPersistence")
    public void testRemoveAndGetSessionPersistence() throws Exception {
-      clbApi.getSessionPersistenceApiForZoneAndLoadBalancer(zone, lb.getId()).remove();
+      clbApi.getSessionPersistenceApiForZoneAndLoadBalancer(zone, lb.getId()).delete();
       assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
       
       SessionPersistence sessionPersistence = 
@@ -80,7 +80,7 @@ public class SessionPersistenceApiLiveTest extends BaseCloudLoadBalancersApiLive
    @AfterGroups(groups = "live")
    protected void tearDownContext() {
       assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
-      clbApi.getLoadBalancerApiForZone(zone).remove(lb.getId());
+      clbApi.getLoadBalancerApiForZone(zone).delete(lb.getId());
       assertTrue(awaitDeleted(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
       super.tearDownContext();
    }

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/VirtualIPApiExpectTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/VirtualIPApiExpectTest.java
@@ -73,7 +73,7 @@ public class VirtualIPApiExpectTest extends BaseCloudLoadBalancerApiExpectTest<C
             HttpResponse.builder().statusCode(200).build()
       ).getVirtualIPApiForZoneAndLoadBalancer("DFW", 2000);
 
-      api.remove(23);
+      api.delete(23);
    }
 
    public void testRemoveManyVirtualIPs() {
@@ -86,7 +86,7 @@ public class VirtualIPApiExpectTest extends BaseCloudLoadBalancerApiExpectTest<C
       ).getVirtualIPApiForZoneAndLoadBalancer("DFW", 2000);
 
       List<Integer> virtualIPIds = ImmutableList.<Integer> of(23, 24);
-      api.remove(virtualIPIds);
+      api.delete(virtualIPIds);
    }
 
    private Iterable<VirtualIPWithId> getVirtualIPs() {

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/VirtualIPApiLiveTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/features/VirtualIPApiLiveTest.java
@@ -77,7 +77,7 @@ public class VirtualIPApiLiveTest extends BaseCloudLoadBalancersApiLiveTest {
       Iterable<VirtualIPWithId> actualVirtualIPs = clbApi.getVirtualIPApiForZoneAndLoadBalancer(zone, lb.getId()).list();
       VirtualIPWithId removedVirtualIP = Iterables.getFirst(actualVirtualIPs, null);
       
-      assertTrue(clbApi.getVirtualIPApiForZoneAndLoadBalancer(zone, lb.getId()).remove(removedVirtualIP.getId()));
+      assertTrue(clbApi.getVirtualIPApiForZoneAndLoadBalancer(zone, lb.getId()).delete(removedVirtualIP.getId()));
       assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
       
       actualVirtualIPs = clbApi.getVirtualIPApiForZoneAndLoadBalancer(zone, lb.getId()).list();
@@ -92,7 +92,7 @@ public class VirtualIPApiLiveTest extends BaseCloudLoadBalancersApiLiveTest {
       VirtualIPWithId removedVirtualIP2 = Iterables.getLast(actualVirtualIPs);
       List<Integer> removedVirtualIPIds = ImmutableList.<Integer> of(removedVirtualIP1.getId(), removedVirtualIP2.getId());
       
-      assertTrue(clbApi.getVirtualIPApiForZoneAndLoadBalancer(zone, lb.getId()).remove(removedVirtualIPIds));
+      assertTrue(clbApi.getVirtualIPApiForZoneAndLoadBalancer(zone, lb.getId()).delete(removedVirtualIPIds));
       assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
       
       actualVirtualIPs = clbApi.getVirtualIPApiForZoneAndLoadBalancer(zone, lb.getId()).list();
@@ -104,7 +104,7 @@ public class VirtualIPApiLiveTest extends BaseCloudLoadBalancersApiLiveTest {
    @AfterGroups(groups = "live")
    protected void tearDownContext() {
       assertTrue(awaitAvailable(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
-      clbApi.getLoadBalancerApiForZone(zone).remove(lb.getId());
+      clbApi.getLoadBalancerApiForZone(zone).delete(lb.getId());
       assertTrue(awaitDeleted(clbApi.getLoadBalancerApiForZone(zone)).apply(lb));
       super.tearDownContext();
    }


### PR DESCRIPTION
Changed remove to delete as delete is the opposite of create.

Best to do this before CLB starts seeing heavy use.
