### PR TITLE
Fix CloudStack URL signing for fields with [ chars

### DIFF
--- a/apis/cloudstack/src/test/java/org/jclouds/cloudstack/filters/QuerySignerTest.java
+++ b/apis/cloudstack/src/test/java/org/jclouds/cloudstack/filters/QuerySignerTest.java
@@ -62,6 +62,18 @@ public class QuerySignerTest {
    }
 
    @Test
+   void testCreateStringToSignWithBrackets() {
+      // This test asserts that key *names* are not URL-encoded - only values
+      // should be encoded, according to "CloudStack API Developer’s Guide".
+      QuerySigner filter = INJECTOR.getInstance(QuerySigner.class);
+
+      assertEquals(
+            filter.createStringToSign(HttpRequest.builder().method("GET")
+                  .endpoint("http://localhost:8080/client/api?command=deployVirtualMachine&iptonetworklist[0].ip=127.0.0.1&iptonetworklist[0].networkid=1").build()),
+            "apikey=apikey&command=deployvirtualmachine&iptonetworklist[0].ip=127.0.0.1&iptonetworklist[0].networkid=1");
+   }
+
+   @Test
    void testFilter() {
       QuerySigner filter = INJECTOR.getInstance(QuerySigner.class);
 


### PR DESCRIPTION
Commit 69a8304 caused the CloudStack QuerySigner to generate invalid
signatures where key names contained square brackets, such as in the
"iptonetworklist[N]" field to deployVirtualMachine. The commit changed
the whole query string being URL-encoded, whereas previously the field
values were encoded but the field names were not. The CloudStack API
guide says that values that should be encoded for signing but not field
names, and indeed the commit does cause signatures to be rejected.

This commit reverses the change to QuerySigner.createStringToSign() and
adds a unit test for this case.

This is the equivalent of pull request 1265 (which was on 1.5.x branch), applied to master.

Tests: unit tests (pass), live tests (no regressions)
