### PR TITLE
normalize command names for all swift derivatives

### DIFF
--- a/apis/cloudfiles/src/main/java/org/jclouds/cloudfiles/CloudFilesAsyncClient.java
+++ b/apis/cloudfiles/src/main/java/org/jclouds/cloudfiles/CloudFilesAsyncClient.java
@@ -72,7 +72,7 @@ public interface CloudFilesAsyncClient extends CommonSwiftAsyncClient {
    /**
     * @see CloudFilesClient#listCDNContainers
     */
-   @Named("cdn:listcontainers")
+   @Named("ListCDNEnabledContainers")
    @GET
    @Consumes(MediaType.APPLICATION_JSON)
    @QueryParams(keys = "format", values = "json")
@@ -83,7 +83,7 @@ public interface CloudFilesAsyncClient extends CommonSwiftAsyncClient {
    /**
     * @see CloudFilesClient#getCDNMetadata
     */
-   @Named("cdn:getmetadata")
+   @Named("ListCDNEnabledContainerMetadata")
    @HEAD
    @ResponseParser(ParseContainerCDNMetadataFromHeaders.class)
    @Fallback(NullOnContainerNotFound.class)
@@ -94,7 +94,7 @@ public interface CloudFilesAsyncClient extends CommonSwiftAsyncClient {
    /**
     * @see CloudFilesClient#enableCDN(String, long, boolean);
     */
-   @Named("cdn:enable")
+   @Named("CDNEnableContainer")
    @PUT
    @Path("/{container}")
    @Headers(keys = CloudFilesHeaders.CDN_ENABLED, values = "True")
@@ -107,7 +107,7 @@ public interface CloudFilesAsyncClient extends CommonSwiftAsyncClient {
    /**
     * @see CloudFilesClient#enableCDN(String, long);
     */
-   @Named("cdn:enable")
+   @Named("CDNEnableContainer")
    @PUT
    @Path("/{container}")
    @Headers(keys = CloudFilesHeaders.CDN_ENABLED, values = "True")
@@ -119,7 +119,7 @@ public interface CloudFilesAsyncClient extends CommonSwiftAsyncClient {
    /**
     * @see CloudFilesClient#enableCDN(String)
     */
-   @Named("cdn:enable")
+   @Named("CDNEnableContainer")
    @PUT
    @Path("/{container}")
    @Headers(keys = CloudFilesHeaders.CDN_ENABLED, values = "True")
@@ -130,7 +130,7 @@ public interface CloudFilesAsyncClient extends CommonSwiftAsyncClient {
    /**
     * @see CloudFilesClient#updateCDN(long, boolean)
     */
-   @Named("cdn:update")
+   @Named("UpdateCDNEnabledContainerMetadata")
    @POST
    @Path("/{container}")
    @ResponseParser(ParseCdnUriFromHeaders.class)
@@ -142,7 +142,7 @@ public interface CloudFilesAsyncClient extends CommonSwiftAsyncClient {
    /**
     * @see CloudFilesClient#updateCDN(boolean)
     */
-   @Named("cdn:update")
+   @Named("UpdateCDNEnabledContainerMetadata")
    @POST
    @Path("/{container}")
    @ResponseParser(ParseCdnUriFromHeaders.class)
@@ -153,7 +153,7 @@ public interface CloudFilesAsyncClient extends CommonSwiftAsyncClient {
    /**
     * @see CloudFilesClient#updateCDN(long)
     */
-   @Named("cdn:update")
+   @Named("UpdateCDNEnabledContainerMetadata")
    @POST
    @Path("/{container}")
    @ResponseParser(ParseCdnUriFromHeaders.class)
@@ -164,7 +164,7 @@ public interface CloudFilesAsyncClient extends CommonSwiftAsyncClient {
    /**
     * @see CloudFilesClient#disableCDN
     */
-   @Named("cdn:disable")
+   @Named("DisableCDNEnabledContainer")
    @POST
    @Path("/{container}")
    @Headers(keys = CloudFilesHeaders.CDN_ENABLED, values = "False")
@@ -174,7 +174,7 @@ public interface CloudFilesAsyncClient extends CommonSwiftAsyncClient {
    /**
     * @see CloudFilesClient#purgeCDNObject(String, String, Iterable)
     */
-   @Named("cdn:purgeobject")
+   @Named("PurgeCDNEnabledObject")
    @DELETE
    @Path("/{container}/{object}")
    @Headers(keys = CloudFilesHeaders.CDN_CONTAINER_PURGE_OBJECT_EMAIL, values = "{email}")
@@ -186,7 +186,7 @@ public interface CloudFilesAsyncClient extends CommonSwiftAsyncClient {
    /**
     * @see CloudFilesClient#purgeCDNObject(String, String)
     */
-   @Named("cdn:purgeobject")
+   @Named("PurgeCDNEnabledObject")
    @DELETE
    @Path("/{container}/{object}")
    @Endpoint(CDNManagement.class)
@@ -196,7 +196,7 @@ public interface CloudFilesAsyncClient extends CommonSwiftAsyncClient {
    /**
     * @see CloudFilesClient#setCDNStaticWebsiteIndex
     */
-   @Named("cdn:setstaticwebsiteindex")
+   @Named("UpdateCDNEnabledContainerMetadata")
    @POST
    @Path("/{container}")
    @Headers(keys = CloudFilesHeaders.CDN_WEBSITE_INDEX, values = "{index}")
@@ -206,7 +206,7 @@ public interface CloudFilesAsyncClient extends CommonSwiftAsyncClient {
    /**
     * @see CloudFilesClient#setCDNStaticWebsiteError
     */
-   @Named("cdn:setstaticwebsiteerror")
+   @Named("UpdateCDNEnabledContainerMetadata")
    @POST
    @Path("/{container}")
    @Headers(keys = CloudFilesHeaders.CDN_WEBSITE_ERROR, values = "{error}")

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/CommonSwiftAsyncClient.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/CommonSwiftAsyncClient.java
@@ -84,7 +84,7 @@ public interface CommonSwiftAsyncClient {
    /**
     * @see CommonSwiftClient#getAccountStatistics
     */
-   @Named("swift:getaccountstats")
+   @Named("GetAccountMetadata")
    @HEAD
    @Path("/")
    @Consumes(MediaType.WILDCARD)
@@ -94,7 +94,7 @@ public interface CommonSwiftAsyncClient {
    /**
     * @see CommonSwiftClient#listContainers
     */
-   @Named("swift:listcontainers")
+   @Named("ListContainers")
    @GET
    @Consumes(MediaType.APPLICATION_JSON)
    @QueryParams(keys = "format", values = "json")
@@ -104,7 +104,7 @@ public interface CommonSwiftAsyncClient {
    /**
     * @see CommonSwiftClient#getContainerMetadata
     */
-   @Named("swift:getcontainermetadata")
+   @Named("GetContainerMetadata")
    @Beta
    @HEAD
    @Path("/{container}")
@@ -116,7 +116,7 @@ public interface CommonSwiftAsyncClient {
    /**
     * @see CommonSwiftClient#setContainerMetadata
     */
-   @Named("swift:setcontainermetadata")
+   @Named("UpdateContainerMetadata")
    @POST
    @Path("/{container}")
    @Fallback(FalseOnContainerNotFound.class)
@@ -126,7 +126,7 @@ public interface CommonSwiftAsyncClient {
    /**
     * @see CommonSwiftClient#deleteContainerMetadata
     */
-   @Named("swift:deletecontainermetadata")
+   @Named("UpdateContainerMetadata")
    @POST
    @Path("/{container}")
    @Fallback(FalseOnContainerNotFound.class)
@@ -136,7 +136,7 @@ public interface CommonSwiftAsyncClient {
    /**
     * @see CommonSwiftClient#createContainer
     */
-   @Named("swift:createcontainer")
+   @Named("CreateContainer")
    @PUT
    @Path("/{container}")
    ListenableFuture<Boolean> createContainer(@PathParam("container") String container,
@@ -145,7 +145,7 @@ public interface CommonSwiftAsyncClient {
    /**
     * @see CommonSwiftClient#setObjectInfo
     */
-   @Named("swift:setobjectinfo")
+   @Named("UpdateObjectMetadata")
    @POST
    @Path("/{container}/{name}")
    ListenableFuture<Boolean> setObjectInfo(@PathParam("container") String container, 
@@ -155,7 +155,7 @@ public interface CommonSwiftAsyncClient {
    /**
     * @see CommonSwiftClient#createContainer
     */
-   @Named("swift:createcontainer")
+   @Named("CreateContainer")
    @PUT
    @Path("/{container}")
    ListenableFuture<Boolean> createContainer(@PathParam("container") String container);
@@ -163,7 +163,7 @@ public interface CommonSwiftAsyncClient {
    /**
     * @see CommonSwiftClient#deleteContainerIfEmpty
     */
-   @Named("swift:deletecontainerifempty")
+   @Named("DeleteContainer")
    @DELETE
    @Fallback(TrueOn404FalseOn409.class)
    @Path("/{container}")
@@ -172,7 +172,7 @@ public interface CommonSwiftAsyncClient {
    /**
     * @see CommonSwiftClient#listObjects
     */
-   @Named("swift:listobjects")
+   @Named("ListObjects")
    @GET
    @QueryParams(keys = "format", values = "json")
    @ResponseParser(ParseObjectInfoListFromJsonResponse.class)
@@ -183,7 +183,7 @@ public interface CommonSwiftAsyncClient {
    /**
     * @see CommonSwiftClient#containerExists
     */
-   @Named("swift:containerexists")
+   @Named("GetContainerMetadata")
    @HEAD
    @Path("/{container}")
    @Consumes(MediaType.WILDCARD)
@@ -193,7 +193,7 @@ public interface CommonSwiftAsyncClient {
    /**
     * @see CommonSwiftClient#putObject
     */
-   @Named("swift:putobject")
+   @Named("PutObject")
    @PUT
    @Path("/{container}/{name}")
    @ResponseParser(ParseETagHeader.class)
@@ -203,7 +203,7 @@ public interface CommonSwiftAsyncClient {
    /**
     * @see CommonSwiftClient#copyObject
     */
-   @Named("swift:copyobject")
+   @Named("CopyObject")
    @PUT
    @Path("/{destinationContainer}/{destinationObject}")
    @Headers(keys = SwiftHeaders.OBJECT_COPY_FROM, values = "/{sourceContainer}/{sourceObject}")
@@ -216,7 +216,7 @@ public interface CommonSwiftAsyncClient {
    /**
     * @see CommonSwiftClient#getObject
     */
-   @Named("swift:getobject")
+   @Named("GetObject")
    @GET
    @ResponseParser(ParseObjectFromHeadersAndHttpContent.class)
    @Fallback(NullOnKeyNotFound.class)
@@ -228,7 +228,7 @@ public interface CommonSwiftAsyncClient {
    /**
     * @see CommonSwiftClient#getObjectInfo
     */
-   @Named("swift:getobjectinfo")
+   @Named("GetObjectMetadata")
    @HEAD
    @ResponseParser(ParseObjectInfoFromHeaders.class)
    @Fallback(NullOnKeyNotFound.class)
@@ -240,7 +240,7 @@ public interface CommonSwiftAsyncClient {
    /**
     * @see CommonSwiftClient#objectExists
     */
-   @Named("swift:objectexists")
+   @Named("GetObjectMetadata")
    @HEAD
    @Fallback(FalseOnKeyNotFound.class)
    @Path("/{container}/{name}")
@@ -251,14 +251,14 @@ public interface CommonSwiftAsyncClient {
    /**
     * @see CommonSwiftClient#removeObject
     */
-   @Named("swift:removeobject")
+   @Named("RemoveObject")
    @DELETE
    @Fallback(VoidOnNotFoundOr404.class)
    @Path("/{container}/{name}")
    ListenableFuture<Void> removeObject(@PathParam("container") String container, 
                                        @PathParam("name") String name);
 
-   @Named("swift:putobjectmanifest")
+   @Named("PutObjectManifest")
    @PUT
    @Path("/{container}/{name}")
    @ResponseParser(ParseETagHeader.class)

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/extensions/TemporaryUrlKeyAsyncApi.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/extensions/TemporaryUrlKeyAsyncApi.java
@@ -38,6 +38,7 @@ import javax.ws.rs.core.MediaType;
 /**
  * @author Andrei Savu
  * @see TemporaryUrlKeyApi
+ * @see <a href="http://docs.openstack.org/trunk/openstack-object-storage/admin/content/swift-tempurl.html">docs</a>
  */
 @RequestFilters(AuthenticateRequest.class)
 @Endpoint(Storage.class)
@@ -46,7 +47,7 @@ public interface TemporaryUrlKeyAsyncApi {
    /**
     * @see TemporaryUrlKeyApi#getTemporaryUrlKey
     */
-   @Named("tempurlkey:get")
+   @Named("GetAccountMetadata")
    @HEAD
    @Path("/")
    @Consumes(MediaType.WILDCARD)
@@ -56,7 +57,7 @@ public interface TemporaryUrlKeyAsyncApi {
    /**
     * @see TemporaryUrlKeyApi#setTemporaryUrlKey
     */
-   @Named("tempurlkey:set")
+   @Named("UpdateAccountMetadata")
    @POST
    @Path("/")
    ListenableFuture<Void> setTemporaryUrlKey(@HeaderParam(SwiftHeaders.ACCOUNT_TEMPORARY_URL_KEY) String key);

--- a/providers/hpcloud-objectstorage/src/main/java/org/jclouds/hpcloud/objectstorage/HPCloudObjectStorageAsyncApi.java
+++ b/providers/hpcloud-objectstorage/src/main/java/org/jclouds/hpcloud/objectstorage/HPCloudObjectStorageAsyncApi.java
@@ -20,6 +20,7 @@ package org.jclouds.hpcloud.objectstorage;
 
 import java.util.Set;
 
+import javax.inject.Named;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -49,13 +50,15 @@ import com.google.inject.Provides;
  * Provides asynchronous access to HP Cloud Object Storage via the REST API.
  * 
  * <p/>
- * All commands return a ListenableFuture of the result. Any exceptions incurred during processing
- * will be backend in an {@link java.util.concurrent.ExecutionException} as documented in
+ * All commands return a ListenableFuture of the result. Any exceptions incurred
+ * during processing will be backend in an
+ * {@link java.util.concurrent.ExecutionException} as documented in
  * {@link ListenableFuture#get()}.
  * 
  * @see HPCloudObjectStorageApi
- * @see <a href="https://manage.hpcloud.com/pages/build/docs/objectstorage-lvs/api">HP Cloud Object
- *      Storage API</a>
+ * @see <a
+ *      href="https://api-docs.hpcloud.com/hpcloud-object-storage/1.0/content/ch_object-storage-dev-overview.html">HP
+ *      Cloud Object Storage API</a>
  * @author Jeremy Daggett
  */
 @RequestFilters(AuthenticateRequest.class)
@@ -72,6 +75,7 @@ public interface HPCloudObjectStorageAsyncApi extends CommonSwiftAsyncClient {
    /**
     * @see org.jclouds.openstack.swift.CommonSwiftClient#listContainers
     */
+   @Named("ListContainers")
    @GET
    @Consumes(MediaType.APPLICATION_JSON)
    @QueryParams(keys = "format", values = "json")
@@ -81,6 +85,7 @@ public interface HPCloudObjectStorageAsyncApi extends CommonSwiftAsyncClient {
    /**
     * @see org.jclouds.openstack.swift.CommonSwiftClient#deleteContainerIfEmpty
     */
+   @Named("DeleteContainer")
    @DELETE
    @Fallback(TrueOn404FalseOn409.class)
    @Path("/{container}")

--- a/providers/hpcloud-objectstorage/src/main/java/org/jclouds/hpcloud/objectstorage/extensions/CDNContainerAsyncApi.java
+++ b/providers/hpcloud-objectstorage/src/main/java/org/jclouds/hpcloud/objectstorage/extensions/CDNContainerAsyncApi.java
@@ -20,6 +20,7 @@ package org.jclouds.hpcloud.objectstorage.extensions;
 
 import java.net.URI;
 
+import javax.inject.Named;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.HEAD;
@@ -55,13 +56,15 @@ import com.google.common.util.concurrent.ListenableFuture;
  * Provides asynchronous access to HP Cloud Object Storage via the REST API.
  * 
  * <p/>
- * All commands return a ListenableFuture of the result. Any exceptions incurred during processing
- * will be backend in an {@link java.util.concurrent.ExecutionException} as documented in
+ * All commands return a ListenableFuture of the result. Any exceptions incurred
+ * during processing will be backend in an
+ * {@link java.util.concurrent.ExecutionException} as documented in
  * {@link ListenableFuture#get()}.
  * 
  * @see HPCloudObjectStorageApi
- * @see <a href="https://manage.hpcloud.com/pages/build/docs/objectstorage-lvs/api">HP Cloud Object
- *      Storage API</a>
+ * @see <a
+ *      href="https://api-docs.hpcloud.com/hpcloud-cdn-storage/1.0/content/ch_cdn-dev-overview.html">HP
+ *      Cloud Object Storage API</a>
  * @author Jeremy Daggett
  */
 @RequestFilters(AuthenticateRequest.class)
@@ -71,6 +74,7 @@ public interface CDNContainerAsyncApi {
     * @see HPCloudObjectStorageApi#list()
     */
    @Beta
+   @Named("ListCDNEnabledContainers")
    @GET
    @Consumes(MediaType.APPLICATION_JSON)
    @QueryParams(keys = "format", values = "json")
@@ -82,6 +86,7 @@ public interface CDNContainerAsyncApi {
     * @see HPCloudObjectStorageApi#list(ListCDNContainerOptions)
     */
    @Beta
+   @Named("ListCDNEnabledContainers")
    @GET
    @Consumes(MediaType.APPLICATION_JSON)
    @QueryParams(keys = "format", values = "json")
@@ -93,6 +98,7 @@ public interface CDNContainerAsyncApi {
     * @see HPCloudObjectStorageApi#get(String)
     */
    @Beta
+   @Named("ListCDNEnabledContainerMetadata")
    @HEAD
    @ResponseParser(ParseCDNContainerFromHeaders.class)
    @Fallback(NullOnContainerNotFound.class)
@@ -103,6 +109,7 @@ public interface CDNContainerAsyncApi {
     * @see HPCloudObjectStorageApi#enable(String, long)
     */
    @Beta
+   @Named("CDNEnableContainer")
    @PUT
    @Path("/{container}")
    @Headers(keys = HPCloudObjectStorageHeaders.CDN_ENABLED, values = "True")
@@ -114,6 +121,7 @@ public interface CDNContainerAsyncApi {
     * @see HPCloudObjectStorageApi#enable(String)
     */
    @Beta
+   @Named("CDNEnableContainer")
    @PUT
    @Path("/{container}")
    @Headers(keys = HPCloudObjectStorageHeaders.CDN_ENABLED, values = "True")
@@ -124,6 +132,7 @@ public interface CDNContainerAsyncApi {
     * @see HPCloudObjectStorageApi#update(String, long)
     */
    @Beta
+   @Named("UpdateCDNEnabledContainerMetadata")
    @POST
    @Path("/{container}")
    @ResponseParser(ParseCDNUriFromHeaders.class)
@@ -134,6 +143,7 @@ public interface CDNContainerAsyncApi {
     * @see HPCloudObjectStorageApi#disable(String)
     */
    @Beta
+   @Named("DisableCDNEnabledContainer")
    @PUT
    @Path("/{container}")
    @Headers(keys = HPCloudObjectStorageHeaders.CDN_ENABLED, values = "False")


### PR DESCRIPTION
issue #1184 normalize command names for all swift derivatives

cc @everett-toews note I've normalized to the names of commands as specified in the docs, using the more dominant aws-style case format, as there's no defined case format for openstack
