### PR TITLE
Added generic refresh method in Abiquo

### DIFF
--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/DomainWrapper.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/DomainWrapper.java
@@ -35,6 +35,9 @@ import org.jclouds.abiquo.domain.exception.WrapperException;
 import org.jclouds.abiquo.domain.task.AsyncTask;
 import org.jclouds.abiquo.domain.util.LinkUtils;
 import org.jclouds.abiquo.reference.ValidationErrors;
+import org.jclouds.abiquo.rest.internal.ExtendedUtils;
+import org.jclouds.http.HttpResponse;
+import org.jclouds.http.functions.ParseXMLWithJAXB;
 import org.jclouds.rest.RestContext;
 
 import com.abiquo.model.rest.RESTLink;
@@ -46,6 +49,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.reflect.Invokable;
+import com.google.inject.TypeLiteral;
 
 /**
  * This class is used to decorate transport objects with high level
@@ -82,6 +86,22 @@ public abstract class DomainWrapper<T extends SingleResourceTransportDto> {
     */
    public T unwrap() {
       return target;
+   }
+
+   /**
+    * Refresh the state of the current object.
+    */
+   @SuppressWarnings("unchecked")
+   public void refresh() {
+      RESTLink link = checkNotNull(LinkUtils.getSelfLink(target), ValidationErrors.MISSING_REQUIRED_LINK + " edit/self");
+
+      ExtendedUtils utils = (ExtendedUtils) context.getUtils();
+      HttpResponse response = utils.getAbiquoHttpClient().get(link);
+
+      ParseXMLWithJAXB<T> parser = new ParseXMLWithJAXB<T>(utils.getXml(),
+            TypeLiteral.get((Class<T>) target.getClass()));
+
+      target = parser.apply(response);
    }
 
    /**

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/cloud/Conversion.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/cloud/Conversion.java
@@ -58,20 +58,6 @@ public class Conversion extends DomainWithTasksWrapper<ConversionDto> {
       super(context, target);
    }
 
-   // Domain methods
-
-   public void refresh() {
-      RESTLink link = checkNotNull(target.searchLink("edit"), ValidationErrors.MISSING_REQUIRED_LINK + "edit");
-
-      ExtendedUtils utils = (ExtendedUtils) context.getUtils();
-      HttpResponse response = checkNotNull(utils.getAbiquoHttpClient().get(link), "conversion");
-
-      ParseXMLWithJAXB<ConversionDto> parser = new ParseXMLWithJAXB<ConversionDto>(utils.getXml(),
-            TypeLiteral.get(ConversionDto.class));
-
-      target = parser.apply(response);
-   }
-
    // Parent access
 
    /**

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/cloud/VirtualMachine.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/cloud/VirtualMachine.java
@@ -220,18 +220,6 @@ public class VirtualMachine extends DomainWithTasksWrapper<VirtualMachineWithNod
       return state;
    }
 
-   public void refresh() {
-      RESTLink link = checkNotNull(target.getEditLink(), ValidationErrors.MISSING_REQUIRED_LINK + " edit");
-
-      ExtendedUtils utils = (ExtendedUtils) context.getUtils();
-      HttpResponse response = utils.getAbiquoHttpClient().get(link);
-
-      ParseXMLWithJAXB<VirtualMachineWithNodeExtendedDto> parser = new ParseXMLWithJAXB<VirtualMachineWithNodeExtendedDto>(
-            utils.getXml(), TypeLiteral.get(VirtualMachineWithNodeExtendedDto.class));
-
-      target = parser.apply(response);
-   }
-
    // Parent access
 
    /**

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/StoragePool.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/infrastructure/StoragePool.java
@@ -112,6 +112,7 @@ public class StoragePool extends DomainWrapper<StoragePoolDto> {
       target = context.getApi().getInfrastructureApi().updateStoragePool(target);
    }
 
+   @Override
    public void refresh() {
       target = context.getApi().getInfrastructureApi()
             .refreshStoragePool(target, StoragePoolOptions.builder().sync(true).build());
@@ -187,7 +188,6 @@ public class StoragePool extends DomainWrapper<StoragePoolDto> {
       private String name;
       private Long totalSizeInMb;
 
-
       public Builder(final RestContext<AbiquoApi, AbiquoAsyncApi> context, final StorageDevice storageDevice) {
          super();
          checkNotNull(storageDevice, ValidationErrors.NULL_RESOURCE + StorageDevice.class);
@@ -206,12 +206,10 @@ public class StoragePool extends DomainWrapper<StoragePoolDto> {
          return this;
       }
 
-
       public Builder totalSizeInMb(final long totalSizeInMb) {
          this.totalSizeInMb = totalSizeInMb;
          return this;
       }
-
 
       public StoragePool build() {
          StoragePoolDto dto = new StoragePoolDto();
@@ -223,8 +221,7 @@ public class StoragePool extends DomainWrapper<StoragePoolDto> {
       }
 
       public static Builder fromStoragePool(final StoragePool in) {
-         Builder builder = StoragePool.builder(in.context, in.getStorageDevice())
-               .totalSizeInMb(in.getTotalSizeInMb());
+         Builder builder = StoragePool.builder(in.context, in.getStorageDevice()).totalSizeInMb(in.getTotalSizeInMb());
 
          return builder;
       }

--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/task/AsyncTask.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/task/AsyncTask.java
@@ -23,8 +23,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.List;
 
-import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.AbiquoApi;
+import org.jclouds.abiquo.AbiquoAsyncApi;
 import org.jclouds.abiquo.domain.DomainWrapper;
 import org.jclouds.abiquo.reference.ValidationErrors;
 import org.jclouds.rest.RestContext;
@@ -52,6 +52,7 @@ public class AsyncTask extends DomainWrapper<TaskDto> {
    /**
     * Refresh the state of the task.
     */
+   @Override
    public void refresh() {
       RESTLink self = checkNotNull(target.searchLink("self"), ValidationErrors.MISSING_REQUIRED_LINK + "self");
 


### PR DESCRIPTION
In Abiquo every object contains a link to itself with `rel="edit"`. This commit adds a generic method in the DomainWrapper base class that reads the link and performs a GET operation to refresh the object.

This method was already used in conversions and virtual machines, and now every object will have it implemented.
