### PR TITLE
fix hi1.4xlarge and other hardware specifications in 1.5.x

### DIFF
--- a/apis/ec2/src/main/java/org/jclouds/ec2/compute/domain/EC2HardwareBuilder.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/compute/domain/EC2HardwareBuilder.java
@@ -43,6 +43,8 @@ import org.jclouds.ec2.domain.VirtualizationType;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * 
@@ -294,7 +296,23 @@ public class EC2HardwareBuilder extends HardwareBuilder {
                   ImmutableList.<Volume> of(new VolumeImpl(10.0f, "/dev/sda1", true, false), new VolumeImpl(840.0f,
                         "/dev/sdb", false, false), new VolumeImpl(840.0f, "/dev/sdc", false, false))).is64Bit(true);
    }
+   
+   /**
+    * @see InstanceType#M3_XLARGE
+    */
+   public static EC2HardwareBuilder m3_xlarge() {
+      return new EC2HardwareBuilder(InstanceType.M3_XLARGE).ram(15360)
+            .processors(ImmutableList.of(new Processor(4.0, 3.25))).rootDeviceType(RootDeviceType.EBS).is64Bit(true);
+   }
 
+   /**
+    * @see InstanceType#M3_2XLARGE
+    */
+   public static EC2HardwareBuilder m3_2xlarge() {
+      return new EC2HardwareBuilder(InstanceType.M3_2XLARGE).ram(30720)
+            .processors(ImmutableList.of(new Processor(8.0, 3.25))).rootDeviceType(RootDeviceType.EBS).is64Bit(true);
+   }
+   
    /**
     * @see InstanceType#C1_MEDIUM
     */
@@ -355,11 +373,27 @@ public class EC2HardwareBuilder extends HardwareBuilder {
    public static EC2HardwareBuilder hi1_4xlarge() {
       return new EC2HardwareBuilder(InstanceType.HI1_4XLARGE)
             .ram(60 * 1024 + 512)
-            .processors(ImmutableList.of(new Processor(8.0, 5.5), new Processor(8.0, 5.5)))
+            .processors(ImmutableList.of(new Processor(16.0, 2.1875)))
             .volumes(ImmutableList.<Volume> of(new VolumeImpl(1024.0f, "/dev/sda1", true, false),
-                  new VolumeImpl(1024.0f, "/dev/sdb", false, false)));
+                  new VolumeImpl(1024.0f, "/dev/sdb", false, false)))
+            .virtualizationType(VirtualizationType.HVM);
    }
