### PR TITLE
changed aws apis to use Action key for config instead of more verbose iam names

### DIFF
--- a/apis/cloudwatch/src/main/java/org/jclouds/cloudwatch/features/MetricAsyncApi.java
+++ b/apis/cloudwatch/src/main/java/org/jclouds/cloudwatch/features/MetricAsyncApi.java
@@ -63,7 +63,7 @@ public interface MetricAsyncApi {
    /**
     * @see MetricApi#list()
     */
-   @Named("cloudwatch:ListMetrics")
+   @Named("ListMetrics")
    @POST
    @Path("/")
    @XMLResponseParser(ListMetricsResponseHandler.class)
@@ -75,7 +75,7 @@ public interface MetricAsyncApi {
    /**
     * @see MetricApi#list(ListMetricsOptions)
     */
-   @Named("cloudwatch:ListMetrics")
+   @Named("ListMetrics")
    @POST
    @Path("/")
    @XMLResponseParser(ListMetricsResponseHandler.class)
@@ -86,7 +86,7 @@ public interface MetricAsyncApi {
    /**
     * @see MetricApi#getMetricStatistics(GetMetricStatistics)
     */
-   @Named("cloudwatch:GetMetricStatistics")
+   @Named("GetMetricStatistics")
    @POST
    @Path("/")
    @XMLResponseParser(GetMetricStatisticsResponseHandlerV2.class)
@@ -97,7 +97,7 @@ public interface MetricAsyncApi {
    /**
     * @see MetricApi#getMetricStatistics(GetMetricStatistics, GetMetricStatisticsOptions)
     */
-   @Named("cloudwatch:GetMetricStatistics")
+   @Named("GetMetricStatistics")
    @POST
    @Path("/")
    @XMLResponseParser(GetMetricStatisticsResponseHandlerV2.class)
@@ -109,7 +109,7 @@ public interface MetricAsyncApi {
    /**
     * @see MetricApi#putMetricsInNamespace(Iterable, String)
     */
-   @Named("cloudwatch:PutMetricData")
+   @Named("PutMetricData")
    @POST
    @Path("/")
    @FormParams(keys = "Action", values = "PutMetricData")

--- a/apis/ec2/src/main/java/org/jclouds/ec2/features/TagAsyncApi.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/features/TagAsyncApi.java
@@ -65,7 +65,7 @@ public interface TagAsyncApi {
     * @see <a
     *      href="http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-CreateTags.html">docs</a>
     */
-   @Named("ec2:CreateTags")
+   @Named("CreateTags")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreateTags")
@@ -77,7 +77,7 @@ public interface TagAsyncApi {
     * @see <a
     *      href="http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-CreateTags.html">docs</a>
     */
-   @Named("ec2:CreateTags")
+   @Named("CreateTags")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreateTags")
@@ -89,7 +89,7 @@ public interface TagAsyncApi {
     * @see <a
     *      href="http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeTags.html">docs</a>
     */
-   @Named("ec2:DescribeTags")
+   @Named("DescribeTags")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeTags")
@@ -102,7 +102,7 @@ public interface TagAsyncApi {
     * @see <a
     *      href="http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeTags.html">docs</a>
     */
-   @Named("ec2:DescribeTags")
+   @Named("DescribeTags")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeTags")
@@ -116,7 +116,7 @@ public interface TagAsyncApi {
     * @see <a
     *      href="http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DeleteTags.html">docs</a>
     */
-   @Named("ec2:DeleteTags")
+   @Named("DeleteTags")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeleteTags")
@@ -129,7 +129,7 @@ public interface TagAsyncApi {
     * @see <a
     *      href="http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DeleteTags.html">docs</a>
     */
-   @Named("ec2:DeleteTags")
+   @Named("DeleteTags")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeleteTags")

--- a/apis/ec2/src/main/java/org/jclouds/ec2/features/WindowsAsyncApi.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/features/WindowsAsyncApi.java
@@ -56,7 +56,7 @@ public interface WindowsAsyncApi {
    /**
     * @see WindowsApi#getPasswordDataForInstance
     */
-   @Named("ec2:GetPasswordData")
+   @Named("GetPasswordData")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "GetPasswordData")

--- a/apis/ec2/src/main/java/org/jclouds/ec2/services/AMIAsyncClient.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/services/AMIAsyncClient.java
@@ -68,7 +68,7 @@ public interface AMIAsyncClient {
    /**
     * @see AMIClient#describeImagesInRegion
     */
-   @Named("ec2:DescribeImages")
+   @Named("DescribeImages")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeImages")
@@ -81,7 +81,7 @@ public interface AMIAsyncClient {
    /**
     * @see AMIClient#createImageInRegion
     */
-   @Named("ec2:CreateImage")
+   @Named("CreateImage")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreateImage")
@@ -93,7 +93,7 @@ public interface AMIAsyncClient {
    /**
     * @see AMIClient#deregisterImageInRegion
     */
-   @Named("ec2:DeregisterImage")
+   @Named("DeregisterImage")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeregisterImage")
@@ -104,7 +104,7 @@ public interface AMIAsyncClient {
    /**
     * @see AMIClient#registerImageFromManifestInRegion
     */
-   @Named("ec2:RegisterImage")
+   @Named("RegisterImage")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "RegisterImage")
@@ -117,7 +117,7 @@ public interface AMIAsyncClient {
    /**
     * @see AMIClient#registerUnixImageBackedByEbsInRegion
     */
-   @Named("ec2:RegisterImage")
+   @Named("RegisterImage")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "RootDeviceName", "BlockDeviceMapping.0.DeviceName" }, values = { "RegisterImage",
@@ -132,7 +132,7 @@ public interface AMIAsyncClient {
    /**
     * @see AMIClient#resetLaunchPermissionsOnImageInRegion
     */
-   @Named("ec2:ResetImageAttribute")
+   @Named("ResetImageAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "ResetImageAttribute", "launchPermission" })
@@ -143,7 +143,7 @@ public interface AMIAsyncClient {
    /**
     * @see AMIClient#addLaunchPermissionsToImageInRegion
     */
-   @Named("ec2:ModifyImageAttribute")
+   @Named("ModifyImageAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "OperationType", "Attribute" }, values = { "ModifyImageAttribute", "add",
@@ -157,7 +157,7 @@ public interface AMIAsyncClient {
    /**
     * @see AMIClient#removeLaunchPermissionsToImageInRegion
     */
-   @Named("ec2:ModifyImageAttribute")
+   @Named("ModifyImageAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "OperationType", "Attribute" }, values = { "ModifyImageAttribute", "remove",
@@ -171,7 +171,7 @@ public interface AMIAsyncClient {
    /**
     * @see AMIClient#getLaunchPermissionForImageInRegion
     */
-   @Named("ec2:DescribeImageAttribute")
+   @Named("DescribeImageAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeImageAttribute", "launchPermission" })
@@ -183,7 +183,7 @@ public interface AMIAsyncClient {
    /**
     * @see AMIClient#getBlockDeviceMappingsForImageInRegion
     */
-   @Named("ec2:DescribeImageAttribute")
+   @Named("DescribeImageAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeImageAttribute", "blockDeviceMapping" })

--- a/apis/ec2/src/main/java/org/jclouds/ec2/services/AvailabilityZoneAndRegionAsyncClient.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/services/AvailabilityZoneAndRegionAsyncClient.java
@@ -59,7 +59,7 @@ public interface AvailabilityZoneAndRegionAsyncClient {
    /**
     * @see AvailabilityZoneAndRegionClient#describeAvailabilityZonesInRegion
     */
-   @Named("ec2:DescribeAvailabilityZones")
+   @Named("DescribeAvailabilityZones")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeAvailabilityZones")
@@ -72,7 +72,7 @@ public interface AvailabilityZoneAndRegionAsyncClient {
    /**
     * @see AvailabilityZoneAndRegionClient#describeRegions
     */
-   @Named("ec2:DescribeRegions")
+   @Named("DescribeRegions")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeRegions")

--- a/apis/ec2/src/main/java/org/jclouds/ec2/services/ElasticBlockStoreAsyncClient.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/services/ElasticBlockStoreAsyncClient.java
@@ -72,7 +72,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#createVolumeFromSnapshotInAvailabilityZone
     */
-   @Named("ec2:CreateVolume")   
+   @Named("CreateVolume")   
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreateVolume")
@@ -84,7 +84,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#createVolumeFromSnapshotInAvailabilityZone
     */
-   @Named("ec2:CreateVolume")   
+   @Named("CreateVolume")   
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreateVolume")
@@ -96,7 +96,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#createVolumeInAvailabilityZone
     */
-   @Named("ec2:CreateVolume")   
+   @Named("CreateVolume")   
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreateVolume")
@@ -109,7 +109,7 @@ public interface ElasticBlockStoreAsyncClient {
     * @see ElasticBlockStoreClient#describeVolumesInRegion
     */
    @POST
-   @Named("ec2:DescribeVolumes")   
+   @Named("DescribeVolumes")   
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeVolumes")
    @XMLResponseParser(DescribeVolumesResponseHandler.class)
@@ -120,7 +120,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#deleteVolumeInRegion
     */
-   @Named("ec2:DeleteVolume")   
+   @Named("DeleteVolume")   
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeleteVolume")
@@ -130,7 +130,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#detachVolumeInRegion
     */
-   @Named("ec2:DetachVolume")   
+   @Named("DetachVolume")   
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DetachVolume")
@@ -141,7 +141,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#attachVolumeInRegion
     */
-   @Named("ec2:AttachVolume")   
+   @Named("AttachVolume")   
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "AttachVolume")
@@ -154,7 +154,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#createSnapshotInRegion
     */
-   @Named("ec2:CreateSnapshot")   
+   @Named("CreateSnapshot")   
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreateSnapshot")
@@ -166,7 +166,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#describeSnapshotsInRegion
     */
-   @Named("ec2:DescribeSnapshots")   
+   @Named("DescribeSnapshots")   
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeSnapshots")
@@ -179,7 +179,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#deleteSnapshotInRegion
     */
-   @Named("ec2:DeleteSnapshot")   
+   @Named("DeleteSnapshot")   
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeleteSnapshot")
@@ -190,7 +190,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#addCreateVolumePermissionsToSnapshotInRegion
     */
-   @Named("ec2:ModifySnapshotAttribute")   
+   @Named("ModifySnapshotAttribute")   
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "OperationType", "Attribute" }, values = { "ModifySnapshotAttribute", "add",
@@ -204,7 +204,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#removeCreateVolumePermissionsFromSnapshotInRegion
     */
-   @Named("ec2:ModifySnapshotAttribute")   
+   @Named("ModifySnapshotAttribute")   
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "OperationType", "Attribute" }, values = { "ModifySnapshotAttribute", "remove",
@@ -218,7 +218,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#getCreateVolumePermissionForSnapshotInRegion
     */
-   @Named("ec2:DescribeSnapshotAttribute")   
+   @Named("DescribeSnapshotAttribute")   
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeSnapshotAttribute", "createVolumePermission" })
@@ -230,7 +230,7 @@ public interface ElasticBlockStoreAsyncClient {
    /**
     * @see ElasticBlockStoreClient#resetCreateVolumePermissionsOnSnapshotInRegion
     */
-   @Named("ec2:ResetSnapshotAttribute")   
+   @Named("ResetSnapshotAttribute")   
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "ResetSnapshotAttribute", "createVolumePermission" })

--- a/apis/ec2/src/main/java/org/jclouds/ec2/services/ElasticIPAddressAsyncClient.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/services/ElasticIPAddressAsyncClient.java
@@ -58,7 +58,7 @@ public interface ElasticIPAddressAsyncClient {
    /**
     * @see BaseEC2Client#allocateAddressInRegion
     */
-   @Named("ec2:AllocateAddress")
+   @Named("AllocateAddress")
    @POST
    @Path("/")
    @XMLResponseParser(AllocateAddressResponseHandler.class)
@@ -69,7 +69,7 @@ public interface ElasticIPAddressAsyncClient {
    /**
     * @see BaseEC2Client#associateAddressInRegion
     */
-   @Named("ec2:AssociateAddress")
+   @Named("AssociateAddress")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "AssociateAddress")
@@ -80,7 +80,7 @@ public interface ElasticIPAddressAsyncClient {
    /**
     * @see BaseEC2Client#disassociateAddressInRegion
     */
-   @Named("ec2:DisassociateAddress")
+   @Named("DisassociateAddress")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DisassociateAddress")
@@ -91,7 +91,7 @@ public interface ElasticIPAddressAsyncClient {
    /**
     * @see BaseEC2Client#releaseAddressInRegion
     */
-   @Named("ec2:ReleaseAddress")
+   @Named("ReleaseAddress")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ReleaseAddress")
@@ -102,7 +102,7 @@ public interface ElasticIPAddressAsyncClient {
    /**
     * @see BaseEC2Client#describeAddressesInRegion
     */
-   @Named("ec2:DescribeAddresses")
+   @Named("DescribeAddresses")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeAddresses")

--- a/apis/ec2/src/main/java/org/jclouds/ec2/services/InstanceAsyncClient.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/services/InstanceAsyncClient.java
@@ -76,7 +76,7 @@ public interface InstanceAsyncClient {
    /**
     * @see InstanceClient#describeInstancesInRegion
     */
-   @Named("ec2:DescribeInstances")
+   @Named("DescribeInstances")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeInstances")
@@ -89,7 +89,7 @@ public interface InstanceAsyncClient {
    /**
     * @see InstanceClient#runInstancesInRegion
     */
-   @Named("ec2:RunInstances")
+   @Named("RunInstances")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "RunInstances")
@@ -103,7 +103,7 @@ public interface InstanceAsyncClient {
    /**
     * @see InstanceClient#rebootInstancesInRegion
     */
-   @Named("ec2:RebootInstances")
+   @Named("RebootInstances")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "RebootInstances")
@@ -114,7 +114,7 @@ public interface InstanceAsyncClient {
    /**
     * @see InstanceClient#terminateInstancesInRegion
     */
-   @Named("ec2:TerminateInstances")
+   @Named("TerminateInstances")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "TerminateInstances")
@@ -127,7 +127,7 @@ public interface InstanceAsyncClient {
    /**
     * @see InstanceClient#stopInstancesInRegion
     */
-   @Named("ec2:StopInstances")
+   @Named("StopInstances")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "StopInstances")
@@ -140,7 +140,7 @@ public interface InstanceAsyncClient {
    /**
     * @see InstanceClient#startInstancesInRegion
     */
-   @Named("ec2:StartInstances")
+   @Named("StartInstances")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "StartInstances")
@@ -152,7 +152,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#getUserDataForInstanceInRegion
     */
-   @Named("ec2:DescribeInstanceAttribute")
+   @Named("DescribeInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeInstanceAttribute", "userData" })
@@ -164,7 +164,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#getRootDeviceNameForInstanceInRegion
     */
-   @Named("ec2:DescribeInstanceAttribute")
+   @Named("DescribeInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeInstanceAttribute", "rootDeviceName" })
@@ -176,7 +176,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#getRamdiskForInstanceInRegion
     */
-   @Named("ec2:DescribeInstanceAttribute")
+   @Named("DescribeInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeInstanceAttribute", "ramdisk" })
@@ -188,7 +188,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#getKernelForInstanceInRegion
     */
-   @Named("ec2:DescribeInstanceAttribute")
+   @Named("DescribeInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeInstanceAttribute", "kernel" })
@@ -200,7 +200,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#isApiTerminationDisabledForInstanceInRegion
     */
-   @Named("ec2:DescribeInstanceAttribute")
+   @Named("DescribeInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeInstanceAttribute", "disableApiTermination" })
@@ -212,7 +212,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#getInstanceTypeForInstanceInRegion
     */
-   @Named("ec2:DescribeInstanceAttribute")
+   @Named("DescribeInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeInstanceAttribute", "instanceType" })
@@ -224,7 +224,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#getInstanceInitiatedShutdownBehaviorForInstanceInRegion
     */
-   @Named("ec2:DescribeInstanceAttribute")
+   @Named("DescribeInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeInstanceAttribute",
@@ -237,7 +237,7 @@ public interface InstanceAsyncClient {
    /**
     * @see InstanceClient#getBlockDeviceMappingForInstanceInRegion
     */
-   @Named("ec2:DescribeInstanceAttribute")
+   @Named("DescribeInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeInstanceAttribute", "blockDeviceMapping" })
@@ -249,7 +249,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#resetRamdiskForInstanceInRegion
     */
-   @Named("ec2:ResetInstanceAttribute")
+   @Named("ResetInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "ResetInstanceAttribute", "ramdisk" })
@@ -260,7 +260,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#resetKernelForInstanceInRegion
     */
-   @Named("ec2:ResetInstanceAttribute")
+   @Named("ResetInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "ResetInstanceAttribute", "kernel" })
@@ -271,7 +271,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#setUserDataForInstanceInRegion
     */
-   @Named("ec2:ModifyInstanceAttribute")
+   @Named("ModifyInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "ModifyInstanceAttribute", "userData" })
@@ -283,7 +283,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#setRamdiskForInstanceInRegion
     */
-   @Named("ec2:ModifyInstanceAttribute")
+   @Named("ModifyInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "ModifyInstanceAttribute", "ramdisk" })
@@ -294,7 +294,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#setKernelForInstanceInRegion
     */
-   @Named("ec2:ModifyInstanceAttribute")
+   @Named("ModifyInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "ModifyInstanceAttribute", "kernel" })
@@ -305,7 +305,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#setApiTerminationDisabledForInstanceInRegion
     */
-   @Named("ec2:ModifyInstanceAttribute")
+   @Named("ModifyInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "ModifyInstanceAttribute", "disableApiTermination" })
@@ -316,7 +316,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#setInstanceTypeForInstanceInRegion
     */
-   @Named("ec2:ModifyInstanceAttribute")
+   @Named("ModifyInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "ModifyInstanceAttribute", "instanceType" })
@@ -327,7 +327,7 @@ public interface InstanceAsyncClient {
    /**
     * @see AMIClient#setInstanceInitiatedShutdownBehaviorForInstanceInRegion
     */
-   @Named("ec2:ModifyInstanceAttribute")
+   @Named("ModifyInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "ModifyInstanceAttribute",
@@ -340,7 +340,7 @@ public interface InstanceAsyncClient {
    /**
     * @see InstanceClient#setBlockDeviceMappingForInstanceInRegion
     */
-   @Named("ec2:ModifyInstanceAttribute")
+   @Named("ModifyInstanceAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION }, values = { "ModifyInstanceAttribute" })
@@ -352,7 +352,7 @@ public interface InstanceAsyncClient {
    /**
     * @see InstanceClient#getConsoleOutputForInstanceInRegion(String, String)
     */
-   @Named("ec2:GetConsoleOutput")
+   @Named("GetConsoleOutput")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION }, values = { "GetConsoleOutput" })

--- a/apis/ec2/src/main/java/org/jclouds/ec2/services/KeyPairAsyncClient.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/services/KeyPairAsyncClient.java
@@ -58,7 +58,7 @@ public interface KeyPairAsyncClient {
    /**
     * @see KeyPairClient#createKeyPairInRegion
     */
-   @Named("ec2:CreateKeyPair")
+   @Named("CreateKeyPair")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreateKeyPair")
@@ -70,7 +70,7 @@ public interface KeyPairAsyncClient {
    /**
     * @see KeyPairClient#describeKeyPairsInRegion
     */
-   @Named("ec2:DescribeKeyPairs")
+   @Named("DescribeKeyPairs")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeKeyPairs")
@@ -83,7 +83,7 @@ public interface KeyPairAsyncClient {
    /**
     * @see KeyPairClient#deleteKeyPairInRegion
     */
-   @Named("ec2:DeleteKeyPair")
+   @Named("DeleteKeyPair")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeleteKeyPair")

--- a/apis/ec2/src/main/java/org/jclouds/ec2/services/SecurityGroupAsyncClient.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/services/SecurityGroupAsyncClient.java
@@ -61,7 +61,7 @@ public interface SecurityGroupAsyncClient {
    /**
     * @see SecurityGroupClient#createSecurityGroupInRegion
     */
-   @Named("ec2:CreateSecurityGroup")
+   @Named("CreateSecurityGroup")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreateSecurityGroup")
@@ -72,7 +72,7 @@ public interface SecurityGroupAsyncClient {
    /**
     * @see SecurityGroupClient#deleteSecurityGroupInRegion
     */
-   @Named("ec2:DeleteSecurityGroup")
+   @Named("DeleteSecurityGroup")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeleteSecurityGroup")
@@ -83,7 +83,7 @@ public interface SecurityGroupAsyncClient {
    /**
     * @see SecurityGroupClient#describeSecurityGroupsInRegion
     */
-   @Named("ec2:DescribeSecurityGroups")
+   @Named("DescribeSecurityGroups")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeSecurityGroups")
@@ -97,7 +97,7 @@ public interface SecurityGroupAsyncClient {
     * @see SecurityGroupClient#authorizeSecurityGroupIngressInRegion(@ org.jclouds.javax.annotation.Nullable Region,
     *      String,UserIdGroupPair)
     */
-   @Named("ec2:AuthorizeSecurityGroupIngress")
+   @Named("AuthorizeSecurityGroupIngress")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "AuthorizeSecurityGroupIngress")
@@ -110,7 +110,7 @@ public interface SecurityGroupAsyncClient {
     * @see SecurityGroupClient#authorizeSecurityGroupIngressInRegion(@ org.jclouds.javax.annotation.Nullable Region,
     *      String,IpProtocol,int,int,String)
     */
-   @Named("ec2:AuthorizeSecurityGroupIngress")
+   @Named("AuthorizeSecurityGroupIngress")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "AuthorizeSecurityGroupIngress")
@@ -123,7 +123,7 @@ public interface SecurityGroupAsyncClient {
     * @see SecurityGroupClient#revokeSecurityGroupIngressInRegion(@Nullable Region,
     *      String,UserIdGroupPair)
     */
-   @Named("ec2:RevokeSecurityGroupIngress")
+   @Named("RevokeSecurityGroupIngress")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "RevokeSecurityGroupIngress")
@@ -136,7 +136,7 @@ public interface SecurityGroupAsyncClient {
     * @see SecurityGroupClient#revokeSecurityGroupIngressInRegion(@ org.jclouds.javax.annotation.Nullable Region,
     *      String,IpProtocol,int,int,String)
     */
-   @Named("ec2:RevokeSecurityGroupIngress")
+   @Named("RevokeSecurityGroupIngress")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "RevokeSecurityGroupIngress")

--- a/apis/ec2/src/main/java/org/jclouds/ec2/services/WindowsAsyncClient.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/services/WindowsAsyncClient.java
@@ -62,7 +62,7 @@ public interface WindowsAsyncClient {
    /**
     * @see WindowsClient#bundleInstanceInRegion
     */
-   @Named("ec2:BundleInstance")
+   @Named("BundleInstance")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "BundleInstance")
@@ -77,7 +77,7 @@ public interface WindowsAsyncClient {
    /**
     * @see WindowsClient#cancelBundleTaskInRegion
     */
-   @Named("ec2:CancelBundleTask")
+   @Named("CancelBundleTask")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CancelBundleTask")
@@ -89,7 +89,7 @@ public interface WindowsAsyncClient {
    /**
     * @see BundleTaskClient#describeBundleTasksInRegion
     */
-   @Named("ec2:DescribeBundleTasks")
+   @Named("DescribeBundleTasks")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeBundleTasks")
@@ -102,7 +102,7 @@ public interface WindowsAsyncClient {
    /**
     * @see WindowsClient#getPasswordDataInRegion
     */
-   @Named("ec2:GetPasswordData")
+   @Named("GetPasswordData")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "GetPasswordData")

--- a/apis/s3/src/main/java/org/jclouds/s3/S3AsyncClient.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/S3AsyncClient.java
@@ -119,7 +119,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#getObject
     */
-   @Named("s3:GetObject")
+   @Named("GetObject")
    @GET
    @Path("/{key}")
    @Fallback(NullOnKeyNotFound.class)
@@ -131,7 +131,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#headObject
     */
-   @Named("s3:GetObject")
+   @Named("GetObject")
    @HEAD
    @Path("/{key}")
    @Fallback(NullOnKeyNotFound.class)
@@ -143,7 +143,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#objectExists
     */
-   @Named("s3:GetObject")
+   @Named("GetObject")
    @HEAD
    @Path("/{key}")
    @Fallback(FalseOnKeyNotFound.class)
@@ -154,7 +154,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#deleteObject
     */
-   @Named("s3:DeleteObject")
+   @Named("DeleteObject")
    @DELETE
    @Path("/{key}")
    @Fallback(VoidOnNotFoundOr404.class)
@@ -165,7 +165,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#putObject
     */
-   @Named("s3:PutObject")
+   @Named("PutObject")
    @PUT
    @Path("/{key}")
    @ResponseParser(ParseETagHeader.class)
@@ -177,7 +177,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#putBucketInRegion
     */
-   @Named("s3:CreateBucket")
+   @Named("CreateBucket")
    @PUT
    @Path("/")
    @Endpoint(Bucket.class)
@@ -190,7 +190,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#deleteBucketIfEmpty
     */
-   @Named("s3:DeleteBucket")
+   @Named("DeleteBucket")
    @DELETE
    @Path("/")
    @Fallback(TrueOn404OrNotFoundFalseOnIllegalState.class)
@@ -200,7 +200,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#bucketExists
     */
-   @Named("s3:ListBucket")
+   @Named("ListBucket")
    @GET
    @Path("/")
    @QueryParams(keys = "max-keys", values = "0")
@@ -212,7 +212,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#getBucketLocation
     */
-   @Named("s3:GetBucketLocation")
+   @Named("GetBucketLocation")
    @GET
    @QueryParams(keys = "location")
    @Path("/")
@@ -224,7 +224,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#getBucketPayer
     */
-   @Named("s3:GetBucketRequestPayment")
+   @Named("GetBucketRequestPayment")
    @GET
    @QueryParams(keys = "requestPayment")
    @Path("/")
@@ -235,7 +235,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#setBucketPayer
     */
-   @Named("s3:PutBucketRequestPayment")
+   @Named("PutBucketRequestPayment")
    @PUT
    @QueryParams(keys = "requestPayment")
    @Path("/")
@@ -246,7 +246,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#listBucket
     */
-   @Named("s3:ListBucket")
+   @Named("ListBucket")
    @GET
    @Path("/")
    @XMLResponseParser(ListBucketHandler.class)
@@ -257,7 +257,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#listOwnedBuckets
     */
-   @Named("s3:ListAllMyBuckets")
+   @Named("ListAllMyBuckets")
    @GET
    @XMLResponseParser(ListAllMyBucketsHandler.class)
    @Path("/")
@@ -267,7 +267,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#copyObject
     */
-   @Named("s3:PutObject")
+   @Named("PutObject")
    @PUT
    @Path("/{destinationObject}")
    @Headers(keys = "x-amz-copy-source", values = "/{sourceBucket}/{sourceObject}")
@@ -281,7 +281,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#getBucketACL
     */
-   @Named("s3:GetBucketAcl")
+   @Named("GetBucketAcl")
    @GET
    @QueryParams(keys = "acl")
    @XMLResponseParser(AccessControlListHandler.class)
@@ -293,7 +293,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#putBucketACL
     */
-   @Named("s3:PutBucketAcl")
+   @Named("PutBucketAcl")
    @PUT
    @Path("/")
    @QueryParams(keys = "acl")
@@ -304,7 +304,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#getObjectACL
     */
-   @Named("s3:GetObjectAcl")
+   @Named("GetObjectAcl")
    @GET
    @QueryParams(keys = "acl")
    @Path("/{key}")
@@ -317,7 +317,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#putObjectACL
     */
-   @Named("s3:PutObjectAcl")
+   @Named("PutObjectAcl")
    @PUT
    @QueryParams(keys = "acl")
    @Path("/{key}")
@@ -328,7 +328,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#getBucketLogging
     */
-   @Named("s3:GetBucketLogging")
+   @Named("GetBucketLogging")
    @GET
    @QueryParams(keys = "logging")
    @XMLResponseParser(BucketLoggingHandler.class)
@@ -340,7 +340,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#enableBucketLogging
     */
-   @Named("s3:PutBucketLogging")
+   @Named("PutBucketLogging")
    @PUT
    @Path("/")
    @QueryParams(keys = "logging")
@@ -351,7 +351,7 @@ public interface S3AsyncClient {
    /**
     * @see S3Client#putBucketLogging
     */
-   @Named("s3:PutBucketLogging")
+   @Named("PutBucketLogging")
    @PUT
    @Path("/")
    @QueryParams(keys = "logging")

--- a/apis/sqs/src/main/java/org/jclouds/sqs/features/MessageAsyncApi.java
+++ b/apis/sqs/src/main/java/org/jclouds/sqs/features/MessageAsyncApi.java
@@ -74,7 +74,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#delete(String)
     */
-   @Named("sqs:DeleteMessage")
+   @Named("DeleteMessage")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeleteMessage")
@@ -84,7 +84,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#delete(Map)
     */
-   @Named("sqs:DeleteMessageBatch")
+   @Named("DeleteMessageBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeleteMessageBatch")
@@ -95,7 +95,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#delete(Iterable)
     */
-   @Named("sqs:DeleteMessageBatch")
+   @Named("DeleteMessageBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeleteMessageBatch")
@@ -106,7 +106,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#changeVisibility(String, int)
     */
-   @Named("sqs:ChangeMessageVisibility")
+   @Named("ChangeMessageVisibility")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ChangeMessageVisibility")
@@ -116,7 +116,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#changeVisibility(Table)
     */
-   @Named("sqs:ChangeMessageVisibilityBatch")
+   @Named("ChangeMessageVisibilityBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ChangeMessageVisibilityBatch")
@@ -127,7 +127,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#changeVisibility(Map)
     */
-   @Named("sqs:ChangeMessageVisibilityBatch")
+   @Named("ChangeMessageVisibilityBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ChangeMessageVisibilityBatch")
@@ -138,7 +138,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#changeVisibility(Map, int)
     */
-   @Named("sqs:ChangeMessageVisibilityBatch")
+   @Named("ChangeMessageVisibilityBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ChangeMessageVisibilityBatch")
@@ -151,7 +151,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#changeVisibility(Iterable, int)
     */
-   @Named("sqs:ChangeMessageVisibilityBatch")
+   @Named("ChangeMessageVisibilityBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ChangeMessageVisibilityBatch")
@@ -164,7 +164,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#send(String)
     */
-   @Named("sqs:SendMessage")
+   @Named("SendMessage")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "SendMessage")
@@ -174,7 +174,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#send(String, SendMessageOptions)
     */
-   @Named("sqs:SendMessage")
+   @Named("SendMessage")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "SendMessage")
@@ -184,7 +184,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#sendWithDelays(Table)
     */
-   @Named("sqs:SendMessageBatch")
+   @Named("SendMessageBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "SendMessageBatch")
@@ -196,7 +196,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#sendWithDelays(Map)
     */
-   @Named("sqs:SendMessageBatch")
+   @Named("SendMessageBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "SendMessageBatch")
@@ -208,7 +208,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#sendWithDelay(Map, int)
     */
-   @Named("sqs:SendMessageBatch")
+   @Named("SendMessageBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "SendMessageBatch")
@@ -221,7 +221,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#sendWithDelay(Iterable, int)
     */
-   @Named("sqs:SendMessageBatch")
+   @Named("SendMessageBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "SendMessageBatch")
@@ -233,7 +233,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#send(Map)
     */
-   @Named("sqs:SendMessageBatch")
+   @Named("SendMessageBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "SendMessageBatch")
@@ -244,7 +244,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#send(Iterable)
     */
-   @Named("sqs:SendMessageBatch")
+   @Named("SendMessageBatch")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "SendMessageBatch")
@@ -255,7 +255,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#receive()
     */
-   @Named("sqs:ReceiveMessage")
+   @Named("ReceiveMessage")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ReceiveMessage")
@@ -265,7 +265,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#receive(ReceiveMessageOptions)
     */
-   @Named("sqs:ReceiveMessage")
+   @Named("ReceiveMessage")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ReceiveMessage")
@@ -275,7 +275,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#receive(int)
     */
-   @Named("sqs:ReceiveMessage")
+   @Named("ReceiveMessage")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ReceiveMessage")
@@ -285,7 +285,7 @@ public interface MessageAsyncApi {
    /**
     * @see MessageApi#receive(int, ReceiveMessageOptions)
     */
-   @Named("sqs:ReceiveMessage")
+   @Named("ReceiveMessage")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ReceiveMessage")

--- a/apis/sqs/src/main/java/org/jclouds/sqs/features/PermissionAsyncApi.java
+++ b/apis/sqs/src/main/java/org/jclouds/sqs/features/PermissionAsyncApi.java
@@ -49,7 +49,7 @@ public interface PermissionAsyncApi {
    /**
     * @see PermissionApi#addPermissionToAccount
     */
-   @Named("sqs:AddPermission")
+   @Named("AddPermission")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "AddPermission")
@@ -59,7 +59,7 @@ public interface PermissionAsyncApi {
    /**
     * @see PermissionApi#remove
     */
-   @Named("sqs:RemovePermission")
+   @Named("RemovePermission")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "RemovePermission")

--- a/apis/sqs/src/main/java/org/jclouds/sqs/features/QueueAsyncApi.java
+++ b/apis/sqs/src/main/java/org/jclouds/sqs/features/QueueAsyncApi.java
@@ -69,7 +69,7 @@ public interface QueueAsyncApi {
    /**
     * @see QueueApi#list
     */
-   @Named("sqs:ListQueues")
+   @Named("ListQueues")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ListQueues")
@@ -79,7 +79,7 @@ public interface QueueAsyncApi {
    /**
     * @see QueueApi#list(ListQueuesOptions)
     */
-   @Named("sqs:ListQueues")
+   @Named("ListQueues")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ListQueues")
@@ -89,7 +89,7 @@ public interface QueueAsyncApi {
    /**
     * @see QueueApi#get(String)
     */
-   @Named("sqs:GetQueueUrl")
+   @Named("GetQueueUrl")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "GetQueueUrl")
@@ -100,7 +100,7 @@ public interface QueueAsyncApi {
    /**
     * @see QueueApi#getInAccount
     */
-   @Named("sqs:GetQueueUrl")
+   @Named("GetQueueUrl")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "GetQueueUrl")
@@ -112,7 +112,7 @@ public interface QueueAsyncApi {
    /**
     * @see QueueApi#create
     */
-   @Named("sqs:CreateQueue")
+   @Named("CreateQueue")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreateQueue")
@@ -122,7 +122,7 @@ public interface QueueAsyncApi {
    /**
     * @see QueueApi#create
     */
-   @Named("sqs:CreateQueue")
+   @Named("CreateQueue")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreateQueue")
@@ -132,7 +132,7 @@ public interface QueueAsyncApi {
    /**
     * @see QueueApi#delete
     */
-   @Named("sqs:DeleteQueue")
+   @Named("DeleteQueue")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeleteQueue")
@@ -142,7 +142,7 @@ public interface QueueAsyncApi {
    /**
     * @see QueueApi#getAttributes(URI)
     */
-   @Named("sqs:GetQueueAttributes")
+   @Named("GetQueueAttributes")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "AttributeName.1" }, values = { "GetQueueAttributes", "All" })
@@ -154,7 +154,7 @@ public interface QueueAsyncApi {
    /**
     * @see QueueApi#getAttributes(URI, Iterable)
     */
-   @Named("sqs:GetQueueAttributes")
+   @Named("GetQueueAttributes")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "GetQueueAttributes")
@@ -165,7 +165,7 @@ public interface QueueAsyncApi {
    /**
     * @see QueueApi#getAttribute
     */
-   @Named("sqs:GetQueueAttributes")
+   @Named("GetQueueAttributes")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "GetQueueAttributes")
@@ -175,7 +175,7 @@ public interface QueueAsyncApi {
    /**
     * @see QueueApi#setAttribute
     */
-   @Named("sqs:SetQueueAttributes")
+   @Named("SetQueueAttributes")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "SetQueueAttributes")

--- a/labs/elb/src/main/java/org/jclouds/elb/features/AvailabilityZoneAsyncApi.java
+++ b/labs/elb/src/main/java/org/jclouds/elb/features/AvailabilityZoneAsyncApi.java
@@ -54,7 +54,7 @@ public interface AvailabilityZoneAsyncApi {
    /**
     * @see AvailabilityZoneApi#addAvailabilityZonesToLoadBalancer
     */
-   @Named("elasticloadbalancing:EnableAvailabilityZonesForLoadBalancer")
+   @Named("EnableAvailabilityZonesForLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(AvailabilityZonesResultHandler.class)
@@ -67,7 +67,7 @@ public interface AvailabilityZoneAsyncApi {
    /**
     * @see AvailabilityZoneApi#addAvailabilityZoneToLoadBalancer
     */
-   @Named("elasticloadbalancing:EnableAvailabilityZonesForLoadBalancer")
+   @Named("EnableAvailabilityZonesForLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(AvailabilityZonesResultHandler.class)
@@ -79,7 +79,7 @@ public interface AvailabilityZoneAsyncApi {
    /**
     * @see AvailabilityZoneApi#removeAvailabilityZonesFromLoadBalancer
     */
-   @Named("elasticloadbalancing:DisableAvailabilityZonesForLoadBalancer")
+   @Named("DisableAvailabilityZonesForLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(AvailabilityZonesResultHandler.class)
@@ -91,7 +91,7 @@ public interface AvailabilityZoneAsyncApi {
    /**
     * @see AvailabilityZoneApi#removeAvailabilityZoneFromLoadBalancer
     */
-   @Named("elasticloadbalancing:DisableAvailabilityZonesForLoadBalancer")
+   @Named("DisableAvailabilityZonesForLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(AvailabilityZonesResultHandler.class)

--- a/labs/elb/src/main/java/org/jclouds/elb/features/InstanceAsyncApi.java
+++ b/labs/elb/src/main/java/org/jclouds/elb/features/InstanceAsyncApi.java
@@ -58,7 +58,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#getHealthOfInstancesOfLoadBalancer(String)
     */
-   @Named("elasticloadbalancing:DescribeInstanceHealth")
+   @Named("DescribeInstanceHealth")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeInstanceHealthResultHandler.class)
@@ -70,7 +70,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#getHealthOfInstancesOfLoadBalancer(Iterable, String)
     */
-   @Named("elasticloadbalancing:DescribeInstanceHealth")
+   @Named("DescribeInstanceHealth")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeInstanceHealthResultHandler.class)
@@ -84,7 +84,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#registerInstancesWithLoadBalancer
     */
-   @Named("elasticloadbalancing:RegisterInstancesWithLoadBalancer")
+   @Named("RegisterInstancesWithLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(InstancesResultHandler.class)
@@ -97,7 +97,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#registerInstanceWithLoadBalancer
     */
-   @Named("elasticloadbalancing:RegisterInstancesWithLoadBalancer")
+   @Named("RegisterInstancesWithLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(InstancesResultHandler.class)
@@ -109,7 +109,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#deregisterInstancesFromLoadBalancer
     */
-   @Named("elasticloadbalancing:DeregisterInstancesFromLoadBalancer")
+   @Named("DeregisterInstancesFromLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(InstancesResultHandler.class)
@@ -121,7 +121,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#deregisterInstanceFromLoadBalancer
     */
-   @Named("elasticloadbalancing:DeregisterInstancesFromLoadBalancer")
+   @Named("DeregisterInstancesFromLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(InstancesResultHandler.class)

--- a/labs/elb/src/main/java/org/jclouds/elb/features/LoadBalancerAsyncApi.java
+++ b/labs/elb/src/main/java/org/jclouds/elb/features/LoadBalancerAsyncApi.java
@@ -68,7 +68,7 @@ public interface LoadBalancerAsyncApi {
    /**
     * @see LoadBalancerApi#createListeningInAvailabilityZones()
     */
-   @Named("elasticloadbalancing:CreateLoadBalancer")
+   @Named("CreateLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(CreateLoadBalancerResponseHandler.class)
@@ -80,7 +80,7 @@ public interface LoadBalancerAsyncApi {
    /**
     * @see LoadBalancerApi#createListeningInAvailabilityZones()
     */
-   @Named("elasticloadbalancing:CreateLoadBalancer")
+   @Named("CreateLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(CreateLoadBalancerResponseHandler.class)
@@ -92,7 +92,7 @@ public interface LoadBalancerAsyncApi {
    /**
     * @see LoadBalancerApi#createListeningInSubnetAssignedToSecurityGroups()
     */
-   @Named("elasticloadbalancing:CreateLoadBalancer")
+   @Named("CreateLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(CreateLoadBalancerResponseHandler.class)
@@ -105,7 +105,7 @@ public interface LoadBalancerAsyncApi {
    /**
     * @see LoadBalancerApi#createListeningInSubnetsAssignedToSecurityGroups()
     */
-   @Named("elasticloadbalancing:CreateLoadBalancer")
+   @Named("CreateLoadBalancer")
    @POST
    @Path("/")
    @XMLResponseParser(CreateLoadBalancerResponseHandler.class)
@@ -118,7 +118,7 @@ public interface LoadBalancerAsyncApi {
    /**
     * @see LoadBalancerApi#get()
     */
-   @Named("elasticloadbalancing:DescribeLoadBalancers")
+   @Named("DescribeLoadBalancers")
    @POST
    @Path("/")
    @XMLResponseParser(LoadBalancerHandler.class)
@@ -129,7 +129,7 @@ public interface LoadBalancerAsyncApi {
    /**
     * @see LoadBalancerApi#list()
     */
-   @Named("elasticloadbalancing:DescribeLoadBalancers")
+   @Named("DescribeLoadBalancers")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeLoadBalancersResultHandler.class)
@@ -141,7 +141,7 @@ public interface LoadBalancerAsyncApi {
    /**
     * @see LoadBalancerApi#list(ListLoadBalancersOptions)
     */
-   @Named("elasticloadbalancing:DescribeLoadBalancers")
+   @Named("DescribeLoadBalancers")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeLoadBalancersResultHandler.class)
@@ -152,7 +152,7 @@ public interface LoadBalancerAsyncApi {
    /**
     * @see LoadBalancerApi#delete()
     */
-   @Named("elasticloadbalancing:DeleteLoadBalancer")
+   @Named("DeleteLoadBalancer")
    @POST
    @Path("/")
    @Fallback(VoidOnNotFoundOr404.class)

--- a/labs/elb/src/main/java/org/jclouds/elb/features/PolicyAsyncApi.java
+++ b/labs/elb/src/main/java/org/jclouds/elb/features/PolicyAsyncApi.java
@@ -60,7 +60,7 @@ public interface PolicyAsyncApi {
    /**
     * @see PolicyApi#get()
     */
-   @Named("elasticloadbalancing:DescribeLoadBalancerPolicies")
+   @Named("DescribeLoadBalancerPolicies")
    @POST
    @Path("/")
    @XMLResponseParser(PolicyHandler.class)
@@ -71,7 +71,7 @@ public interface PolicyAsyncApi {
    /**
     * @see PolicyApi#list()
     */
-   @Named("elasticloadbalancing:DescribeLoadBalancerPolicies")
+   @Named("DescribeLoadBalancerPolicies")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeLoadBalancerPoliciesResultHandler.class)
@@ -82,7 +82,7 @@ public interface PolicyAsyncApi {
    /**
     * @see PolicyApi#list(ListPoliciesOptions)
     */
-   @Named("elasticloadbalancing:DescribeLoadBalancerPolicies")
+   @Named("DescribeLoadBalancerPolicies")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeLoadBalancerPoliciesResultHandler.class)
@@ -94,7 +94,7 @@ public interface PolicyAsyncApi {
    /**
     * @see PolicyApi#getType()
     */
-   @Named("elasticloadbalancing:DescribeLoadBalancerPolicyTypes")
+   @Named("DescribeLoadBalancerPolicyTypes")
    @POST
    @Path("/")
    @XMLResponseParser(PolicyTypeHandler.class)
@@ -105,7 +105,7 @@ public interface PolicyAsyncApi {
    /**
     * @see PolicyApi#listTypes()
     */
-   @Named("elasticloadbalancing:DescribeLoadBalancerPolicyTypes")
+   @Named("DescribeLoadBalancerPolicyTypes")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeLoadBalancerPolicyTypesResultHandler.class)
@@ -116,7 +116,7 @@ public interface PolicyAsyncApi {
    /**
     * @see PolicyApi#listTypes(Iterable<String>)
     */
-   @Named("elasticloadbalancing:DescribeLoadBalancerPolicyTypes")
+   @Named("DescribeLoadBalancerPolicyTypes")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeLoadBalancerPolicyTypesResultHandler.class)

--- a/labs/iam/src/main/java/org/jclouds/iam/IAMAsyncApi.java
+++ b/labs/iam/src/main/java/org/jclouds/iam/IAMAsyncApi.java
@@ -50,7 +50,7 @@ public interface IAMAsyncApi {
    /**
     * @see IAMApi#getCurrentUser()
     */
-   @Named("iam:GetUser")
+   @Named("GetUser")
    @POST
    @Path("/")
    @XMLResponseParser(UserHandler.class)

--- a/labs/iam/src/main/java/org/jclouds/iam/features/UserAsyncApi.java
+++ b/labs/iam/src/main/java/org/jclouds/iam/features/UserAsyncApi.java
@@ -55,7 +55,7 @@ public interface UserAsyncApi {
    /**
     * @see UserApi#getCurrent()
     */
-   @Named("iam:GetUser")
+   @Named("GetUser")
    @POST
    @Path("/")
    @XMLResponseParser(UserHandler.class)
@@ -65,7 +65,7 @@ public interface UserAsyncApi {
    /**
     * @see UserApi#get()
     */
-   @Named("iam:GetUser")
+   @Named("GetUser")
    @POST
    @Path("/")
    @XMLResponseParser(UserHandler.class)
@@ -76,7 +76,7 @@ public interface UserAsyncApi {
    /**
     * @see UserApi#list()
     */
-   @Named("iam:ListUsers")
+   @Named("ListUsers")
    @POST
    @Path("/")
    @XMLResponseParser(ListUsersResultHandler.class)
@@ -87,7 +87,7 @@ public interface UserAsyncApi {
    /**
     * @see UserApi#list(ListUsersOptions)
     */
-   @Named("iam:ListUsers")
+   @Named("ListUsers")
    @POST
    @Path("/")
    @XMLResponseParser(ListUsersResultHandler.class)

--- a/labs/rds/src/main/java/org/jclouds/rds/features/InstanceAsyncApi.java
+++ b/labs/rds/src/main/java/org/jclouds/rds/features/InstanceAsyncApi.java
@@ -61,7 +61,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#create
     */
-   @Named("rds:CreateDBInstance")
+   @Named("CreateDBInstance")
    @POST
    @Path("/")
    @XMLResponseParser(InstanceHandler.class)
@@ -72,7 +72,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#createInAvailabilityZone
     */
-   @Named("rds:CreateDBInstance")
+   @Named("CreateDBInstance")
    @POST
    @Path("/")
    @XMLResponseParser(InstanceHandler.class)
@@ -84,7 +84,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#createMultiAZ
     */
-   @Named("rds:CreateDBInstance")
+   @Named("CreateDBInstance")
    @POST
    @Path("/")
    @XMLResponseParser(InstanceHandler.class)
@@ -95,7 +95,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#get()
     */
-   @Named("rds:DescribeDBInstances")
+   @Named("DescribeDBInstances")
    @POST
    @Path("/")
    @XMLResponseParser(InstanceHandler.class)
@@ -106,7 +106,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#list()
     */
-   @Named("rds:DescribeDBInstances")
+   @Named("DescribeDBInstances")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeDBInstancesResultHandler.class)
@@ -117,7 +117,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#list(ListInstancesOptions)
     */
-   @Named("rds:DescribeDBInstances")
+   @Named("DescribeDBInstances")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeDBInstancesResultHandler.class)
@@ -127,7 +127,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#delete()
     */
-   @Named("rds:DeleteDBInstance")
+   @Named("DeleteDBInstance")
    @POST
    @Path("/")
    @XMLResponseParser(InstanceHandler.class)
@@ -138,7 +138,7 @@ public interface InstanceAsyncApi {
    /**
     * @see InstanceApi#deleteAndSaveSnapshot
     */
-   @Named("rds:DeleteDBInstance")
+   @Named("DeleteDBInstance")
    @POST
    @Path("/")
    @XMLResponseParser(InstanceHandler.class)

--- a/labs/rds/src/main/java/org/jclouds/rds/features/SecurityGroupAsyncApi.java
+++ b/labs/rds/src/main/java/org/jclouds/rds/features/SecurityGroupAsyncApi.java
@@ -58,7 +58,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#createWithNameAndDescription
     */
-   @Named("rds:CreateDBSecurityGroup")
+   @Named("CreateDBSecurityGroup")
    @POST
    @Path("/")
    @XMLResponseParser(SecurityGroupHandler.class)
@@ -69,7 +69,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#createInVPCWithNameAndDescription
     */
-   @Named("rds:CreateDBSecurityGroup")
+   @Named("CreateDBSecurityGroup")
    @POST
    @Path("/")
    @XMLResponseParser(SecurityGroupHandler.class)
@@ -80,7 +80,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#get()
     */
-   @Named("rds:DescribeDBSecurityGroups")
+   @Named("DescribeDBSecurityGroups")
    @POST
    @Path("/")
    @XMLResponseParser(SecurityGroupHandler.class)
@@ -91,7 +91,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#list()
     */
-   @Named("rds:DescribeDBSecurityGroups")
+   @Named("DescribeDBSecurityGroups")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeDBSecurityGroupsResultHandler.class)
@@ -102,7 +102,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#list(ListSecurityGroupsOptions)
     */
-   @Named("rds:DescribeDBSecurityGroups")
+   @Named("DescribeDBSecurityGroups")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeDBSecurityGroupsResultHandler.class)
@@ -112,7 +112,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#authorizeIngressToIPRange
     */
-   @Named("rds:AuthorizeDBSecurityGroupIngress")
+   @Named("AuthorizeDBSecurityGroupIngress")
    @POST
    @Path("/")
    @XMLResponseParser(SecurityGroupHandler.class)
@@ -123,7 +123,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#authorizeIngressToEC2SecurityGroupOfOwner
     */
-   @Named("rds:AuthorizeDBSecurityGroupIngress")
+   @Named("AuthorizeDBSecurityGroupIngress")
    @POST
    @Path("/")
    @XMLResponseParser(SecurityGroupHandler.class)
@@ -136,7 +136,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#authorizeIngressToVPCSecurityGroup
     */
-   @Named("rds:AuthorizeDBSecurityGroupIngress")
+   @Named("AuthorizeDBSecurityGroupIngress")
    @POST
    @Path("/")
    @XMLResponseParser(SecurityGroupHandler.class)
@@ -148,7 +148,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#revokeIngressFromIPRange
     */
-   @Named("rds:RevokeDBSecurityGroupIngress")
+   @Named("RevokeDBSecurityGroupIngress")
    @POST
    @Path("/")
    @XMLResponseParser(SecurityGroupHandler.class)
@@ -159,7 +159,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#revokeIngressFromEC2SecurityGroupOfOwner
     */
-   @Named("rds:RevokeDBSecurityGroupIngress")
+   @Named("RevokeDBSecurityGroupIngress")
    @POST
    @Path("/")
    @XMLResponseParser(SecurityGroupHandler.class)
@@ -172,7 +172,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#revokeIngressFromVPCSecurityGroup
     */
-   @Named("rds:RevokeDBSecurityGroupIngress")
+   @Named("RevokeDBSecurityGroupIngress")
    @POST
    @Path("/")
    @XMLResponseParser(SecurityGroupHandler.class)
@@ -183,7 +183,7 @@ public interface SecurityGroupAsyncApi {
    /**
     * @see SecurityGroupApi#delete()
     */
-   @Named("rds:DeleteDBSecurityGroup")
+   @Named("DeleteDBSecurityGroup")
    @POST
    @Path("/")
    @Fallback(VoidOnNotFoundOr404.class)

--- a/labs/rds/src/main/java/org/jclouds/rds/features/SubnetGroupAsyncApi.java
+++ b/labs/rds/src/main/java/org/jclouds/rds/features/SubnetGroupAsyncApi.java
@@ -60,7 +60,7 @@ public interface SubnetGroupAsyncApi {
    /**
     * @see SubnetGroupApi#get()
     */
-   @Named("rds:DescribeDBSubnetGroups")
+   @Named("DescribeDBSubnetGroups")
    @POST
    @Path("/")
    @XMLResponseParser(SubnetGroupHandler.class)
@@ -71,7 +71,7 @@ public interface SubnetGroupAsyncApi {
    /**
     * @see SubnetGroupApi#list()
     */
-   @Named("rds:DescribeDBSubnetGroups")
+   @Named("DescribeDBSubnetGroups")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeDBSubnetGroupsResultHandler.class)
@@ -82,7 +82,7 @@ public interface SubnetGroupAsyncApi {
    /**
     * @see SubnetGroupApi#list(ListSubnetGroupsOptions)
     */
-   @Named("rds:DescribeDBSubnetGroups")
+   @Named("DescribeDBSubnetGroups")
    @POST
    @Path("/")
    @XMLResponseParser(DescribeDBSubnetGroupsResultHandler.class)
@@ -92,7 +92,7 @@ public interface SubnetGroupAsyncApi {
    /**
     * @see SubnetGroupApi#delete()
     */
-   @Named("rds:DeleteDBSubnetGroup")
+   @Named("DeleteDBSubnetGroup")
    @POST
    @Path("/")
    @Fallback(VoidOnNotFoundOr404.class)

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/AWSAMIAsyncClient.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/AWSAMIAsyncClient.java
@@ -56,7 +56,7 @@ public interface AWSAMIAsyncClient extends AMIAsyncClient {
    /**
     * @see AMIClient#getProductCodesForImageInRegion
     */
-   @Named("ec2:DescribeImageAttribute")
+   @Named("DescribeImageAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Attribute" }, values = { "DescribeImageAttribute", "productCodes" })
@@ -68,7 +68,7 @@ public interface AWSAMIAsyncClient extends AMIAsyncClient {
    /**
     * @see AMIClient#addProductCodesToImageInRegion
     */
-   @Named("ec2:ModifyImageAttribute")
+   @Named("ModifyImageAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "OperationType", "Attribute" }, values = { "ModifyImageAttribute", "add",
@@ -81,7 +81,7 @@ public interface AWSAMIAsyncClient extends AMIAsyncClient {
    /**
     * @see AMIClient#removeProductCodesToImageInRegion
     */
-   @Named("ec2:ModifyImageAttribute")
+   @Named("ModifyImageAttribute")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "OperationType", "Attribute" }, values = { "ModifyImageAttribute", "remove",

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/AWSInstanceAsyncClient.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/AWSInstanceAsyncClient.java
@@ -62,7 +62,7 @@ public interface AWSInstanceAsyncClient extends InstanceAsyncClient {
    /**
     * @see AWSInstanceClient#describeInstancesInRegion
     */
-   @Named("ec2:DescribeInstances")
+   @Named("DescribeInstances")
    @Override
    @POST
    @Path("/")
@@ -76,7 +76,7 @@ public interface AWSInstanceAsyncClient extends InstanceAsyncClient {
    /**
     * @see AWSInstanceClient#runInstancesInRegion
     */
-   @Named("ec2:RunInstances")
+   @Named("RunInstances")
    @Override
    @POST
    @Path("/")

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/AWSKeyPairAsyncClient.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/AWSKeyPairAsyncClient.java
@@ -51,7 +51,7 @@ public interface AWSKeyPairAsyncClient extends KeyPairAsyncClient {
    /**
     * @see AWSKeyPairClient#importKeyPairInRegion
     */
-   @Named("ec2:ImportKeyPair")
+   @Named("ImportKeyPair")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "ImportKeyPair")

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/AWSSecurityGroupAsyncClient.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/AWSSecurityGroupAsyncClient.java
@@ -65,7 +65,7 @@ public interface AWSSecurityGroupAsyncClient extends SecurityGroupAsyncClient {
    /**
     * @see AWSSecurityGroupClient#createSecurityGroupInRegion
     */
-   @Named("ec2:CreateSecurityGroup")
+   @Named("CreateSecurityGroup")
    @POST
    @Path("/")
    @XMLResponseParser(CreateSecurityGroupResponseHandler.class)
@@ -79,7 +79,7 @@ public interface AWSSecurityGroupAsyncClient extends SecurityGroupAsyncClient {
     * @see AWSSecurityGroupClient#authorizeSecurityGroupIngressInRegion(String,
     *      String,IpPermission)
     */
-   @Named("ec2:AuthorizeSecurityGroupIngress")
+   @Named("AuthorizeSecurityGroupIngress")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "AuthorizeSecurityGroupIngress")
@@ -91,7 +91,7 @@ public interface AWSSecurityGroupAsyncClient extends SecurityGroupAsyncClient {
     * @see AWSSecurityGroupClient#authorizeSecurityGroupIngressInRegion(String,
     *      String,Iterable)
     */
-   @Named("ec2:AuthorizeSecurityGroupIngress")
+   @Named("AuthorizeSecurityGroupIngress")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "AuthorizeSecurityGroupIngress")
@@ -104,7 +104,7 @@ public interface AWSSecurityGroupAsyncClient extends SecurityGroupAsyncClient {
     * @see AWSSecurityGroupClient#revokeSecurityGroupIngressInRegion(@Nullable
     *      Region, String,IpPermission)
     */
-   @Named("ec2:RevokeSecurityGroupIngress")
+   @Named("RevokeSecurityGroupIngress")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "RevokeSecurityGroupIngress")
@@ -116,7 +116,7 @@ public interface AWSSecurityGroupAsyncClient extends SecurityGroupAsyncClient {
     * @see AWSSecurityGroupClient#revokeSecurityGroupIngressInRegion(@Nullable
     *      Region, String,Iterable)
     */
-   @Named("ec2:RevokeSecurityGroupIngress")
+   @Named("RevokeSecurityGroupIngress")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "RevokeSecurityGroupIngress")
@@ -128,7 +128,7 @@ public interface AWSSecurityGroupAsyncClient extends SecurityGroupAsyncClient {
    /**
     * @see AWSSecurityGroupClient#deleteSecurityGroupInRegionById
     */
-   @Named("ec2:DeleteSecurityGroup")
+   @Named("DeleteSecurityGroup")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeleteSecurityGroup")
@@ -139,7 +139,7 @@ public interface AWSSecurityGroupAsyncClient extends SecurityGroupAsyncClient {
    /**
     * @see AWSSecurityGroupClient#describeSecurityGroupsInRegionById
     */
-   @Named("ec2:DescribeSecurityGroups")
+   @Named("DescribeSecurityGroups")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeSecurityGroups")

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/MonitoringAsyncClient.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/MonitoringAsyncClient.java
@@ -55,7 +55,7 @@ public interface MonitoringAsyncClient {
    /**
     * @see Monitoring#monitorInstancesInRegion
     */
-   @Named("ec2:MonitorInstances")
+   @Named("MonitorInstances")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "MonitorInstances")
@@ -68,7 +68,7 @@ public interface MonitoringAsyncClient {
    /**
     * @see Monitoring#monitorInstancesInRegion
     */
-   @Named("ec2:UnmonitorInstances")
+   @Named("UnmonitorInstances")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "UnmonitorInstances")

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/PlacementGroupAsyncClient.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/PlacementGroupAsyncClient.java
@@ -58,7 +58,7 @@ public interface PlacementGroupAsyncClient {
    /**
     * @see PlacementGroupClient#createPlacementGroupInRegion(String,String,String)
     */
-   @Named("ec2:CreatePlacementGroup")
+   @Named("CreatePlacementGroup")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CreatePlacementGroup")
@@ -69,7 +69,7 @@ public interface PlacementGroupAsyncClient {
    /**
     * @see PlacementGroupClient#createPlacementGroupInRegion(String,String)
     */
-   @Named("ec2:CreatePlacementGroup")
+   @Named("CreatePlacementGroup")
    @POST
    @Path("/")
    @FormParams(keys = { ACTION, "Strategy" }, values = { "CreatePlacementGroup", "cluster" })
@@ -79,7 +79,7 @@ public interface PlacementGroupAsyncClient {
    /**
     * @see PlacementGroupClient#deletePlacementGroupInRegion
     */
-   @Named("ec2:DeletePlacementGroup")
+   @Named("DeletePlacementGroup")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DeletePlacementGroup")
@@ -90,7 +90,7 @@ public interface PlacementGroupAsyncClient {
    /**
     * @see PlacementGroupClient#describePlacementGroupsInRegion
     */
-   @Named("ec2:DescribePlacementGroups")
+   @Named("DescribePlacementGroups")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribePlacementGroups")

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/SpotInstanceAsyncClient.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/services/SpotInstanceAsyncClient.java
@@ -65,7 +65,7 @@ public interface SpotInstanceAsyncClient {
    /**
     * @see SpotInstanceClient#describeSpotInstanceRequestsInRegion
     */
-   @Named("ec2:DescribeSpotInstanceRequests")
+   @Named("DescribeSpotInstanceRequests")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeSpotInstanceRequests")
@@ -78,7 +78,7 @@ public interface SpotInstanceAsyncClient {
    /**
     * @see SpotInstanceClient#requestSpotInstanceInRegion
     */
-   @Named("ec2:RequestSpotInstances")
+   @Named("RequestSpotInstances")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "RequestSpotInstances")
@@ -91,7 +91,7 @@ public interface SpotInstanceAsyncClient {
    /**
     * @see SpotInstanceClient#requestSpotInstancesInRegion
     */
-   @Named("ec2:RequestSpotInstances")
+   @Named("RequestSpotInstances")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "RequestSpotInstances")
@@ -105,7 +105,7 @@ public interface SpotInstanceAsyncClient {
    /**
     * @see SpotInstanceClient#describeSpotPriceHistoryInRegion
     */
-   @Named("ec2:DescribeSpotPriceHistory")
+   @Named("DescribeSpotPriceHistory")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "DescribeSpotPriceHistory")
@@ -118,7 +118,7 @@ public interface SpotInstanceAsyncClient {
    /**
     * @see SpotInstanceClient#cancelSpotInstanceRequestsInRegion
     */
-   @Named("ec2:CancelSpotInstanceRequests")
+   @Named("CancelSpotInstanceRequests")
    @POST
    @Path("/")
    @FormParams(keys = ACTION, values = "CancelSpotInstanceRequests")

--- a/providers/aws-s3/src/main/java/org/jclouds/aws/s3/AWSS3AsyncClient.java
+++ b/providers/aws-s3/src/main/java/org/jclouds/aws/s3/AWSS3AsyncClient.java
@@ -74,7 +74,7 @@ public interface AWSS3AsyncClient extends S3AsyncClient {
    /**
     * @see AWSS3Client#initiateMultipartUpload
     */
-   @Named("s3:PutObject")
+   @Named("PutObject")
    @POST
    @QueryParams(keys = "uploads")
    @Path("/{key}")
@@ -87,7 +87,7 @@ public interface AWSS3AsyncClient extends S3AsyncClient {
    /**
     * @see AWSS3Client#abortMultipartUpload
     */
-   @Named("s3:AbortMultipartUpload")
+   @Named("AbortMultipartUpload")
    @DELETE
    @Path("/{key}")
    @Fallback(VoidOnNotFoundOr404.class)
@@ -98,7 +98,7 @@ public interface AWSS3AsyncClient extends S3AsyncClient {
    /**
     * @see AWSS3Client#uploadPart
     */
-   @Named("s3:PutObject")
+   @Named("PutObject")
    @PUT
    @Path("/{key}")
    @ResponseParser(ParseETagHeader.class)
@@ -110,7 +110,7 @@ public interface AWSS3AsyncClient extends S3AsyncClient {
    /**
     * @see AWSS3Client#completeMultipartUpload
     */
-   @Named("s3:PutObject")
+   @Named("PutObject")
    @POST
    @Path("/{key}")
    @ResponseParser(ETagFromHttpResponseViaRegex.class)
@@ -122,7 +122,7 @@ public interface AWSS3AsyncClient extends S3AsyncClient {
    /**
     * @see AWSS3Client#deleteObjects
     */
-   @Named("s3:DeleteObject")
+   @Named("DeleteObject")
    @POST                              
    @Path("/")
    @QueryParams(keys = "delete")


### PR DESCRIPTION
changed aws apis to use Action key for config instead of more verbose iam names

ex. configuration files will be easier, as properties are already scoped to the provider.  Moreover, the convention `DescribeInstances` is much more like other apis.

https://github.com/jclouds/jclouds/issues/1184
