### PR TITLE
Fixed inheritance hierarchy for Swift and Cloud Files to avoid problems when using BlobStore.

### DIFF
--- a/apis/cloudfiles/src/main/java/org/jclouds/cloudfiles/CloudFilesAsyncClient.java
+++ b/apis/cloudfiles/src/main/java/org/jclouds/cloudfiles/CloudFilesAsyncClient.java
@@ -42,8 +42,8 @@ import org.jclouds.cloudfiles.functions.ParseContainerCDNMetadataFromHeaders;
 import org.jclouds.cloudfiles.options.ListCdnContainerOptions;
 import org.jclouds.cloudfiles.reference.CloudFilesHeaders;
 import org.jclouds.openstack.filters.AuthenticateRequest;
-import org.jclouds.openstack.swift.CommonSwiftAsyncClient;
 import org.jclouds.openstack.swift.Storage;
+import org.jclouds.openstack.swift.SwiftAsyncClient;
 import org.jclouds.rest.annotations.BinderParam;
 import org.jclouds.rest.annotations.Endpoint;
 import org.jclouds.rest.annotations.Fallback;
@@ -67,7 +67,7 @@ import com.google.common.util.concurrent.ListenableFuture;
  */
 @RequestFilters(AuthenticateRequest.class)
 @Endpoint(Storage.class)
-public interface CloudFilesAsyncClient extends CommonSwiftAsyncClient {
+public interface CloudFilesAsyncClient extends SwiftAsyncClient {
 
    /**
     * @see CloudFilesClient#listCDNContainers

--- a/apis/cloudfiles/src/main/java/org/jclouds/cloudfiles/CloudFilesClient.java
+++ b/apis/cloudfiles/src/main/java/org/jclouds/cloudfiles/CloudFilesClient.java
@@ -20,9 +20,10 @@ package org.jclouds.cloudfiles;
 
 import java.net.URI;
 import java.util.Set;
+
 import org.jclouds.cloudfiles.domain.ContainerCDNMetadata;
 import org.jclouds.cloudfiles.options.ListCdnContainerOptions;
-import org.jclouds.openstack.swift.CommonSwiftClient;
+import org.jclouds.openstack.swift.SwiftClient;
 
 /**
  * Provides access to Cloud Files via their REST API.
@@ -30,7 +31,7 @@ import org.jclouds.openstack.swift.CommonSwiftClient;
  * @author Adrian Cole
  * @see <a href="http://docs.rackspace.com/files/api/v1/cf-devguide/content/index.html">Cloud Files</a>
  */
-public interface CloudFilesClient extends CommonSwiftClient {
+public interface CloudFilesClient extends SwiftClient {
 
    /**
     * Retrieve a list of existing CDN-enabled containers.

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/SwiftKeystoneAsyncClient.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/SwiftKeystoneAsyncClient.java
@@ -29,6 +29,6 @@ import org.jclouds.rest.annotations.RequestFilters;
  */
 @RequestFilters(AuthenticateRequest.class)
 @Endpoint(Storage.class)
-public interface SwiftKeystoneAsyncClient extends CommonSwiftAsyncClient {
+public interface SwiftKeystoneAsyncClient extends SwiftAsyncClient {
 
 }

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/SwiftKeystoneClient.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/SwiftKeystoneClient.java
@@ -23,6 +23,6 @@ package org.jclouds.openstack.swift;
  * 
  * @author Adrian Cole
  */
-public interface SwiftKeystoneClient extends CommonSwiftClient {
+public interface SwiftKeystoneClient extends SwiftClient {
 
 }


### PR DESCRIPTION
This fixes problems like 

```
java.lang.IllegalArgumentException: backend type: org.jclouds.rest.RestContext<org.jclouds.cloudfiles.CloudFilesClient, org.jclouds.cloudfiles.CloudFilesAsyncClient> not assignable from org.jclouds.rest.RestContext<? extends org.jclouds.openstack.swift.SwiftClient, ? extends org.jclouds.openstack.swift.SwiftAsyncClient>
```

when trying to use the BlobStore with Swift/Cloud Files.