-
+   
+   public static EC2HardwareBuilder hs1_8xlarge() {
+      float twoTB = 2048.0f * 1024.0f;
+      Builder<Volume> all24Volumes = ImmutableList.<Volume>builder();
+      all24Volumes.add(new VolumeImpl(twoTB, "/dev/sda1", true, false));
+      for (char letter : ImmutableSet.of('b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p',
+            'q', 'r', 's', 't', 'u', 'v', 'w', 'x')) {
+         all24Volumes.add(new VolumeImpl(twoTB, "/dev/sd" + letter, false, false));
+      }
+      return new EC2HardwareBuilder(InstanceType.HS1_8XLARGE)
+            .ram(117 * 1024)
+            .processors(ImmutableList.of(new Processor(16.0, 2.1875)))
+            .volumes(all24Volumes.build())
+            .virtualizationType(VirtualizationType.HVM);
+   }
+   
    @SuppressWarnings("unchecked")
    @Override
    public Hardware build() {

--- a/apis/ec2/src/main/java/org/jclouds/ec2/domain/InstanceType.java
+++ b/apis/ec2/src/main/java/org/jclouds/ec2/domain/InstanceType.java
@@ -18,8 +18,6 @@
  */
 package org.jclouds.ec2.domain;
 
-import org.jclouds.ec2.EC2AsyncClient;
-
 /**
  * 
  * The type of the instance. Description accurate as of 8-15-2009 release.
@@ -122,6 +120,28 @@ public class InstanceType {
     */
    public static final String M2_4XLARGE = "m2.4xlarge";
    /**
+    * M3 Extra Large Instance
+    * <ul>
+    * <li>15 GiB memory</li>
+    * <li>13 EC2 Compute Units (4 virtual cores with 3.25 EC2 Compute Units each)</li>
+    * <li>EBS storage only</li>
+    * <li>64-bit platform</li>
+    * <li>I/O Performance: Moderate</li>
+    * </ul>
+    */
+   public static final String M3_XLARGE = "m3.xlarge";
+   /**
+    * M3 Double Extra Large Instance
+    * <ul>
+    * <li>30 GiB memory</li>
+    * <li>26 EC2 Compute Units (8 virtual cores with 3.25 EC2 Compute Units each)</li>
+    * <li>EBS storage only</li>
+    * <li>64-bit platform</li>
+    * <li>I/O Performance: High</li>
+    * </ul>
+    */
+   public static final String M3_2XLARGE = "m3.2xlarge";
+   /**
     * High-CPU Medium Instance
     * <ul>
     * <li>1.7 GB of memory</li>
@@ -199,4 +219,16 @@ public class InstanceType {
     */
    public static final String HI1_4XLARGE = "hi1.4xlarge";
 
+   /**
+    * High Storage Eight Extra Large
+    * <ul>
+    * <li>117 GiB of memory</li>
+    * <li>35 EC2 Compute Units (16 virtual cores*)</li>
+    * <li>24 hard disk drives each with 2 TB of instance storage</li>
+    * <li>64-bit platform</li>
+    * <li>I/O Performance: Very High (10 Gigabit Ethernet)</li>
+    * <li>Storage I/O Performance: Very High**</li>
+    * </ul>
+    */
+   public static final String HS1_8XLARGE = "hs1.8xlarge";
 }

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/suppliers/AWSEC2HardwareSupplier.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/suppliers/AWSEC2HardwareSupplier.java
@@ -24,6 +24,7 @@ import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.cc1_4xlarge;
 import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.cc2_8xlarge;
 import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.cg1_4xlarge;
 import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.hi1_4xlarge;
+import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.hs1_8xlarge;
 import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.m1_large;
 import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.m1_medium;
 import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.m1_small;
@@ -31,6 +32,8 @@ import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.m1_xlarge;
 import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.m2_2xlarge;
 import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.m2_4xlarge;
 import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.m2_xlarge;
+import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.m3_xlarge;
+import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.m3_2xlarge;
 import static org.jclouds.ec2.compute.domain.EC2HardwareBuilder.t1_micro;
 
 import java.util.Set;
@@ -65,9 +68,11 @@ public class AWSEC2HardwareSupplier extends EC2HardwareSupplier {
       sizes.add(cc1_4xlarge().supportsImageIds(ccAmis).build());
       sizes.add(cg1_4xlarge().supportsImageIds(ccAmis).build());
       sizes.add(cc2_8xlarge().supportsImageIds(ccAmis).build());
+      sizes.add(hi1_4xlarge().supportsImageIds(ccAmis).build());
+      sizes.add(hs1_8xlarge().supportsImageIds(ccAmis).build());
       sizes.addAll(ImmutableSet.<Hardware> of(t1_micro().build(), c1_medium().build(), c1_xlarge().build(), m1_large()
                .build(), m1_small().build(), m1_medium().build(), m1_xlarge().build(), m2_xlarge().build(), 
-               m2_2xlarge().build(), m2_4xlarge().build(), hi1_4xlarge().build()));
+               m2_2xlarge().build(), m2_4xlarge().build(), m3_xlarge().build(), m3_2xlarge().build()));
       return sizes.build();
    }
 }


### PR DESCRIPTION
This pull request fixes the obvious problems in this issue:
https://github.com/jclouds/jclouds/issues/1306

Unfortunately, whirr still can't place hi1.4xlarge instances in a placement group.  See 
https://issues.apache.org/jira/browse/WHIRR-700
