### PR TITLE
Virtual machine nameLabel property is mandatory

### DIFF
--- a/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/cloud/VirtualMachine.java
+++ b/labs/abiquo/src/main/java/org/jclouds/abiquo/domain/cloud/VirtualMachine.java
@@ -612,7 +612,7 @@ public class VirtualMachine extends DomainWithTasksWrapper<VirtualMachineWithNod
       }
 
       public Builder nameLabel(final String nameLabel) {
-         this.nameLabel = nameLabel;
+         this.nameLabel = checkNotNull(nameLabel, "nameLabel must not be null");
          return this;
       }
 
@@ -683,7 +683,7 @@ public class VirtualMachine extends DomainWithTasksWrapper<VirtualMachineWithNod
 
       public VirtualMachine build() {
          VirtualMachineWithNodeExtendedDto dto = new VirtualMachineWithNodeExtendedDto();
-         dto.setNodeName(nameLabel);
+         dto.setNodeName(checkNotNull(nameLabel, ValidationErrors.MISSING_REQUIRED_FIELD + "nameLabel"));
          dto.setDescription(description);
          dto.setHdInBytes(template.getHdRequired());
          dto.setVdrpIP(vncAddress);

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/cloud/VirtualMachineTest.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/cloud/VirtualMachineTest.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.abiquo.domain.cloud;
+
+import org.easymock.EasyMock;
+import org.jclouds.abiquo.AbiquoContext;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for the {@link VirtualMachine} class.
+ * 
+ * @author Ignasi Barrera
+ */
+@Test(groups = "unit", testName = "VirtualMachineTest")
+public class VirtualMachineTest {
+
+   @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "Missing required field nameLabel")
+   public void testNameLabelIsMandatory() {
+      AbiquoContext context = EasyMock.createMock(AbiquoContext.class);
+      VirtualAppliance vapp = EasyMock.createMock(VirtualAppliance.class);
+      VirtualMachineTemplate template = EasyMock.createMock(VirtualMachineTemplate.class);
+
+      VirtualMachine.builder(context.getApiContext(), vapp, template).build();
+   }
+}

--- a/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/event/EventLiveApiTest.java
+++ b/labs/abiquo/src/test/java/org/jclouds/abiquo/domain/event/EventLiveApiTest.java
@@ -230,7 +230,8 @@ public class EventLiveApiTest extends BaseAbiquoApiLiveApiTest {
 
    private VirtualMachine createVirtualMachine() {
       VirtualMachine virtualMachine = VirtualMachine
-            .builder(env.context.getApiContext(), env.virtualAppliance, env.template).cpu(2).ram(128).build();
+            .builder(env.context.getApiContext(), env.virtualAppliance, env.template).cpu(2).ram(128)
+            .nameLabel(PREFIX + "events").build();
 
       virtualMachine.save();
       assertNotNull(virtualMachine.getId());


### PR DESCRIPTION
Virtual machine nameLabel property is mandatory; make sure jclouds does not allow to create a VirtualMachine object without it.
