### PR TITLE
RedirectionRetryHandler ignored PROPERTY_MAX_REDIRECTS on backoff

### DIFF
--- a/apis/deltacloud/src/test/java/org/jclouds/deltacloud/handlers/DeltacloudRedirectionRetryHandlerTest.java
+++ b/apis/deltacloud/src/test/java/org/jclouds/deltacloud/handlers/DeltacloudRedirectionRetryHandlerTest.java
@@ -67,6 +67,7 @@ public class DeltacloudRedirectionRetryHandlerTest {
       HttpRequest request = HttpRequest.builder().method("GET").endpoint("http://localhost").build();
       HttpResponse response = HttpResponse.builder().statusCode(302).message("HTTP/1.1 302 Found").build();
 
+      expect(command.isReplayable()).andReturn(true);
       expect(command.getCurrentRequest()).andReturn(request).atLeastOnce();
       expect(command.incrementRedirectCount()).andReturn(1);
 

--- a/core/src/test/java/org/jclouds/http/handlers/RedirectionRetryHandlerTest.java
+++ b/core/src/test/java/org/jclouds/http/handlers/RedirectionRetryHandlerTest.java
@@ -59,6 +59,7 @@ public class RedirectionRetryHandlerTest {
                                           .statusCode(302)
                                           .message("HTTP/1.1 302 Found").build();
 
+      expect(command.isReplayable()).andReturn(true);
       expect(command.incrementRedirectCount()).andReturn(0);
 
       replay(command);
@@ -80,7 +81,8 @@ public class RedirectionRetryHandlerTest {
                                           .message("HTTP/1.1 302 Found")
                                           .addHeader(LOCATION, "/api/v0.8b-ext2.5/Error.aspx?aspxerrorpath=/api/v0.8b-ext2.5/org.svc/1906645").build(); 
 
-      expect(command.incrementRedirectCount()).andReturn(5);
+      expect(command.isReplayable()).andReturn(true);
+      expect(command.incrementRedirectCount()).andReturn(6);
 
       replay(command);
 
@@ -174,6 +176,7 @@ public class RedirectionRetryHandlerTest {
    protected void verifyRedirectRoutes(HttpRequest request, HttpResponse response, HttpRequest expected) {
       HttpCommand command = createMock(HttpCommand.class);
 
+      expect(command.isReplayable()).andReturn(true);
       expect(command.incrementRedirectCount()).andReturn(0);
       expect(command.getCurrentRequest()).andReturn(request);
       command.setCurrentRequest(expected);


### PR DESCRIPTION
RedirectionRetryHandler ignored PROPERTY_MAX_REDIRECTS on backoff and instead used PROPERTY_MAX_RETRIES. In fixing this, I also cleaned up the code a bit.
