### PR TITLE
Replace unneeded Function with imperative approach

### DIFF
--- a/blobstore/src/main/java/org/jclouds/blobstore/LocalAsyncBlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/LocalAsyncBlobStore.java
@@ -191,15 +191,12 @@ public class LocalAsyncBlobStore extends BaseAsyncBlobStore {
 
             contents = newTreeSet(filter(contents, new DelimiterFilter(prefix, delimiter)));
 
-            Iterables.<StorageMetadata> addAll(contents, transform(commonPrefixes,
-                  new Function<String, StorageMetadata>() {
-                     public StorageMetadata apply(String o) {
-                        MutableStorageMetadata md = new MutableStorageMetadataImpl();
-                        md.setType(StorageType.RELATIVE_PATH);
-                        md.setName(o);
-                        return md;
-                     }
-                  }));
+            for (String o : commonPrefixes) {
+               MutableStorageMetadata md = new MutableStorageMetadataImpl();
+               md.setType(StorageType.RELATIVE_PATH);
+               md.setName(o);
+               contents.add(md);
+            }
          }
 
          // trim metadata, if the response isn't supposed to be detailed.


### PR DESCRIPTION
The latter is more concise, faster, and compact.  .class size in bytes
before:

LocalAsyncBlobStore$5.class      1883
LocalAsyncBlobStore.class       20743

and after:

LocalAsyncBlobStore.class       21041
