### PR TITLE
synchronized naming of route53 with aws sdk

### DIFF
--- a/apis/route53/src/main/java/org/jclouds/route53/Route53Api.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/Route53Api.java
@@ -22,8 +22,8 @@ import javax.ws.rs.PathParam;
 
 import org.jclouds.rest.annotations.Delegate;
 import org.jclouds.route53.domain.Change;
-import org.jclouds.route53.features.RecordSetApi;
-import org.jclouds.route53.features.ZoneApi;
+import org.jclouds.route53.features.ResourceRecordSetApi;
+import org.jclouds.route53.features.HostedZoneApi;
 
 /**
  * Provides access to Amazon Route53 via the Query API
@@ -49,11 +49,11 @@ public interface Route53Api {
     * Provides synchronous access to Zone features.
     */
    @Delegate
-   ZoneApi getZoneApi();
+   HostedZoneApi getHostedZoneApi();
    
    /**
     * Provides synchronous access to record set features.
     */
    @Delegate
-   RecordSetApi getRecordSetApiForZone(@PathParam("zoneId") String zoneId);
+   ResourceRecordSetApi getResourceRecordSetApiForHostedZone(@PathParam("zoneId") String zoneId);
 }

--- a/apis/route53/src/main/java/org/jclouds/route53/Route53AsyncApi.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/Route53AsyncApi.java
@@ -30,8 +30,8 @@ import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.VirtualHost;
 import org.jclouds.rest.annotations.XMLResponseParser;
 import org.jclouds.route53.domain.Change;
-import org.jclouds.route53.features.RecordSetAsyncApi;
-import org.jclouds.route53.features.ZoneAsyncApi;
+import org.jclouds.route53.features.ResourceRecordSetAsyncApi;
+import org.jclouds.route53.features.HostedZoneAsyncApi;
 import org.jclouds.route53.filters.RestAuthentication;
 import org.jclouds.route53.xml.ChangeHandler;
 
@@ -64,11 +64,11 @@ public interface Route53AsyncApi {
     * Provides asynchronous access to Zone features.
     */
    @Delegate
-   ZoneAsyncApi getZoneApi();
+   HostedZoneAsyncApi getHostedZoneApi();
 
    /**
     * Provides asynchronous access to record set features.
     */
    @Delegate
-   RecordSetAsyncApi getRecordSetApiForZone(@PathParam("zoneId") String zoneId);
+   ResourceRecordSetAsyncApi getResourceRecordSetApiForHostedZone(@PathParam("zoneId") String zoneId);
 }

--- a/apis/route53/src/main/java/org/jclouds/route53/binders/BindNextRecord.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/binders/BindNextRecord.java
@@ -23,7 +23,7 @@ import javax.inject.Singleton;
 import org.jclouds.http.HttpRequest;
 import org.jclouds.http.HttpRequest.Builder;
 import org.jclouds.rest.Binder;
-import org.jclouds.route53.domain.RecordSetIterable.NextRecord;
+import org.jclouds.route53.domain.ResourceRecordSetIterable.NextRecord;
 
 /**
  * 

--- a/apis/route53/src/main/java/org/jclouds/route53/config/Route53RestClientModule.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/config/Route53RestClientModule.java
@@ -36,10 +36,10 @@ import org.jclouds.rest.ConfiguresRestClient;
 import org.jclouds.rest.RequestSigner;
 import org.jclouds.route53.Route53Api;
 import org.jclouds.route53.Route53AsyncApi;
-import org.jclouds.route53.features.RecordSetApi;
-import org.jclouds.route53.features.RecordSetAsyncApi;
-import org.jclouds.route53.features.ZoneApi;
-import org.jclouds.route53.features.ZoneAsyncApi;
+import org.jclouds.route53.features.ResourceRecordSetApi;
+import org.jclouds.route53.features.ResourceRecordSetAsyncApi;
+import org.jclouds.route53.features.HostedZoneApi;
+import org.jclouds.route53.features.HostedZoneAsyncApi;
 import org.jclouds.route53.filters.RestAuthentication;
 import org.jclouds.route53.handlers.Route53ErrorHandler;
 
@@ -54,8 +54,8 @@ import com.google.inject.Provides;
 @ConfiguresRestClient
 public class Route53RestClientModule extends AWSRestClientModule<Route53Api, Route53AsyncApi> {
    public static final Map<Class<?>, Class<?>> DELEGATE_MAP = ImmutableMap.<Class<?>, Class<?>> builder()//
-         .put(ZoneApi.class, ZoneAsyncApi.class)
-         .put(RecordSetApi.class, RecordSetAsyncApi.class).build();
+         .put(HostedZoneApi.class, HostedZoneAsyncApi.class)
+         .put(ResourceRecordSetApi.class, ResourceRecordSetAsyncApi.class).build();
 
    public Route53RestClientModule() {
       super(typeToken(Route53Api.class), typeToken(Route53AsyncApi.class), DELEGATE_MAP);

--- a/apis/route53/src/main/java/org/jclouds/route53/domain/ChangeBatch.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/domain/ChangeBatch.java
@@ -38,11 +38,11 @@ import com.google.common.collect.ImmutableList;
  */
 public class ChangeBatch extends ForwardingList<ActionOnResourceRecordSet> {
 
-   public static ChangeBatch createAll(Iterable<RecordSet> toCreate) {
+   public static ChangeBatch createAll(Iterable<ResourceRecordSet> toCreate) {
       return builder().createAll(toCreate).build();
    }
 
-   public static ChangeBatch deleteAll(Iterable<RecordSet> toDelete) {
+   public static ChangeBatch deleteAll(Iterable<ResourceRecordSet> toDelete) {
       return builder().deleteAll(toDelete).build();
    }
 
@@ -55,9 +55,9 @@ public class ChangeBatch extends ForwardingList<ActionOnResourceRecordSet> {
 
    public static class ActionOnResourceRecordSet {
       private final Action action;
-      private final RecordSet rrs;
+      private final ResourceRecordSet rrs;
 
-      private ActionOnResourceRecordSet(Action action, RecordSet rrs) {
+      private ActionOnResourceRecordSet(Action action, ResourceRecordSet rrs) {
          this.action = action;
          this.rrs = rrs;
       }
@@ -66,7 +66,7 @@ public class ChangeBatch extends ForwardingList<ActionOnResourceRecordSet> {
          return action;
       }
 
-      public RecordSet getRRS() {
+      public ResourceRecordSet getRRS() {
          return rrs;
       }
 
@@ -145,24 +145,24 @@ public class ChangeBatch extends ForwardingList<ActionOnResourceRecordSet> {
          return this;
       }
 
-      public Builder create(RecordSet rrs) {
+      public Builder create(ResourceRecordSet rrs) {
          this.changes.add(new ActionOnResourceRecordSet(Action.CREATE, rrs));
          return this;
       }
 
-      public Builder createAll(Iterable<RecordSet> toCreate) {
-         for (RecordSet rrs : toCreate)
+      public Builder createAll(Iterable<ResourceRecordSet> toCreate) {
+         for (ResourceRecordSet rrs : toCreate)
             create(rrs);
          return this;
       }
 
-      public Builder delete(RecordSet rrs) {
+      public Builder delete(ResourceRecordSet rrs) {
          this.changes.add(new ActionOnResourceRecordSet(Action.DELETE, rrs));
          return this;
       }
 
-      public Builder deleteAll(Iterable<RecordSet> toDelete) {
-         for (RecordSet rrs : toDelete)
+      public Builder deleteAll(Iterable<ResourceRecordSet> toDelete) {
+         for (ResourceRecordSet rrs : toDelete)
             delete(rrs);
          return this;
       }

--- a/apis/route53/src/main/java/org/jclouds/route53/domain/HostedZone.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/domain/HostedZone.java
@@ -29,7 +29,7 @@ import com.google.common.base.Optional;
  * 
  * @author Adrian Cole
  */
-public final class Zone {
+public final class HostedZone {
 
    private final String id;
    private final String name;
@@ -37,7 +37,7 @@ public final class Zone {
    private final int resourceRecordSetCount;
    private final Optional<String> comment;
 
-   private Zone(String id, String name, String callerReference, int resourceRecordSetCount, Optional<String> comment) {
+   private HostedZone(String id, String name, String callerReference, int resourceRecordSetCount, Optional<String> comment) {
       this.id = checkNotNull(id, "id");
       this.name = checkNotNull(name, "name");
       this.callerReference = checkNotNull(callerReference, "callerReference for %s", name);
@@ -67,7 +67,7 @@ public final class Zone {
    }
 
    /**
-    * A percentage value that indicates the size of the policy in packed form.
+    * count of record sets
     */
    public int getResourceRecordSetCount() {
       return resourceRecordSetCount;
@@ -88,7 +88,7 @@ public final class Zone {
          return true;
       if (obj == null || getClass() != obj.getClass())
          return false;
-      Zone that = Zone.class.cast(obj);
+      HostedZone that = HostedZone.class.cast(obj);
       return equal(this.id, that.id) && equal(this.name, that.name)
             && equal(this.callerReference, that.callerReference);
    }
@@ -112,11 +112,11 @@ public final class Zone {
       private String id;
       private String name;
       private String callerReference;
-      private int resourceRecordSetCount = 0;
+      private int resourceRecordSetCount;
       private Optional<String> comment = Optional.absent();
 
       /**
-       * @see Zone#getId()
+       * @see HostedZone#getId()
        */
       public Builder id(String id) {
          this.id = id;
@@ -124,7 +124,7 @@ public final class Zone {
       }
 
       /**
-       * @see Zone#getName()
+       * @see HostedZone#getName()
        */
       public Builder name(String name) {
          this.name = name;
@@ -132,7 +132,7 @@ public final class Zone {
       }
 
       /**
-       * @see Zone#getCallerReference()
+       * @see HostedZone#getCallerReference()
        */
       public Builder callerReference(String callerReference) {
          this.callerReference = callerReference;
@@ -140,7 +140,7 @@ public final class Zone {
       }
 
       /**
-       * @see Zone#getResourceRecordSetCount()
+       * @see HostedZone#getResourceRecordSetCount()
        */
       public Builder resourceRecordSetCount(int resourceRecordSetCount) {
          this.resourceRecordSetCount = resourceRecordSetCount;
@@ -148,18 +148,18 @@ public final class Zone {
       }
 
       /**
-       * @see Zone#getComment()
+       * @see HostedZone#getComment()
        */
       public Builder comment(String comment) {
          this.comment = Optional.fromNullable(comment);
          return this;
       }
 
-      public Zone build() {
-         return new Zone(id, name, callerReference, resourceRecordSetCount, comment);
+      public HostedZone build() {
+         return new HostedZone(id, name, callerReference, resourceRecordSetCount, comment);
       }
 
-      public Builder from(Zone in) {
+      public Builder from(HostedZone in) {
          return this.id(in.id).name(in.name).callerReference(in.callerReference)
                .resourceRecordSetCount(in.resourceRecordSetCount).comment(in.comment.orNull());
       }

--- a/apis/route53/src/main/java/org/jclouds/route53/domain/HostedZoneAndNameServers.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/domain/HostedZoneAndNameServers.java
@@ -29,40 +29,33 @@ import com.google.common.collect.ImmutableList;
  * 
  * @author Adrian Cole
  */
-public final class NewZone {
+public final class HostedZoneAndNameServers {
 
-   private final ZoneAndNameServers zone;
-   private final Change change;
+   private final HostedZone zone;
+   private final ImmutableList<String> nameServers;
 
-   private NewZone(ZoneAndNameServers zone, Change change) {
+   private HostedZoneAndNameServers(HostedZone zone, ImmutableList<String> nameServers) {
       this.zone = checkNotNull(zone, "zone");
-      this.change = checkNotNull(change, "change of %s", zone);
+      this.nameServers = checkNotNull(nameServers, "nameServers for %s", zone);
    }
 
    /**
-    * @see ZoneAndNameServers#getZone()
+    * the hosted zone
     */
-   public Zone getZone() {
-      return zone.getZone();
+   public HostedZone getZone() {
+      return zone;
    }
 
    /**
-    * @see ZoneAndNameServers#getNameServers()
+    * the authoritative name servers for the hosted zone
     */
    public ImmutableList<String> getNameServers() {
-      return zone.getNameServers();
-   }
-
-   /**
-    * the zone creation event
-    */
-   public Change getChange() {
-      return change;
+      return nameServers;
    }
 
    @Override
    public int hashCode() {
-      return Objects.hashCode(zone);
+      return Objects.hashCode(zone, nameServers);
    }
 
    @Override
@@ -71,17 +64,16 @@ public final class NewZone {
          return true;
       if (obj == null || getClass() != obj.getClass())
          return false;
-      NewZone that = NewZone.class.cast(obj);
-      return equal(this.zone, that.zone);
+      HostedZoneAndNameServers that = HostedZoneAndNameServers.class.cast(obj);
+      return equal(this.zone, that.zone) && equal(this.nameServers, that.nameServers);
    }
 
    @Override
    public String toString() {
-      return toStringHelper("").add("zone", zone.getZone()).add("nameServers", zone.getNameServers())
-            .add("change", change).toString();
+      return toStringHelper("").add("zone", zone).add("nameServers", nameServers).toString();
    }
 
-   public static NewZone create(ZoneAndNameServers zone, Change change) {
-      return new NewZone(zone, change);
+   public static HostedZoneAndNameServers create(HostedZone zone, Iterable<String> nameServers) {
+      return new HostedZoneAndNameServers(zone, ImmutableList.<String> copyOf(checkNotNull(nameServers, "nameServers")));
    }
 }

--- a/apis/route53/src/main/java/org/jclouds/route53/domain/NewHostedZone.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/domain/NewHostedZone.java
@@ -29,33 +29,40 @@ import com.google.common.collect.ImmutableList;
  * 
  * @author Adrian Cole
  */
-public final class ZoneAndNameServers {
+public final class NewHostedZone {
 
-   private final Zone zone;
-   private final ImmutableList<String> nameServers;
+   private final HostedZoneAndNameServers zone;
+   private final Change change;
 
-   private ZoneAndNameServers(Zone zone, ImmutableList<String> nameServers) {
+   private NewHostedZone(HostedZoneAndNameServers zone, Change change) {
       this.zone = checkNotNull(zone, "zone");
-      this.nameServers = checkNotNull(nameServers, "nameServers for %s", zone);
+      this.change = checkNotNull(change, "change of %s", zone);
    }
 
    /**
-    * the hosted zone
+    * @see HostedZoneAndNameServers#getZone()
     */
-   public Zone getZone() {
-      return zone;
+   public HostedZone getZone() {
+      return zone.getZone();
    }
 
    /**
-    * the authoritative name servers for the hosted zone
+    * @see HostedZoneAndNameServers#getNameServers()
     */
    public ImmutableList<String> getNameServers() {
-      return nameServers;
+      return zone.getNameServers();
+   }
+
+   /**
+    * the zone creation event
+    */
+   public Change getChange() {
+      return change;
    }
 
    @Override
    public int hashCode() {
-      return Objects.hashCode(zone, nameServers);
+      return Objects.hashCode(zone);
    }
 
    @Override
@@ -64,16 +71,17 @@ public final class ZoneAndNameServers {
          return true;
       if (obj == null || getClass() != obj.getClass())
          return false;
-      ZoneAndNameServers that = ZoneAndNameServers.class.cast(obj);
-      return equal(this.zone, that.zone) && equal(this.nameServers, that.nameServers);
+      NewHostedZone that = NewHostedZone.class.cast(obj);
+      return equal(this.zone, that.zone);
    }
 
    @Override
    public String toString() {
-      return toStringHelper("").add("zone", zone).add("nameServers", nameServers).toString();
+      return toStringHelper("").add("zone", zone.getZone()).add("nameServers", zone.getNameServers())
+            .add("change", change).toString();
    }
 
-   public static ZoneAndNameServers create(Zone zone, Iterable<String> nameServers) {
-      return new ZoneAndNameServers(zone, ImmutableList.<String> copyOf(checkNotNull(nameServers, "nameServers")));
+   public static NewHostedZone create(HostedZoneAndNameServers zone, Change change) {
+      return new NewHostedZone(zone, change);
    }
 }

--- a/apis/route53/src/main/java/org/jclouds/route53/domain/ResourceRecordSetIterable.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/domain/ResourceRecordSetIterable.java
@@ -27,7 +27,6 @@ import java.util.Iterator;
 
 import org.jclouds.collect.IterableWithMarker;
 import org.jclouds.javax.annotation.Nullable;
-import org.jclouds.route53.domain.RecordSet.Type;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
@@ -37,12 +36,12 @@ import com.google.common.collect.ImmutableList;
  * 
  * @author Adrian Cole
  */
-public class RecordSetIterable extends IterableWithMarker<RecordSet> {
+public class ResourceRecordSetIterable extends IterableWithMarker<ResourceRecordSet> {
 
-   private final Iterable<RecordSet> items;
+   private final Iterable<ResourceRecordSet> items;
    private final Optional<NextRecord> nextRecord;
 
-   private RecordSetIterable(Iterable<RecordSet> items, @Nullable NextRecord nextRecord) {
+   private ResourceRecordSetIterable(Iterable<ResourceRecordSet> items, @Nullable NextRecord nextRecord) {
       this.items = checkNotNull(items, "items");
       this.nextRecord = Optional.fromNullable(nextRecord);
    }
@@ -61,7 +60,7 @@ public class RecordSetIterable extends IterableWithMarker<RecordSet> {
    }
 
    @Override
-   public Iterator<RecordSet> iterator() {
+   public Iterator<ResourceRecordSet> iterator() {
       return items.iterator();
    }
 
@@ -76,7 +75,7 @@ public class RecordSetIterable extends IterableWithMarker<RecordSet> {
          return true;
       if (obj == null || getClass() != obj.getClass())
          return false;
-      RecordSetIterable that = RecordSetIterable.class.cast(obj);
+      ResourceRecordSetIterable that = ResourceRecordSetIterable.class.cast(obj);
       return equal(this.items, that.items) && equal(this.nextRecord, that.nextRecord);
    }
 
@@ -89,19 +88,19 @@ public class RecordSetIterable extends IterableWithMarker<RecordSet> {
     * If the results were truncated, this holds the position of the next item.
     */
    public static class NextRecord {
-      public static NextRecord nameAndType(String name, Type type) {
+      public static NextRecord nameAndType(String name, String type) {
          return new NextRecord(name, type, null);
       }
 
-      public static NextRecord nameTypeAndIdentifier(String name, Type type, String identifier) {
+      public static NextRecord nameTypeAndIdentifier(String name, String type, String identifier) {
          return new NextRecord(name, type, identifier);
       }
 
       private final String name;
-      private final Type type;
+      private final String type;
       private final Optional<String> identifier;
 
-      private NextRecord(String name, Type type, String identifier) {
+      private NextRecord(String name, String type, String identifier) {
          this.name = checkNotNull(name, "name");
          this.type = checkNotNull(type, "type for %s", name);
          this.identifier = Optional.fromNullable(identifier);
@@ -117,7 +116,7 @@ public class RecordSetIterable extends IterableWithMarker<RecordSet> {
       /**
        * the type of the next record in the list.
        */
-      public Type getType() {
+      public String getType() {
          return type;
       }
 
@@ -157,17 +156,17 @@ public class RecordSetIterable extends IterableWithMarker<RecordSet> {
 
    public static final class Builder {
 
-      private ImmutableList.Builder<RecordSet> items = ImmutableList.<RecordSet> builder();
+      private ImmutableList.Builder<ResourceRecordSet> items = ImmutableList.<ResourceRecordSet> builder();
       private String nextRecordName;
-      private Type nextRecordType;
+      private String nextRecordType;
       private String nextRecordIdentifier;
 
-      public Builder add(RecordSet item) {
+      public Builder add(ResourceRecordSet item) {
          this.items.add(item);
          return this;
       }
 
-      public Builder addAll(Iterable<RecordSet> items) {
+      public Builder addAll(Iterable<ResourceRecordSet> items) {
          this.items.addAll(items);
          return this;
       }
@@ -177,7 +176,7 @@ public class RecordSetIterable extends IterableWithMarker<RecordSet> {
          return this;
       }
 
-      public Builder nextRecordType(Type nextRecordType) {
+      public Builder nextRecordType(String nextRecordType) {
          this.nextRecordType = nextRecordType;
          return this;
       }
@@ -187,10 +186,10 @@ public class RecordSetIterable extends IterableWithMarker<RecordSet> {
          return this;
       }
 
-      public RecordSetIterable build() {
+      public ResourceRecordSetIterable build() {
          NextRecord nextRecord = nextRecordName != null ? new NextRecord(nextRecordName, nextRecordType,
                nextRecordIdentifier) : null;
-         return new RecordSetIterable(items.build(), nextRecord);
+         return new ResourceRecordSetIterable(items.build(), nextRecord);
       }
    }
 }

--- a/apis/route53/src/main/java/org/jclouds/route53/features/HostedZoneApi.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/features/HostedZoneApi.java
@@ -23,18 +23,18 @@ import org.jclouds.collect.PagedIterable;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.route53.domain.Change;
 import org.jclouds.route53.domain.Change.Status;
-import org.jclouds.route53.domain.NewZone;
-import org.jclouds.route53.domain.Zone;
-import org.jclouds.route53.domain.ZoneAndNameServers;
+import org.jclouds.route53.domain.HostedZone;
+import org.jclouds.route53.domain.HostedZoneAndNameServers;
+import org.jclouds.route53.domain.NewHostedZone;
 
 /**
- * @see ZoneAsyncApi
+ * @see HostedZoneAsyncApi
  * @see <a href=
  *      "http://docs.aws.amazon.com/Route53/latest/APIReference/ActionsOnHostedZones.html"
  *      />
  * @author Adrian Cole
  */
-public interface ZoneApi {
+public interface HostedZoneApi {
 
    /**
     * This action creates a new hosted zone.
@@ -51,28 +51,28 @@ public interface ZoneApi {
     *           retries. ex. {@code MyDNSMigration_01}
     * @return the new zone in progress, in {@link Status#PENDING}.
     */
-   NewZone createWithReference(String name, String callerReference);
+   NewHostedZone createWithReference(String name, String callerReference);
 
    /**
     * like {@link #createWithReference(String, String)}, except you can specify
     * a comment.
     */
-   NewZone createWithReferenceAndComment(String name, String callerReference, String comment);
+   NewHostedZone createWithReferenceAndComment(String name, String callerReference, String comment);
 
    /**
     * returns all zones in order.
     */
-   PagedIterable<Zone> list();
+   PagedIterable<HostedZone> list();
 
    /**
     * retrieves up to 100 zones in order.
     */
-   IterableWithMarker<Zone> listFirstPage();
+   IterableWithMarker<HostedZone> listFirstPage();
 
    /**
     * retrieves up to 100 zones in order, starting at {@code nextMarker}
     */
-   IterableWithMarker<Zone> listAt(String nextMarker);
+   IterableWithMarker<HostedZone> listAt(String nextMarker);
 
    /**
     * Retrieves information about the specified zone, including its nameserver
@@ -84,7 +84,7 @@ public interface ZoneApi {
     * @return null if not found
     */
    @Nullable
-   ZoneAndNameServers get(String id);
+   HostedZoneAndNameServers get(String id);
 
    /**
     * This action deletes a hosted zone.

--- a/apis/route53/src/main/java/org/jclouds/route53/features/HostedZoneAsyncApi.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/features/HostedZoneAsyncApi.java
@@ -40,11 +40,11 @@ import org.jclouds.rest.annotations.Transform;
 import org.jclouds.rest.annotations.VirtualHost;
 import org.jclouds.rest.annotations.XMLResponseParser;
 import org.jclouds.route53.domain.Change;
-import org.jclouds.route53.domain.NewZone;
-import org.jclouds.route53.domain.Zone;
-import org.jclouds.route53.domain.ZoneAndNameServers;
+import org.jclouds.route53.domain.HostedZone;
+import org.jclouds.route53.domain.HostedZoneAndNameServers;
+import org.jclouds.route53.domain.NewHostedZone;
 import org.jclouds.route53.filters.RestAuthentication;
-import org.jclouds.route53.functions.ZonesToPagedIterable;
+import org.jclouds.route53.functions.HostedZonesToPagedIterable;
 import org.jclouds.route53.xml.ChangeHandler;
 import org.jclouds.route53.xml.CreateHostedZoneResponseHandler;
 import org.jclouds.route53.xml.GetHostedZoneResponseHandler;
@@ -53,7 +53,7 @@ import org.jclouds.route53.xml.ListHostedZonesResponseHandler;
 import com.google.common.util.concurrent.ListenableFuture;
 
 /**
- * @see ZoneApi
+ * @see HostedZoneApi
  * @see <a href=
  *      "http://docs.aws.amazon.com/Route53/latest/APIReference/ActionsOnHostedZones.html"
  *      />
@@ -62,9 +62,9 @@ import com.google.common.util.concurrent.ListenableFuture;
 @RequestFilters(RestAuthentication.class)
 @VirtualHost
 @Path("/{jclouds.api-version}")
-public interface ZoneAsyncApi {
+public interface HostedZoneAsyncApi {
    /**
-    * @see ZoneApi#createWithReference
+    * @see HostedZoneApi#createWithReference
     */
    @Named("CreateHostedZone")
    @POST
@@ -72,11 +72,11 @@ public interface ZoneAsyncApi {
    @Path("/hostedzone")
    @Payload("<CreateHostedZoneRequest xmlns=\"https://route53.amazonaws.com/doc/2012-02-29/\"><Name>{name}</Name><CallerReference>{callerReference}</CallerReference></CreateHostedZoneRequest>")
    @XMLResponseParser(CreateHostedZoneResponseHandler.class)
-   ListenableFuture<NewZone> createWithReference(@PayloadParam("name") String name,
+   ListenableFuture<NewHostedZone> createWithReference(@PayloadParam("name") String name,
          @PayloadParam("callerReference") String callerReference);
 
    /**
-    * @see ZoneApi#createWithReferenceAndComment
+    * @see HostedZoneApi#createWithReferenceAndComment
     */
    @Named("CreateHostedZone")
    @POST
@@ -84,49 +84,49 @@ public interface ZoneAsyncApi {
    @Path("/hostedzone")
    @Payload("<CreateHostedZoneRequest xmlns=\"https://route53.amazonaws.com/doc/2012-02-29/\"><Name>{name}</Name><CallerReference>{callerReference}</CallerReference><HostedZoneConfig><Comment>{comment}</Comment></HostedZoneConfig></CreateHostedZoneRequest>")
    @XMLResponseParser(CreateHostedZoneResponseHandler.class)
-   ListenableFuture<NewZone> createWithReferenceAndComment(@PayloadParam("name") String name,
+   ListenableFuture<NewHostedZone> createWithReferenceAndComment(@PayloadParam("name") String name,
          @PayloadParam("callerReference") String callerReference, @PayloadParam("comment") String comment);
 
    /**
-    * @see ZoneApi#list()
+    * @see HostedZoneApi#list()
     */
    @Named("ListHostedZones")
    @GET
    @Path("/hostedzone")
    @XMLResponseParser(ListHostedZonesResponseHandler.class)
-   @Transform(ZonesToPagedIterable.class)
-   ListenableFuture<PagedIterable<Zone>> list();
+   @Transform(HostedZonesToPagedIterable.class)
+   ListenableFuture<PagedIterable<HostedZone>> list();
 
    /**
-    * @see ZoneApi#listFirstPage
+    * @see HostedZoneApi#listFirstPage
     */
    @Named("ListHostedZones")
    @GET
    @Path("/hostedzone")
    @XMLResponseParser(ListHostedZonesResponseHandler.class)
-   ListenableFuture<IterableWithMarker<Zone>> listFirstPage();
+   ListenableFuture<IterableWithMarker<HostedZone>> listFirstPage();
 
    /**
-    * @see ZoneApi#listAt(String)
+    * @see HostedZoneApi#listAt(String)
     */
    @Named("ListHostedZones")
    @GET
    @Path("/hostedzone")
    @XMLResponseParser(ListHostedZonesResponseHandler.class)
-   ListenableFuture<IterableWithMarker<Zone>> listAt(@QueryParam("marker") String nextMarker);
+   ListenableFuture<IterableWithMarker<HostedZone>> listAt(@QueryParam("marker") String nextMarker);
 
    /**
-    * @see ZoneApi#get()
+    * @see HostedZoneApi#get()
     */
    @Named("GetHostedZone")
    @GET
    @Path("/hostedzone/{zoneId}")
    @XMLResponseParser(GetHostedZoneResponseHandler.class)
    @Fallback(NullOnNotFoundOr404.class)
-   ListenableFuture<ZoneAndNameServers> get(@PathParam("zoneId") String zoneId);
+   ListenableFuture<HostedZoneAndNameServers> get(@PathParam("zoneId") String zoneId);
 
    /**
-    * @see ZoneApi#delete()
+    * @see HostedZoneApi#delete()
     */
    @Named("DeleteHostedZone")
    @DELETE

--- a/apis/route53/src/main/java/org/jclouds/route53/features/ResourceRecordSetApi.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/features/ResourceRecordSetApi.java
@@ -22,23 +22,23 @@ import org.jclouds.collect.PagedIterable;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.route53.domain.Change;
 import org.jclouds.route53.domain.ChangeBatch;
-import org.jclouds.route53.domain.RecordSet;
-import org.jclouds.route53.domain.RecordSetIterable;
-import org.jclouds.route53.domain.RecordSetIterable.NextRecord;
+import org.jclouds.route53.domain.ResourceRecordSet;
+import org.jclouds.route53.domain.ResourceRecordSetIterable;
+import org.jclouds.route53.domain.ResourceRecordSetIterable.NextRecord;
 
 /**
- * @see RecordSetAsyncApi
+ * @see ResourceRecordSetAsyncApi
  * @see <a href=
  *      "http://docs.aws.amazon.com/Route53/latest/APIReference/ActionsOnRRS.html"
  *      />
  * @author Adrian Cole
  */
-public interface RecordSetApi {
+public interface ResourceRecordSetApi {
 
    /**
     * schedules creation of the resource record set.
     */
-   Change create(RecordSet rrs);
+   Change create(ResourceRecordSet rrs);
 
    /**
     * applies a batch of changes atomically.
@@ -48,18 +48,18 @@ public interface RecordSetApi {
    /**
     * returns all resource record sets in order.
     */
-   PagedIterable<RecordSet> list();
+   PagedIterable<ResourceRecordSet> list();
 
    /**
     * retrieves up to 100 resource record sets in order.
     */
-   RecordSetIterable listFirstPage();
+   ResourceRecordSetIterable listFirstPage();
 
    /**
     * retrieves up to 100 resource record sets in order, starting at
     * {@code nextRecord}
     */
-   RecordSetIterable listAt(NextRecord nextRecord);
+   ResourceRecordSetIterable listAt(NextRecord nextRecord);
 
    /**
     * This action deletes a resource record set.
@@ -69,5 +69,5 @@ public interface RecordSetApi {
     * @return null if not found or the change in progress
     */
    @Nullable
-   Change delete(RecordSet rrs);
+   Change delete(ResourceRecordSet rrs);
 }

--- a/apis/route53/src/main/java/org/jclouds/route53/features/ResourceRecordSetAsyncApi.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/features/ResourceRecordSetAsyncApi.java
@@ -41,11 +41,11 @@ import org.jclouds.route53.binders.BindChangeBatch;
 import org.jclouds.route53.binders.BindNextRecord;
 import org.jclouds.route53.domain.Change;
 import org.jclouds.route53.domain.ChangeBatch;
-import org.jclouds.route53.domain.RecordSet;
-import org.jclouds.route53.domain.RecordSetIterable;
-import org.jclouds.route53.domain.RecordSetIterable.NextRecord;
+import org.jclouds.route53.domain.ResourceRecordSet;
+import org.jclouds.route53.domain.ResourceRecordSetIterable;
+import org.jclouds.route53.domain.ResourceRecordSetIterable.NextRecord;
 import org.jclouds.route53.filters.RestAuthentication;
-import org.jclouds.route53.functions.RecordSetIterableToPagedIterable;
+import org.jclouds.route53.functions.ResourceRecordSetIterableToPagedIterable;
 import org.jclouds.route53.functions.SerializeRRS;
 import org.jclouds.route53.xml.ChangeHandler;
 import org.jclouds.route53.xml.ListResourceRecordSetsResponseHandler;
@@ -53,7 +53,7 @@ import org.jclouds.route53.xml.ListResourceRecordSetsResponseHandler;
 import com.google.common.util.concurrent.ListenableFuture;
 
 /**
- * @see RecordSetApi
+ * @see ResourceRecordSetApi
  * @see <a href=
  *      "http://docs.aws.amazon.com/Route53/latest/APIReference/ActionsOnRRS.html"
  *      />
@@ -62,9 +62,9 @@ import com.google.common.util.concurrent.ListenableFuture;
 @RequestFilters(RestAuthentication.class)
 @VirtualHost
 @Path("/{jclouds.api-version}/hostedzone/{zoneId}")
-public interface RecordSetAsyncApi {
+public interface ResourceRecordSetAsyncApi {
    /**
-    * @see RecordSetApi#create
+    * @see ResourceRecordSetApi#create
     */
    @Named("ChangeResourceRecordSets")
    @POST
@@ -72,10 +72,10 @@ public interface RecordSetAsyncApi {
    @Path("/rrset")
    @Payload("<ChangeResourceRecordSetsRequest xmlns=\"https://route53.amazonaws.com/doc/2012-02-29/\"><ChangeBatch><Changes><Change><Action>CREATE</Action>{rrs}</Change></Changes></ChangeBatch></ChangeResourceRecordSetsRequest>")
    @XMLResponseParser(ChangeHandler.class)
-   ListenableFuture<Change> create(@PayloadParam("rrs") @ParamParser(SerializeRRS.class) RecordSet rrs);
+   ListenableFuture<Change> create(@PayloadParam("rrs") @ParamParser(SerializeRRS.class) ResourceRecordSet rrs);
    
    /**
-    * @see RecordSetApi#apply
+    * @see ResourceRecordSetApi#apply
     */
    @Named("ChangeResourceRecordSets")
    @POST
@@ -85,35 +85,35 @@ public interface RecordSetAsyncApi {
    ListenableFuture<Change> apply(@BinderParam(BindChangeBatch.class) ChangeBatch changes);
 
    /**
-    * @see RecordSetApi#list()
+    * @see ResourceRecordSetApi#list()
     */
    @Named("ListResourceRecordSets")
    @GET
    @Path("/rrset")
    @XMLResponseParser(ListResourceRecordSetsResponseHandler.class)
-   @Transform(RecordSetIterableToPagedIterable.class)
-   ListenableFuture<PagedIterable<RecordSet>> list();
+   @Transform(ResourceRecordSetIterableToPagedIterable.class)
+   ListenableFuture<PagedIterable<ResourceRecordSet>> list();
 
    /**
-    * @see RecordSetApi#listFirstPage
+    * @see ResourceRecordSetApi#listFirstPage
     */
    @Named("ListResourceRecordSets")
    @GET
    @Path("/rrset")
    @XMLResponseParser(ListResourceRecordSetsResponseHandler.class)
-   ListenableFuture<RecordSetIterable> listFirstPage();
+   ListenableFuture<ResourceRecordSetIterable> listFirstPage();
 
    /**
-    * @see RecordSetApi#listAt(NextRecord)
+    * @see ResourceRecordSetApi#listAt(NextRecord)
     */
    @Named("ListResourceRecordSets")
    @GET
    @Path("/rrset")
    @XMLResponseParser(ListResourceRecordSetsResponseHandler.class)
-   ListenableFuture<RecordSetIterable> listAt(@BinderParam(BindNextRecord.class) NextRecord nextRecord);
+   ListenableFuture<ResourceRecordSetIterable> listAt(@BinderParam(BindNextRecord.class) NextRecord nextRecord);
 
    /**
-    * @see RecordSetApi#delete
+    * @see ResourceRecordSetApi#delete
     */
    @Named("ChangeResourceRecordSets")
    @POST
@@ -122,5 +122,5 @@ public interface RecordSetAsyncApi {
    @Payload("<ChangeResourceRecordSetsRequest xmlns=\"https://route53.amazonaws.com/doc/2012-02-29/\"><ChangeBatch><Changes><Change><Action>DELETE</Action>{rrs}</Change></Changes></ChangeBatch></ChangeResourceRecordSetsRequest>")
    @XMLResponseParser(ChangeHandler.class)
    @Fallback(NullOnNotFoundOr404.class)
-   ListenableFuture<Change> delete(@PayloadParam("rrs") @ParamParser(SerializeRRS.class) RecordSet rrs);
+   ListenableFuture<Change> delete(@PayloadParam("rrs") @ParamParser(SerializeRRS.class) ResourceRecordSet rrs);
 }

--- a/apis/route53/src/main/java/org/jclouds/route53/functions/HostedZonesToPagedIterable.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/functions/HostedZonesToPagedIterable.java
@@ -25,9 +25,8 @@ import javax.inject.Inject;
 import org.jclouds.collect.IterableWithMarker;
 import org.jclouds.collect.internal.CallerArg0ToPagedIterable;
 import org.jclouds.route53.Route53Api;
-import org.jclouds.route53.domain.RecordSet;
-import org.jclouds.route53.domain.RecordSetIterable.NextRecord;
-import org.jclouds.route53.features.RecordSetApi;
+import org.jclouds.route53.domain.HostedZone;
+import org.jclouds.route53.features.HostedZoneApi;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Function;
@@ -36,29 +35,28 @@ import com.google.common.base.Function;
  * @author Adrian Cole
  */
 @Beta
-public class RecordSetIterableToPagedIterable extends
-      CallerArg0ToPagedIterable<RecordSet, RecordSetIterableToPagedIterable> {
+public class HostedZonesToPagedIterable extends CallerArg0ToPagedIterable<HostedZone, HostedZonesToPagedIterable> {
 
    private final Route53Api api;
 
    @Inject
-   protected RecordSetIterableToPagedIterable(Route53Api api) {
+   protected HostedZonesToPagedIterable(Route53Api api) {
       this.api = checkNotNull(api, "api");
    }
 
    @Override
-   protected Function<Object, IterableWithMarker<RecordSet>> markerToNextForCallingArg0(String zoneId) {
-      final RecordSetApi resourceRecordSetApi = api.getRecordSetApiForZone(zoneId);
-      return new Function<Object, IterableWithMarker<RecordSet>>() {
+   protected Function<Object, IterableWithMarker<HostedZone>> markerToNextForCallingArg0(String ignored) {
+      final HostedZoneApi zoneApi = api.getHostedZoneApi();
+      return new Function<Object, IterableWithMarker<HostedZone>>() {
 
          @Override
-         public IterableWithMarker<RecordSet> apply(Object input) {
-            return resourceRecordSetApi.listAt(NextRecord.class.cast(input));
+         public IterableWithMarker<HostedZone> apply(Object input) {
+            return zoneApi.listAt(input.toString());
          }
 
          @Override
          public String toString() {
-            return "listResourceRecordSets()";
+            return "listHostedZones()";
          }
       };
    }

--- a/apis/route53/src/main/java/org/jclouds/route53/functions/ResourceRecordSetIterableToPagedIterable.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/functions/ResourceRecordSetIterableToPagedIterable.java
@@ -25,8 +25,9 @@ import javax.inject.Inject;
 import org.jclouds.collect.IterableWithMarker;
 import org.jclouds.collect.internal.CallerArg0ToPagedIterable;
 import org.jclouds.route53.Route53Api;
-import org.jclouds.route53.domain.Zone;
-import org.jclouds.route53.features.ZoneApi;
+import org.jclouds.route53.domain.ResourceRecordSet;
+import org.jclouds.route53.domain.ResourceRecordSetIterable.NextRecord;
+import org.jclouds.route53.features.ResourceRecordSetApi;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Function;
@@ -35,30 +36,30 @@ import com.google.common.base.Function;
  * @author Adrian Cole
  */
 @Beta
-public class ZonesToPagedIterable extends CallerArg0ToPagedIterable<Zone, ZonesToPagedIterable> {
+public class ResourceRecordSetIterableToPagedIterable extends
+      CallerArg0ToPagedIterable<ResourceRecordSet, ResourceRecordSetIterableToPagedIterable> {
 
    private final Route53Api api;
 
    @Inject
-   protected ZonesToPagedIterable(Route53Api api) {
+   protected ResourceRecordSetIterableToPagedIterable(Route53Api api) {
       this.api = checkNotNull(api, "api");
    }
 
    @Override
-   protected Function<Object, IterableWithMarker<Zone>> markerToNextForCallingArg0(String ignored) {
-      final ZoneApi zoneApi = api.getZoneApi();
-      return new Function<Object, IterableWithMarker<Zone>>() {
+   protected Function<Object, IterableWithMarker<ResourceRecordSet>> markerToNextForCallingArg0(String zoneId) {
+      final ResourceRecordSetApi resourceResourceRecordSetApi = api.getResourceRecordSetApiForHostedZone(zoneId);
+      return new Function<Object, IterableWithMarker<ResourceRecordSet>>() {
 
          @Override
-         public IterableWithMarker<Zone> apply(Object input) {
-            return zoneApi.listAt(input.toString());
+         public IterableWithMarker<ResourceRecordSet> apply(Object input) {
+            return resourceResourceRecordSetApi.listAt(NextRecord.class.cast(input));
          }
 
          @Override
          public String toString() {
-            return "listZones()";
+            return "listResourceRecordSets()";
          }
       };
    }
-
 }

--- a/apis/route53/src/main/java/org/jclouds/route53/functions/SerializeRRS.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/functions/SerializeRRS.java
@@ -21,12 +21,13 @@ package org.jclouds.route53.functions;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.jclouds.rest.annotations.ParamParser;
-import org.jclouds.route53.domain.RecordSet;
-import org.jclouds.route53.domain.RecordSet.RecordSubset;
-import org.jclouds.route53.domain.RecordSet.RecordSubset.Latency;
-import org.jclouds.route53.domain.RecordSet.RecordSubset.Weighted;
+import org.jclouds.route53.domain.ResourceRecordSet;
+import org.jclouds.route53.domain.ResourceRecordSet.RecordSubset;
+import org.jclouds.route53.domain.ResourceRecordSet.RecordSubset.Latency;
+import org.jclouds.route53.domain.ResourceRecordSet.RecordSubset.Weighted;
 
 import com.google.common.base.Function;
+import com.google.common.primitives.UnsignedInteger;
 
 /**
  * @author Adrian Cole
@@ -35,7 +36,7 @@ import com.google.common.base.Function;
 public class SerializeRRS implements Function<Object, String> {
    @Override
    public String apply(Object in) {
-      RecordSet rrs = RecordSet.class.cast(checkNotNull(in, "rrs"));
+      ResourceRecordSet rrs = ResourceRecordSet.class.cast(checkNotNull(in, "rrs"));
       StringBuilder builder = new StringBuilder().append("<ResourceRecordSet>");
       builder.append("<Name>").append(rrs.getName()).append("</Name>");
       builder.append("<Type>").append(rrs.getType()).append("</Type>");
@@ -53,7 +54,7 @@ public class SerializeRRS implements Function<Object, String> {
          builder.append("<DNSName>").append(rrs.getAliasTarget().get().getDNSName()).append("</DNSName>");
          builder.append("</AliasTarget>");
       } else {
-         builder.append("<TTL>").append(rrs.getTTL().or(0)).append("</TTL>");
+         builder.append("<TTL>").append(rrs.getTTL().or(UnsignedInteger.ZERO)).append("</TTL>");
          builder.append("<ResourceRecords>");
          for (String record : rrs.getValues())
             builder.append("<ResourceRecord>").append("<Value>").append(record).append("</Value>")

--- a/apis/route53/src/main/java/org/jclouds/route53/predicates/HostedZonePredicates.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/predicates/HostedZonePredicates.java
@@ -20,33 +20,32 @@ package org.jclouds.route53.predicates;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import org.jclouds.route53.domain.RecordSet;
-import org.jclouds.route53.domain.RecordSet.Type;
+import org.jclouds.route53.domain.HostedZone;
 
 import com.google.common.base.Predicate;
 
 /**
- * Predicates handy when working with ResourceRecordSet Types
+ * Predicates handy when working with HostedZones
  * 
  * @author Adrian Cole
  */
-public class RecordSetPredicates {
+public class HostedZonePredicates {
 
    /**
-    * matches zones of the given type
+    * matches zones of the given name
     */
-   public static Predicate<RecordSet> typeEquals(final Type type) {
-      checkNotNull(type, "type must be defined");
+   public static Predicate<HostedZone> nameEquals(final String name) {
+      checkNotNull(name, "name must be defined");
 
-      return new Predicate<RecordSet>() {
+      return new Predicate<HostedZone>() {
          @Override
-         public boolean apply(RecordSet zone) {
-            return type.equals(zone.getType());
+         public boolean apply(HostedZone zone) {
+            return name.equals(zone.getName());
          }
 
          @Override
          public String toString() {
-            return "typeEquals(" + type + ")";
+            return "nameEquals(" + name + ")";
          }
       };
    }

--- a/apis/route53/src/main/java/org/jclouds/route53/predicates/ResourceRecordSetPredicates.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/predicates/ResourceRecordSetPredicates.java
@@ -16,17 +16,37 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.jclouds.aws.route53.features;
+package org.jclouds.route53.predicates;
 
-import org.jclouds.route53.features.ZoneApiLiveTest;
-import org.testng.annotations.Test;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.jclouds.route53.domain.ResourceRecordSet;
+
+import com.google.common.base.Predicate;
 
 /**
+ * Predicates handy when working with ResourceResourceRecordSet Types
+ * 
  * @author Adrian Cole
  */
-@Test(groups = "live", testName = "AWSZoneApiLiveTest")
-public class AWSZoneApiLiveTest extends ZoneApiLiveTest {
-   public AWSZoneApiLiveTest() {
-      provider = "aws-route53";
+public class ResourceRecordSetPredicates {
+
+   /**
+    * matches zones of the given type
+    */
+   public static Predicate<ResourceRecordSet> typeEquals(final String type) {
+      checkNotNull(type, "type must be defined");
+
+      return new Predicate<ResourceRecordSet>() {
+         @Override
+         public boolean apply(ResourceRecordSet zone) {
+            return type.equals(zone.getType());
+         }
+
+         @Override
+         public String toString() {
+            return "typeEquals(" + type + ")";
+         }
+      };
    }
 }

--- a/apis/route53/src/main/java/org/jclouds/route53/xml/CreateHostedZoneResponseHandler.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/xml/CreateHostedZoneResponseHandler.java
@@ -21,8 +21,8 @@ package org.jclouds.route53.xml;
 import static org.jclouds.util.SaxUtils.equalsOrSuffix;
 
 import org.jclouds.http.functions.ParseSax;
-import org.jclouds.route53.domain.NewZone;
-import org.jclouds.route53.domain.ZoneAndNameServers;
+import org.jclouds.route53.domain.HostedZoneAndNameServers;
+import org.jclouds.route53.domain.NewHostedZone;
 import org.xml.sax.Attributes;
 
 import com.google.inject.Inject;
@@ -34,7 +34,7 @@ import com.google.inject.Inject;
  * 
  * @author Adrian Cole
  */
-public class CreateHostedZoneResponseHandler extends ParseSax.HandlerForGeneratedRequestWithResult<NewZone> {
+public class CreateHostedZoneResponseHandler extends ParseSax.HandlerForGeneratedRequestWithResult<NewHostedZone> {
 
    private final GetHostedZoneResponseHandler zoneHandler;
    private final ChangeHandler changeHandler;
@@ -48,9 +48,9 @@ public class CreateHostedZoneResponseHandler extends ParseSax.HandlerForGenerate
    }
 
    @Override
-   public NewZone getResult() {
-      ZoneAndNameServers zone = zoneHandler.getResult();
-      return NewZone.create(zone, changeHandler.getResult());
+   public NewHostedZone getResult() {
+      HostedZoneAndNameServers zone = zoneHandler.getResult();
+      return NewHostedZone.create(zone, changeHandler.getResult());
    }
 
    @Override

--- a/apis/route53/src/main/java/org/jclouds/route53/xml/GetHostedZoneResponseHandler.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/xml/GetHostedZoneResponseHandler.java
@@ -22,8 +22,8 @@ import static org.jclouds.util.SaxUtils.currentOrNull;
 import static org.jclouds.util.SaxUtils.equalsOrSuffix;
 
 import org.jclouds.http.functions.ParseSax;
-import org.jclouds.route53.domain.Zone;
-import org.jclouds.route53.domain.ZoneAndNameServers;
+import org.jclouds.route53.domain.HostedZone;
+import org.jclouds.route53.domain.HostedZoneAndNameServers;
 import org.xml.sax.Attributes;
 
 import com.google.common.collect.ImmutableList;
@@ -37,26 +37,26 @@ import com.google.inject.Inject;
  * 
  * @author Adrian Cole
  */
-public class GetHostedZoneResponseHandler extends ParseSax.HandlerForGeneratedRequestWithResult<ZoneAndNameServers> {
+public class GetHostedZoneResponseHandler extends ParseSax.HandlerForGeneratedRequestWithResult<HostedZoneAndNameServers> {
 
-   private final ZoneHandler zoneHandler;
+   private final HostedZoneHandler zoneHandler;
 
    private StringBuilder currentText = new StringBuilder();
    
-   private boolean inZone;
+   private boolean inHostedZone;
 
-   private Zone zone;
+   private HostedZone zone;
    private Builder<String> nameServers = ImmutableList.<String> builder();
 
    @Inject
-   public GetHostedZoneResponseHandler(ZoneHandler zoneHandler) {
+   public GetHostedZoneResponseHandler(HostedZoneHandler zoneHandler) {
       this.zoneHandler = zoneHandler;
    }
 
    @Override
-   public ZoneAndNameServers getResult() {
+   public HostedZoneAndNameServers getResult() {
       try {
-         return ZoneAndNameServers.create(zone, nameServers.build());
+         return HostedZoneAndNameServers.create(zone, nameServers.build());
       } finally {
          zone = null;
          nameServers = ImmutableList.<String> builder();
@@ -66,18 +66,18 @@ public class GetHostedZoneResponseHandler extends ParseSax.HandlerForGeneratedRe
    @Override
    public void startElement(String url, String name, String qName, Attributes attributes) {
       if (equalsOrSuffix(qName, "HostedZone")) {
-         inZone = true;
+         inHostedZone = true;
       }
-      if (inZone) {
+      if (inHostedZone) {
          zoneHandler.startElement(url, name, qName, attributes);
       }
    }
 
    @Override
    public void endElement(String uri, String name, String qName) {
-      if (inZone) {
+      if (inHostedZone) {
          if (qName.equals("HostedZone")) {
-            inZone = false;
+            inHostedZone = false;
             zone = zoneHandler.getResult();
          } else {
             zoneHandler.endElement(uri, name, qName);
@@ -91,7 +91,7 @@ public class GetHostedZoneResponseHandler extends ParseSax.HandlerForGeneratedRe
 
    @Override
    public void characters(char ch[], int start, int length) {
-      if (inZone) {
+      if (inHostedZone) {
          zoneHandler.characters(ch, start, length);
       } else {
          currentText.append(ch, start, length);

--- a/apis/route53/src/main/java/org/jclouds/route53/xml/HostedZoneHandler.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/xml/HostedZoneHandler.java
@@ -21,24 +21,26 @@ package org.jclouds.route53.xml;
 import static org.jclouds.util.SaxUtils.currentOrNull;
 
 import org.jclouds.http.functions.ParseSax;
-import org.jclouds.route53.domain.Zone;
+import org.jclouds.route53.domain.HostedZone;
 import org.xml.sax.Attributes;
+
+import com.google.common.primitives.UnsignedInteger;
 
 /**
  * 
  * @author Adrian Cole
  */
-public class ZoneHandler extends ParseSax.HandlerForGeneratedRequestWithResult<Zone> {
+public class HostedZoneHandler extends ParseSax.HandlerForGeneratedRequestWithResult<HostedZone> {
 
    private StringBuilder currentText = new StringBuilder();
-   private Zone.Builder builder = Zone.builder();
+   private HostedZone.Builder builder = HostedZone.builder();
 
    @Override
-   public Zone getResult() {
+   public HostedZone getResult() {
       try {
          return builder.build();
       } finally {
-         builder = Zone.builder();
+         builder = HostedZone.builder();
       }
    }
 
@@ -57,7 +59,7 @@ public class ZoneHandler extends ParseSax.HandlerForGeneratedRequestWithResult<Z
       } else if (qName.equals("Comment")) {
          builder.comment(currentOrNull(currentText));
       } else if (qName.equals("ResourceRecordSetCount")) {
-         builder.resourceRecordSetCount(Integer.parseInt(currentOrNull(currentText)));
+         builder.resourceRecordSetCount(UnsignedInteger.valueOf(currentOrNull(currentText)).intValue());
       }
       currentText = new StringBuilder();
    }

--- a/apis/route53/src/main/java/org/jclouds/route53/xml/ListHostedZonesResponseHandler.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/xml/ListHostedZonesResponseHandler.java
@@ -24,7 +24,7 @@ import static org.jclouds.util.SaxUtils.equalsOrSuffix;
 import org.jclouds.collect.IterableWithMarker;
 import org.jclouds.collect.IterableWithMarkers;
 import org.jclouds.http.functions.ParseSax;
-import org.jclouds.route53.domain.Zone;
+import org.jclouds.route53.domain.HostedZone;
 import org.xml.sax.Attributes;
 
 import com.google.common.collect.ImmutableList;
@@ -39,44 +39,44 @@ import com.google.inject.Inject;
  * @author Adrian Cole
  */
 public class ListHostedZonesResponseHandler extends
-      ParseSax.HandlerForGeneratedRequestWithResult<IterableWithMarker<Zone>> {
+      ParseSax.HandlerForGeneratedRequestWithResult<IterableWithMarker<HostedZone>> {
 
-   private final ZoneHandler zoneHandler;
+   private final HostedZoneHandler zoneHandler;
 
    private StringBuilder currentText = new StringBuilder();
-   private Builder<Zone> zones = ImmutableList.<Zone> builder();
-   private boolean inZones;
+   private Builder<HostedZone> zones = ImmutableList.<HostedZone> builder();
+   private boolean inHostedZones;
    private String afterMarker;
 
    @Inject
-   public ListHostedZonesResponseHandler(ZoneHandler zoneHandler) {
+   public ListHostedZonesResponseHandler(HostedZoneHandler zoneHandler) {
       this.zoneHandler = zoneHandler;
    }
 
    @Override
-   public IterableWithMarker<Zone> getResult() {
+   public IterableWithMarker<HostedZone> getResult() {
       try {
          return IterableWithMarkers.from(zones.build(), afterMarker);
       } finally {
-         zones = ImmutableList.<Zone> builder();
+         zones = ImmutableList.<HostedZone> builder();
       }
    }
 
    @Override
    public void startElement(String url, String name, String qName, Attributes attributes) {
       if (equalsOrSuffix(qName, "HostedZones")) {
-         inZones = true;
+         inHostedZones = true;
       }
-      if (inZones) {
+      if (inHostedZones) {
          zoneHandler.startElement(url, name, qName, attributes);
       }
    }
 
    @Override
    public void endElement(String uri, String name, String qName) {
-      if (inZones) {
+      if (inHostedZones) {
          if (qName.equals("HostedZones")) {
-            inZones = false;
+            inHostedZones = false;
          } else if (qName.equals("HostedZone")) {
             zones.add(zoneHandler.getResult());
          } else {
@@ -91,7 +91,7 @@ public class ListHostedZonesResponseHandler extends
 
    @Override
    public void characters(char ch[], int start, int length) {
-      if (inZones) {
+      if (inHostedZones) {
          zoneHandler.characters(ch, start, length);
       } else {
          currentText.append(ch, start, length);

--- a/apis/route53/src/main/java/org/jclouds/route53/xml/ListResourceRecordSetsResponseHandler.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/xml/ListResourceRecordSetsResponseHandler.java
@@ -22,9 +22,8 @@ import static org.jclouds.util.SaxUtils.currentOrNull;
 import static org.jclouds.util.SaxUtils.equalsOrSuffix;
 
 import org.jclouds.http.functions.ParseSax;
-import org.jclouds.route53.domain.RecordSet.Type;
-import org.jclouds.route53.domain.RecordSetIterable;
-import org.jclouds.route53.domain.RecordSetIterable.Builder;
+import org.jclouds.route53.domain.ResourceRecordSetIterable;
+import org.jclouds.route53.domain.ResourceRecordSetIterable.Builder;
 import org.xml.sax.Attributes;
 
 import com.google.inject.Inject;
@@ -37,12 +36,12 @@ import com.google.inject.Inject;
  * @author Adrian Cole
  */
 public class ListResourceRecordSetsResponseHandler extends
-      ParseSax.HandlerForGeneratedRequestWithResult<RecordSetIterable> {
+      ParseSax.HandlerForGeneratedRequestWithResult<ResourceRecordSetIterable> {
 
    private final ResourceRecordSetHandler resourceRecordSetHandler;
 
    private StringBuilder currentText = new StringBuilder();
-   private Builder builder = RecordSetIterable.builder();
+   private Builder builder = ResourceRecordSetIterable.builder();
 
    private boolean inResourceRecordSets;
 
@@ -52,11 +51,11 @@ public class ListResourceRecordSetsResponseHandler extends
    }
 
    @Override
-   public RecordSetIterable getResult() {
+   public ResourceRecordSetIterable getResult() {
       try {
          return builder.build();
       } finally {
-         builder = RecordSetIterable.builder();
+         builder = ResourceRecordSetIterable.builder();
       }
    }
 
@@ -83,7 +82,7 @@ public class ListResourceRecordSetsResponseHandler extends
       } else if (qName.equals("NextRecordName")) {
          builder.nextRecordName(currentOrNull(currentText));
       } else if (qName.equals("NextRecordType")) {
-         builder.nextRecordType(Type.valueOf(currentOrNull(currentText)));
+         builder.nextRecordType(currentOrNull(currentText));
       } else if (qName.equals("NextRecordIdentifier")) {
          builder.nextRecordIdentifier(currentOrNull(currentText));
       }

--- a/apis/route53/src/main/java/org/jclouds/route53/xml/ResourceRecordSetHandler.java
+++ b/apis/route53/src/main/java/org/jclouds/route53/xml/ResourceRecordSetHandler.java
@@ -21,25 +21,26 @@ package org.jclouds.route53.xml;
 import static org.jclouds.util.SaxUtils.currentOrNull;
 
 import org.jclouds.http.functions.ParseSax;
-import org.jclouds.route53.domain.RecordSet;
-import org.jclouds.route53.domain.RecordSet.Type;
+import org.jclouds.route53.domain.ResourceRecordSet;
 import org.xml.sax.Attributes;
+
+import com.google.common.primitives.UnsignedInteger;
 
 /**
  * 
  * @author Adrian Cole
  */
-public class ResourceRecordSetHandler extends ParseSax.HandlerForGeneratedRequestWithResult<RecordSet> {
+public class ResourceRecordSetHandler extends ParseSax.HandlerForGeneratedRequestWithResult<ResourceRecordSet> {
 
    private StringBuilder currentText = new StringBuilder();
-   private RecordSet.Builder builder = RecordSet.builder();
+   private ResourceRecordSet.Builder builder = ResourceRecordSet.builder();
 
    @Override
-   public RecordSet getResult() {
+   public ResourceRecordSet getResult() {
       try {
          return builder.build();
       } finally {
-         builder = RecordSet.builder();
+         builder = ResourceRecordSet.builder();
       }
    }
 
@@ -52,9 +53,9 @@ public class ResourceRecordSetHandler extends ParseSax.HandlerForGeneratedReques
       if (qName.equals("Name")) {
          builder.name(currentOrNull(currentText));
       } else if (qName.equals("Type")) {
-         builder.type(Type.valueOf(currentOrNull(currentText)));
+         builder.type(currentOrNull(currentText));
       } else if (qName.equals("TTL")) {
-         builder.ttl(Integer.parseInt(currentOrNull(currentText)));
+         builder.ttl(UnsignedInteger.valueOf(currentOrNull(currentText)));
       } else if (qName.equals("Value")) {
          builder.add(currentOrNull(currentText));
       } else if (qName.equals("HostedZoneId")) {
@@ -64,7 +65,7 @@ public class ResourceRecordSetHandler extends ParseSax.HandlerForGeneratedReques
       } else if (qName.equals("DNSName")) {
          builder.dnsName(currentOrNull(currentText));
       } else if (qName.equals("Weight")) {
-         builder.weight(Integer.parseInt(currentOrNull(currentText)));
+         builder.weight(UnsignedInteger.valueOf(currentOrNull(currentText)));
       } else if (qName.equals("Region")) {
          builder.region(currentOrNull(currentText));
       }

--- a/apis/route53/src/test/java/org/jclouds/route53/Route53ApiExpectTest.java
+++ b/apis/route53/src/test/java/org/jclouds/route53/Route53ApiExpectTest.java
@@ -37,8 +37,8 @@ public class Route53ApiExpectTest extends BaseRoute53ApiExpectTest {
          .endpoint("https://route53.amazonaws.com/2012-02-29/change/C2682N5HXP0BZ4")
          .addHeader("Host", "route53.amazonaws.com")
          .addHeader("Date", "Mon, 21 Jan 02013 19:29:03 -0800")
-         .addHeader("X-Amzn-Authorization",
-               authForDate)
+         .addHeader("X-Amzn-Authorization", authForDate)
+
          .build();
 
    HttpResponse getChangeResponse = HttpResponse.builder().statusCode(200)

--- a/apis/route53/src/test/java/org/jclouds/route53/features/HostedZoneApiExpectTest.java
+++ b/apis/route53/src/test/java/org/jclouds/route53/features/HostedZoneApiExpectTest.java
@@ -37,14 +37,13 @@ import com.google.common.collect.ImmutableSet;
 /**
  * @author Adrian Cole
  */
-@Test(groups = "unit", testName = "ZoneApiExpectTest")
-public class ZoneApiExpectTest extends BaseRoute53ApiExpectTest {
+@Test(groups = "unit", testName = "HostedZoneApiExpectTest")
+public class HostedZoneApiExpectTest extends BaseRoute53ApiExpectTest {
    HttpRequest createWithReference = HttpRequest.builder().method("POST")
          .endpoint("https://route53.amazonaws.com/2012-02-29/hostedzone")
          .addHeader("Host", "route53.amazonaws.com")
          .addHeader("Date", "Mon, 21 Jan 02013 19:29:03 -0800")
-         .addHeader("X-Amzn-Authorization",
-               authForDate)
+         .addHeader("X-Amzn-Authorization", authForDate)
          .payload(
                payloadFromStringWithContentType(
                      "<CreateHostedZoneRequest xmlns=\"https://route53.amazonaws.com/doc/2012-02-29/\"><Name>jclouds.org.</Name><CallerReference>expect</CallerReference></CreateHostedZoneRequest>",
@@ -55,7 +54,7 @@ public class ZoneApiExpectTest extends BaseRoute53ApiExpectTest {
 
    public void testCreateWithReferenceWhenResponseIs2xx() {
       Route53Api success = requestSendsResponse(createWithReference, createResponse);
-      assertEquals(success.getZoneApi().createWithReference("jclouds.org.", "expect").toString(),
+      assertEquals(success.getHostedZoneApi().createWithReference("jclouds.org.", "expect").toString(),
             new CreateHostedZoneResponseTest().expected().toString());
    }
 
@@ -63,8 +62,7 @@ public class ZoneApiExpectTest extends BaseRoute53ApiExpectTest {
          .endpoint("https://route53.amazonaws.com/2012-02-29/hostedzone")
          .addHeader("Host", "route53.amazonaws.com")
          .addHeader("Date", "Mon, 21 Jan 02013 19:29:03 -0800")
-         .addHeader("X-Amzn-Authorization",
-               authForDate)
+         .addHeader("X-Amzn-Authorization", authForDate)
          .payload(
                payloadFromStringWithContentType(
                      "<CreateHostedZoneRequest xmlns=\"https://route53.amazonaws.com/doc/2012-02-29/\"><Name>jclouds.org.</Name><CallerReference>expect</CallerReference><HostedZoneConfig><Comment>comment</Comment></HostedZoneConfig></CreateHostedZoneRequest>",
@@ -72,7 +70,7 @@ public class ZoneApiExpectTest extends BaseRoute53ApiExpectTest {
 
    public void testCreateWithReferenceAndCommentWhenResponseIs2xx() {
       Route53Api success = requestSendsResponse(createWithReferenceAndComment, createResponse);
-      assertEquals(success.getZoneApi().createWithReferenceAndComment("jclouds.org.", "expect", "comment").toString(),
+      assertEquals(success.getHostedZoneApi().createWithReferenceAndComment("jclouds.org.", "expect", "comment").toString(),
             new CreateHostedZoneResponseTest().expected().toString());
    }
 
@@ -80,8 +78,7 @@ public class ZoneApiExpectTest extends BaseRoute53ApiExpectTest {
          .endpoint("https://route53.amazonaws.com/2012-02-29/hostedzone/Z1XTHCPEFRWV1X")
          .addHeader("Host", "route53.amazonaws.com")
          .addHeader("Date", "Mon, 21 Jan 02013 19:29:03 -0800")
-         .addHeader("X-Amzn-Authorization",
-               authForDate)
+         .addHeader("X-Amzn-Authorization", authForDate)
          .build();
    
    HttpResponse getResponse = HttpResponse.builder().statusCode(200)
@@ -89,21 +86,20 @@ public class ZoneApiExpectTest extends BaseRoute53ApiExpectTest {
 
    public void testGetWhenResponseIs2xx() {
       Route53Api success = requestSendsResponse(get, getResponse);
-      assertEquals(success.getZoneApi().get("Z1XTHCPEFRWV1X").toString(), new GetHostedZoneResponseTest().expected()
+      assertEquals(success.getHostedZoneApi().get("Z1XTHCPEFRWV1X").toString(), new GetHostedZoneResponseTest().expected()
             .toString());
    }
 
    public void testGetWhenResponseIs404() {
       Route53Api fail = requestSendsResponse(get, notFound);
-      assertNull(fail.getZoneApi().get("Z1XTHCPEFRWV1X"));
+      assertNull(fail.getHostedZoneApi().get("Z1XTHCPEFRWV1X"));
    }
 
    HttpRequest list = HttpRequest.builder().method("GET")
          .endpoint("https://route53.amazonaws.com/2012-02-29/hostedzone")
          .addHeader("Host", "route53.amazonaws.com")
          .addHeader("Date", "Mon, 21 Jan 02013 19:29:03 -0800")
-         .addHeader("X-Amzn-Authorization",
-               authForDate)
+         .addHeader("X-Amzn-Authorization", authForDate)
          .build();
 
    HttpResponse listResponse = HttpResponse.builder().statusCode(200)
@@ -111,7 +107,7 @@ public class ZoneApiExpectTest extends BaseRoute53ApiExpectTest {
    
    public void testListWhenResponseIs2xx() {
       Route53Api success = requestSendsResponse(list, listResponse);
-      assertEquals(success.getZoneApi().list().get(0).toString(), new ListHostedZonesResponseTest().expected()
+      assertEquals(success.getHostedZoneApi().list().get(0).toString(), new ListHostedZonesResponseTest().expected()
             .toString());
    }
 
@@ -119,20 +115,19 @@ public class ZoneApiExpectTest extends BaseRoute53ApiExpectTest {
    @Test(expectedExceptions = ResourceNotFoundException.class)
    public void testListWhenResponseIs404() {
       Route53Api fail = requestSendsResponse(list, notFound);
-      assertEquals(fail.getZoneApi().list().get(0).toSet(), ImmutableSet.of());
+      assertEquals(fail.getHostedZoneApi().list().get(0).toSet(), ImmutableSet.of());
    }
    
    HttpRequest listAt = HttpRequest.builder().method("GET")
          .endpoint("https://route53.amazonaws.com/2012-02-29/hostedzone?marker=Z333333YYYYYYY")
          .addHeader("Host", "route53.amazonaws.com")
          .addHeader("Date", "Mon, 21 Jan 02013 19:29:03 -0800")
-         .addHeader("X-Amzn-Authorization",
-               authForDate)
+         .addHeader("X-Amzn-Authorization", authForDate)
          .build();
    
    public void testListAtWhenResponseIs2xx() {
       Route53Api apiWhenAtExist = requestSendsResponse(listAt, listResponse);
-      assertEquals(apiWhenAtExist.getZoneApi().listAt("Z333333YYYYYYY").toString(),
+      assertEquals(apiWhenAtExist.getHostedZoneApi().listAt("Z333333YYYYYYY").toString(),
             new ListHostedZonesResponseTest().expected().toString());
    }
    
@@ -141,7 +136,7 @@ public class ZoneApiExpectTest extends BaseRoute53ApiExpectTest {
             .payload(payloadFromStringWithContentType("<ListHostedZonesResponse />", "text/xml")).build();
 
       Route53Api success = requestsSendResponses(list, listResponse, listAt, noMore);
-      assertEquals(success.getZoneApi().list().concat().toString(), new ListHostedZonesResponseTest().expected()
+      assertEquals(success.getHostedZoneApi().list().concat().toString(), new ListHostedZonesResponseTest().expected()
             .toString());
    }
 
@@ -149,8 +144,7 @@ public class ZoneApiExpectTest extends BaseRoute53ApiExpectTest {
          .endpoint("https://route53.amazonaws.com/2012-02-29/hostedzone/Z1XTHCPEFRWV1X")
          .addHeader("Host", "route53.amazonaws.com")
          .addHeader("Date", "Mon, 21 Jan 02013 19:29:03 -0800")
-         .addHeader("X-Amzn-Authorization",
-               authForDate)
+         .addHeader("X-Amzn-Authorization", authForDate)
          .build();
    
    HttpResponse deleteResponse = HttpResponse.builder().statusCode(200)
@@ -158,11 +152,11 @@ public class ZoneApiExpectTest extends BaseRoute53ApiExpectTest {
 
    public void testDeleteWhenResponseIs2xx() {
       Route53Api success = requestSendsResponse(delete, deleteResponse);
-      assertEquals(success.getZoneApi().delete("Z1XTHCPEFRWV1X").toString(), new GetChangeResponseTest().expected().toString());
+      assertEquals(success.getHostedZoneApi().delete("Z1XTHCPEFRWV1X").toString(), new GetChangeResponseTest().expected().toString());
    }
 
    public void testDeleteWhenResponseIs404() {
       Route53Api fail = requestSendsResponse(delete, notFound);
-      assertNull(fail.getZoneApi().delete("Z1XTHCPEFRWV1X"));
+      assertNull(fail.getHostedZoneApi().delete("Z1XTHCPEFRWV1X"));
    }
 }

--- a/apis/route53/src/test/java/org/jclouds/route53/features/HostedZoneApiLiveTest.java
+++ b/apis/route53/src/test/java/org/jclouds/route53/features/HostedZoneApiLiveTest.java
@@ -29,8 +29,8 @@ import java.util.Date;
 
 import org.jclouds.JcloudsVersion;
 import org.jclouds.route53.domain.Change;
-import org.jclouds.route53.domain.NewZone;
-import org.jclouds.route53.domain.Zone;
+import org.jclouds.route53.domain.NewHostedZone;
+import org.jclouds.route53.domain.HostedZone;
 import org.jclouds.route53.internal.BaseRoute53ApiLiveTest;
 import org.testng.annotations.Test;
 
@@ -39,62 +39,62 @@ import com.google.common.collect.ImmutableList;
 /**
  * @author Adrian Cole
  */
-@Test(groups = "live", testName = "ZoneApiLiveTest")
-public class ZoneApiLiveTest extends BaseRoute53ApiLiveTest {
+@Test(groups = "live", testName = "HostedZoneApiLiveTest")
+public class HostedZoneApiLiveTest extends BaseRoute53ApiLiveTest {
 
-   private void checkZone(Zone zone) {
+   private void checkHostedZone(HostedZone zone) {
       getAnonymousLogger().info(format("zone %s rrs: %s", zone.getName(), zone.getResourceRecordSetCount()));
 
-      checkNotNull(zone.getId(), "Id: Zone %s", zone);
-      checkNotNull(zone.getName(), "Name: Zone %s", zone);
-      checkNotNull(zone.getCallerReference(), "CallerReference: Zone %s", zone);
-      checkNotNull(zone.getComment(), "While Comment can be null for a Zone, its Optional wrapper cannot %s", zone);
+      checkNotNull(zone.getId(), "Id: HostedZone %s", zone);
+      checkNotNull(zone.getName(), "Name: HostedZone %s", zone);
+      checkNotNull(zone.getCallerReference(), "CallerReference: HostedZone %s", zone);
+      checkNotNull(zone.getComment(), "While Comment can be null for a HostedZone, its Optional wrapper cannot %s", zone);
    }
 
    @Test
-   protected void testListZones() {
-      ImmutableList<Zone> zones = api().list().concat().toList();
+   protected void testListHostedZones() {
+      ImmutableList<HostedZone> zones = api().list().concat().toList();
       getAnonymousLogger().info("zones: " + zones.size());
 
-      for (Zone zone : zones) {
-         checkZone(zone);
+      for (HostedZone zone : zones) {
+         checkHostedZone(zone);
          assertEquals(api().get(zone.getId()).getZone(), zone);
       }
    }
 
    @Test
-   public void testGetZoneWhenNotFound() {
+   public void testGetHostedZoneWhenNotFound() {
       assertNull(api().get("AAAAAAAAAAAAAAAA"));
    }
 
    @Test
-   public void testDeleteZoneWhenNotFound() {
+   public void testDeleteHostedZoneWhenNotFound() {
       assertNull(api().delete("AAAAAAAAAAAAAAAA"));
    }
 
    @Test
-   public void testCreateAndDeleteZone() {
+   public void testCreateAndDeleteHostedZone() {
       String name = System.getProperty("user.name").replace('.', '-') + ".zone.route53test.jclouds.org.";
       String nonce = name + " @ " + new Date();
       String comment = name + " for " + JcloudsVersion.get();
-      NewZone newZone = api().createWithReferenceAndComment(name, nonce, comment);
-      getAnonymousLogger().info("created zone: " + newZone);
+      NewHostedZone newHostedZone = api().createWithReferenceAndComment(name, nonce, comment);
+      getAnonymousLogger().info("created zone: " + newHostedZone);
       try {
-         checkZone(newZone.getZone());
-         assertEquals(newZone.getChange().getStatus(), PENDING, "invalid status on zone " + newZone);
-         assertTrue(newZone.getNameServers().size() > 0, "no name servers for zone " + newZone);
-         assertEquals(newZone.getZone().getName(), name);
-         assertEquals(newZone.getZone().getCallerReference(), nonce);
-         assertEquals(newZone.getZone().getComment().get(), comment);
+         checkHostedZone(newHostedZone.getZone());
+         assertEquals(newHostedZone.getChange().getStatus(), PENDING, "invalid status on zone " + newHostedZone);
+         assertTrue(newHostedZone.getNameServers().size() > 0, "no name servers for zone " + newHostedZone);
+         assertEquals(newHostedZone.getZone().getName(), name);
+         assertEquals(newHostedZone.getZone().getCallerReference(), nonce);
+         assertEquals(newHostedZone.getZone().getComment().get(), comment);
          
-         assertTrue(inSync.apply(newZone.getChange()), "zone didn't sync " + newZone);
+         assertTrue(inSync.apply(newHostedZone.getChange()), "zone didn't sync " + newHostedZone);
       } finally {
-         Change delete = api().delete(newZone.getZone().getId());
+         Change delete = api().delete(newHostedZone.getZone().getId());
          assertTrue(inSync.apply(delete), "delete didn't sync " + delete);
       }
    }
 
-   protected ZoneApi api() {
-      return context.getApi().getZoneApi();
+   protected HostedZoneApi api() {
+      return context.getApi().getHostedZoneApi();
    }
 }

--- a/apis/route53/src/test/java/org/jclouds/route53/features/ResourceRecordSetApiExpectTest.java
+++ b/apis/route53/src/test/java/org/jclouds/route53/features/ResourceRecordSetApiExpectTest.java
@@ -26,9 +26,8 @@ import org.jclouds.rest.ResourceNotFoundException;
 import org.jclouds.route53.InvalidChangeBatchException;
 import org.jclouds.route53.Route53Api;
 import org.jclouds.route53.domain.ChangeBatch;
-import org.jclouds.route53.domain.RecordSet;
-import org.jclouds.route53.domain.RecordSet.Type;
-import org.jclouds.route53.domain.RecordSetIterable.NextRecord;
+import org.jclouds.route53.domain.ResourceRecordSet;
+import org.jclouds.route53.domain.ResourceRecordSetIterable.NextRecord;
 import org.jclouds.route53.internal.BaseRoute53ApiExpectTest;
 import org.jclouds.route53.parse.GetChangeResponseTest;
 import org.jclouds.route53.parse.ListResourceRecordSetsResponseTest;
@@ -39,8 +38,8 @@ import com.google.common.collect.ImmutableSet;
 /**
  * @author Adrian Cole
  */
-@Test(groups = "unit", testName = "ResourceRecordSetApiExpectTest")
-public class RecordSetApiExpectTest extends BaseRoute53ApiExpectTest {
+@Test(groups = "unit", testName = "ResourceResourceRecordSetApiExpectTest")
+public class ResourceRecordSetApiExpectTest extends BaseRoute53ApiExpectTest {
 
    HttpRequest create = HttpRequest.builder().method("POST")
          .endpoint("https://route53.amazonaws.com/2012-02-29/hostedzone/Z1PA6795UKMFR9/rrset")
@@ -54,7 +53,7 @@ public class RecordSetApiExpectTest extends BaseRoute53ApiExpectTest {
 
    public void testCreateWhenResponseIs2xx() {
       Route53Api success = requestSendsResponse(create, jobResponse);
-      assertEquals(success.getRecordSetApiForZone("Z1PA6795UKMFR9").create(RecordSet.builder().name("jclouds.org.").type(Type.TXT).add("my texts").build()).toString(),
+      assertEquals(success.getResourceRecordSetApiForHostedZone("Z1PA6795UKMFR9").create(ResourceRecordSet.builder().name("jclouds.org.").type("TXT").add("my texts").build()).toString(),
             new GetChangeResponseTest().expected().toString());
    }
 
@@ -67,10 +66,10 @@ public class RecordSetApiExpectTest extends BaseRoute53ApiExpectTest {
 
    public void testApplyWhenResponseIs2xx() {
       Route53Api success = requestSendsResponse(apply, jobResponse);
-      assertEquals(success.getRecordSetApiForZone("Z1PA6795UKMFR9").apply(
+      assertEquals(success.getResourceRecordSetApiForHostedZone("Z1PA6795UKMFR9").apply(
             ChangeBatch.builder()
-                       .delete(RecordSet.builder().name("jclouds.org.").type(Type.TXT).add("my texts").build())
-                       .create(RecordSet.builder().name("jclouds.org.").type(Type.TXT).add("my better texts").build())
+                       .delete(ResourceRecordSet.builder().name("jclouds.org.").type("TXT").add("my texts").build())
+                       .create(ResourceRecordSet.builder().name("jclouds.org.").type("TXT").add("my better texts").build())
                        .build()).toString(),
             new GetChangeResponseTest().expected().toString());
    }
@@ -81,10 +80,10 @@ public class RecordSetApiExpectTest extends BaseRoute53ApiExpectTest {
             .payload(payloadFromResourceWithContentType("/invalid_change_batch.xml", "application/xml")).build();
 
       Route53Api fails = requestSendsResponse(apply, batchErrorFound);
-      fails.getRecordSetApiForZone("Z1PA6795UKMFR9").apply(
+      fails.getResourceRecordSetApiForHostedZone("Z1PA6795UKMFR9").apply(
             ChangeBatch.builder()
-                       .delete(RecordSet.builder().name("jclouds.org.").type(Type.TXT).add("my texts").build())
-                       .create(RecordSet.builder().name("jclouds.org.").type(Type.TXT).add("my better texts").build())
+                       .delete(ResourceRecordSet.builder().name("jclouds.org.").type("TXT").add("my texts").build())
+                       .create(ResourceRecordSet.builder().name("jclouds.org.").type("TXT").add("my better texts").build())
                        .build());
    }
 
@@ -99,7 +98,7 @@ public class RecordSetApiExpectTest extends BaseRoute53ApiExpectTest {
    
    public void testListWhenResponseIs2xx() {
       Route53Api success = requestSendsResponse(list, listResponse);
-      assertEquals(success.getRecordSetApiForZone("Z1PA6795UKMFR9").list().get(0).toString(), new ListResourceRecordSetsResponseTest().expected()
+      assertEquals(success.getResourceRecordSetApiForHostedZone("Z1PA6795UKMFR9").list().get(0).toString(), new ListResourceRecordSetsResponseTest().expected()
             .toString());
    }
 
@@ -107,7 +106,7 @@ public class RecordSetApiExpectTest extends BaseRoute53ApiExpectTest {
    @Test(expectedExceptions = ResourceNotFoundException.class)
    public void testListWhenResponseIs404() {
       Route53Api fail = requestSendsResponse(list, notFound);
-      assertEquals(fail.getRecordSetApiForZone("Z1PA6795UKMFR9").list().get(0).toSet(), ImmutableSet.of());
+      assertEquals(fail.getResourceRecordSetApiForHostedZone("Z1PA6795UKMFR9").list().get(0).toSet(), ImmutableSet.of());
    }
    
    HttpRequest listAt = HttpRequest.builder().method("GET")
@@ -118,8 +117,8 @@ public class RecordSetApiExpectTest extends BaseRoute53ApiExpectTest {
    
    public void testListAtWhenResponseIs2xx() {
       Route53Api apiWhenAtExist = requestSendsResponse(listAt, listResponse);
-      NextRecord next = NextRecord.nameAndType("testdoc2.example.com", Type.NS);
-      assertEquals(apiWhenAtExist.getRecordSetApiForZone("Z1PA6795UKMFR9").listAt(next).toString(),
+      NextRecord next = NextRecord.nameAndType("testdoc2.example.com", "NS");
+      assertEquals(apiWhenAtExist.getResourceRecordSetApiForHostedZone("Z1PA6795UKMFR9").listAt(next).toString(),
             new ListResourceRecordSetsResponseTest().expected().toString());
    }
    
@@ -128,7 +127,7 @@ public class RecordSetApiExpectTest extends BaseRoute53ApiExpectTest {
             .payload(payloadFromStringWithContentType("<ListResourceRecordSetsResponse />", "text/xml")).build();
 
       Route53Api success = requestsSendResponses(list, listResponse, listAt, noMore);
-      assertEquals(success.getRecordSetApiForZone("Z1PA6795UKMFR9").list().concat().toSet(), new ListResourceRecordSetsResponseTest().expected()
+      assertEquals(success.getResourceRecordSetApiForHostedZone("Z1PA6795UKMFR9").list().concat().toSet(), new ListResourceRecordSetsResponseTest().expected()
             .toSet());
    }
 
@@ -141,7 +140,7 @@ public class RecordSetApiExpectTest extends BaseRoute53ApiExpectTest {
 
    public void testDeleteWhenResponseIs2xx() {
       Route53Api success = requestSendsResponse(delete, jobResponse);
-      assertEquals(success.getRecordSetApiForZone("Z1PA6795UKMFR9").create(RecordSet.builder().name("jclouds.org.").type(Type.TXT).add("my texts").build()).toString(),
+      assertEquals(success.getResourceRecordSetApiForHostedZone("Z1PA6795UKMFR9").create(ResourceRecordSet.builder().name("jclouds.org.").type("TXT").add("my texts").build()).toString(),
             new GetChangeResponseTest().expected().toString());
    }
 }

--- a/apis/route53/src/test/java/org/jclouds/route53/features/ResourceRecordSetApiLiveTest.java
+++ b/apis/route53/src/test/java/org/jclouds/route53/features/ResourceRecordSetApiLiveTest.java
@@ -7,11 +7,11 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICE"NS"E-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIO"NS" OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
@@ -24,11 +24,8 @@ import static com.google.common.base.Predicates.or;
 import static java.util.logging.Logger.getAnonymousLogger;
 import static org.jclouds.route53.domain.ChangeBatch.createAll;
 import static org.jclouds.route53.domain.ChangeBatch.deleteAll;
-import static org.jclouds.route53.domain.RecordSet.Type.NS;
-import static org.jclouds.route53.domain.RecordSet.Type.SOA;
-import static org.jclouds.route53.domain.RecordSet.Type.TXT;
-import static org.jclouds.route53.predicates.RecordSetPredicates.typeEquals;
-import static org.jclouds.route53.predicates.ZonePredicates.nameEquals;
+import static org.jclouds.route53.predicates.HostedZonePredicates.nameEquals;
+import static org.jclouds.route53.predicates.ResourceRecordSetPredicates.typeEquals;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -40,12 +37,12 @@ import java.util.Set;
 import org.jclouds.JcloudsVersion;
 import org.jclouds.collect.PagedIterable;
 import org.jclouds.route53.domain.Change;
-import org.jclouds.route53.domain.NewZone;
-import org.jclouds.route53.domain.RecordSet;
-import org.jclouds.route53.domain.RecordSet.RecordSubset;
-import org.jclouds.route53.domain.RecordSet.RecordSubset.Latency;
-import org.jclouds.route53.domain.RecordSet.RecordSubset.Weighted;
-import org.jclouds.route53.domain.Zone;
+import org.jclouds.route53.domain.HostedZone;
+import org.jclouds.route53.domain.NewHostedZone;
+import org.jclouds.route53.domain.ResourceRecordSet;
+import org.jclouds.route53.domain.ResourceRecordSet.RecordSubset;
+import org.jclouds.route53.domain.ResourceRecordSet.RecordSubset.Latency;
+import org.jclouds.route53.domain.ResourceRecordSet.RecordSubset.Weighted;
 import org.jclouds.route53.internal.BaseRoute53ApiLiveTest;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
@@ -56,10 +53,10 @@ import com.google.common.collect.ImmutableList;
 /**
  * @author Adrian Cole
  */
-@Test(groups = "live", testName = "ResourceRecordSetApiLiveTest")
-public class RecordSetApiLiveTest extends BaseRoute53ApiLiveTest {
+@Test(groups = "live", testName = "ResourceResourceRecordSetApiLiveTest")
+public class ResourceRecordSetApiLiveTest extends BaseRoute53ApiLiveTest {
 
-   private void checkRRS(RecordSet rrs) {
+   private void checkRRS(ResourceRecordSet rrs) {
       checkNotNull(rrs.getName(), "Name: ResourceRecordSet %s", rrs);
       checkNotNull(rrs.getType(), "Type: ResourceRecordSet %s", rrs);
       checkNotNull(rrs.getTTL(), "TTL: ResourceRecordSet %s", rrs);
@@ -73,7 +70,7 @@ public class RecordSetApiLiveTest extends BaseRoute53ApiLiveTest {
          checkNotNull(RecordSubset.class.cast(rrs).getId(), "Id: ResourceRecordSubset %s", rrs);
       }
       if (rrs instanceof Weighted) {
-         assertTrue(Weighted.class.cast(rrs).getWeight() >= 0, "Weight negative: ResourceRecordSubset " + rrs);
+         checkNotNull(Weighted.class.cast(rrs).getWeight(), "Weight: ResourceRecordSubset %s", rrs);
       }
       if (rrs instanceof Latency) {
          checkNotNull(Latency.class.cast(rrs).getRegion(), "Region: ResourceRecordSubset %s", rrs);
@@ -82,72 +79,72 @@ public class RecordSetApiLiveTest extends BaseRoute53ApiLiveTest {
 
    @Test
    private void testListRRSs() {
-      for (Zone zone : zones().concat()) {
+      for (HostedZone zone : zones().concat()) {
          checkAllRRs(zone.getId());
       }
    }
 
    private void checkAllRRs(String zoneId) {
-      Zone zone = context.getApi().getZoneApi().get(zoneId).getZone();
-      List<RecordSet> records = api(zone.getId()).list().concat().toList();
+      HostedZone zone = context.getApi().getHostedZoneApi().get(zoneId).getZone();
+      List<ResourceRecordSet> records = api(zone.getId()).list().concat().toList();
       assertEquals(zone.getResourceRecordSetCount(), records.size());
 
-      for (RecordSet rrs : records) {
+      for (ResourceRecordSet rrs : records) {
          checkRRS(rrs);
       }
    }
 
    @Test
    public void testDeleteRRSNotFound() {
-      for (Zone zone : zones().concat()) {
+      for (HostedZone zone : zones().concat()) {
          assertNull(api(zone.getId()).delete(
-               RecordSet.builder().name("krank.foo.bar.").type(TXT).add("kranko").build()));
+               ResourceRecordSet.builder().name("krank.foo.bar.").type("TXT").add("kranko").build()));
       }
    }
 
    /**
     * cannot delete a zone without at least one of each
     */
-   private static final Predicate<RecordSet> requiredRRTypes = or(typeEquals(SOA), typeEquals(NS));
+   private static final Predicate<ResourceRecordSet> requiredRRTypes = or(typeEquals("SOA"), typeEquals("NS"));
 
    @Test
    public void testCreateAndDeleteBulkRecords() {
       String name = System.getProperty("user.name").replace('.', '-') + ".bulk.route53test.jclouds.org.";
-      clearAndDeleteZonesNamed(name);
+      clearAndDeleteHostedZonesNamed(name);
 
-      ImmutableList<RecordSet> records = ImmutableList.<RecordSet> builder()
-            .add(RecordSet.builder().name("dom1." + name).type(TXT).add("\"somehow\" \" somewhere\"").build())
-            .add(RecordSet.builder().name("dom2." + name).type(TXT).add("\"goodies\"").build()).build();
+      ImmutableList<ResourceRecordSet> records = ImmutableList.<ResourceRecordSet> builder()
+            .add(ResourceRecordSet.builder().name("dom1." + name).type("TXT").add("\"somehow\" \" somewhere\"").build())
+            .add(ResourceRecordSet.builder().name("dom2." + name).type("TXT").add("\"goodies\"").build()).build();
 
       String nonce = name + " @ " + new Date();
       String comment = name + " for " + JcloudsVersion.get();
-      NewZone newZone = context.getApi().getZoneApi().createWithReferenceAndComment(name, nonce, comment);
-      String zoneId = newZone.getZone().getId();
-      getAnonymousLogger().info("created zone: " + newZone);
+      NewHostedZone newHostedZone = context.getApi().getHostedZoneApi().createWithReferenceAndComment(name, nonce, comment);
+      String zoneId = newHostedZone.getZone().getId();
+      getAnonymousLogger().info("created zone: " + newHostedZone);
       try {
-         assertTrue(inSync.apply(newZone.getChange()), "zone didn't sync " + newZone);
+         assertTrue(inSync.apply(newHostedZone.getChange()), "zone didn't sync " + newHostedZone);
          sync(api(zoneId).apply(createAll(records)));
 
          checkAllRRs(zoneId);
 
          sync(api(zoneId).apply(deleteAll(records)));
 
-         PagedIterable<RecordSet> refreshed = refresh(zoneId);
+         PagedIterable<ResourceRecordSet> refreshed = refresh(zoneId);
          assertTrue(refreshed.concat().filter(not(requiredRRTypes)).isEmpty(), "zone still has optional records: "
                + refreshed);
 
       } finally {
-         clearAndDeleteZonesNamed(name);
+         clearAndDeleteHostedZonesNamed(name);
       }
    }
 
-   private void clearAndDeleteZonesNamed(String name) {
-      for (Zone zone : context.getApi().getZoneApi().list().concat().filter(nameEquals(name))) {
+   private void clearAndDeleteHostedZonesNamed(String name) {
+      for (HostedZone zone : context.getApi().getHostedZoneApi().list().concat().filter(nameEquals(name))) {
          getAnonymousLogger().info("clearing and deleting zone: " + zone);
-         Set<RecordSet> remaining = refresh(zone.getId()).concat().filter(not(requiredRRTypes)).toSet();
+         Set<ResourceRecordSet> remaining = refresh(zone.getId()).concat().filter(not(requiredRRTypes)).toSet();
          if (!remaining.isEmpty())
             sync(api(zone.getId()).apply(deleteAll(remaining)));
-         sync(context.getApi().getZoneApi().delete(zone.getId()));
+         sync(context.getApi().getHostedZoneApi().delete(zone.getId()));
       }
    }
 
@@ -155,18 +152,18 @@ public class RecordSetApiLiveTest extends BaseRoute53ApiLiveTest {
       assertTrue(inSync.apply(job), "job didn't sync " + job);
    }
 
-   private PagedIterable<RecordSet> refresh(String zoneId) {
+   private PagedIterable<ResourceRecordSet> refresh(String zoneId) {
       return api(zoneId).list();
    }
 
-   private PagedIterable<Zone> zones() {
-      PagedIterable<Zone> zones = context.getApi().getZoneApi().list();
+   private PagedIterable<HostedZone> zones() {
+      PagedIterable<HostedZone> zones = context.getApi().getHostedZoneApi().list();
       if (zones.get(0).isEmpty())
          throw new SkipException("no zones in context: " + context);
       return zones;
    }
 
-   private RecordSetApi api(String zoneId) {
-      return context.getApi().getRecordSetApiForZone(zoneId);
+   private ResourceRecordSetApi api(String zoneId) {
+      return context.getApi().getResourceRecordSetApiForHostedZone(zoneId);
    }
 }

--- a/apis/route53/src/test/java/org/jclouds/route53/parse/CreateHostedZoneResponseTest.java
+++ b/apis/route53/src/test/java/org/jclouds/route53/parse/CreateHostedZoneResponseTest.java
@@ -23,7 +23,7 @@ import static org.testng.Assert.assertEquals;
 import java.io.InputStream;
 
 import org.jclouds.http.functions.BaseHandlerTest;
-import org.jclouds.route53.domain.NewZone;
+import org.jclouds.route53.domain.NewHostedZone;
 import org.jclouds.route53.xml.CreateHostedZoneResponseHandler;
 import org.testng.annotations.Test;
 
@@ -37,15 +37,15 @@ public class CreateHostedZoneResponseTest extends BaseHandlerTest {
    public void test() {
       InputStream is = getClass().getResourceAsStream("/new_zone.xml");
 
-      NewZone expected = expected();
+      NewHostedZone expected = expected();
 
       CreateHostedZoneResponseHandler handler = injector.getInstance(CreateHostedZoneResponseHandler.class);
-      NewZone result = factory.create(handler).parse(is);
+      NewHostedZone result = factory.create(handler).parse(is);
 
       assertEquals(result, expected);
    }
 
-   public NewZone expected() {
-      return NewZone.create(new GetHostedZoneResponseTest().expected(), new GetChangeResponseTest().expected());
+   public NewHostedZone expected() {
+      return NewHostedZone.create(new GetHostedZoneResponseTest().expected(), new GetChangeResponseTest().expected());
    }
 }

--- a/apis/route53/src/test/java/org/jclouds/route53/parse/GetHostedZoneResponseTest.java
+++ b/apis/route53/src/test/java/org/jclouds/route53/parse/GetHostedZoneResponseTest.java
@@ -23,8 +23,8 @@ import static org.testng.Assert.assertEquals;
 import java.io.InputStream;
 
 import org.jclouds.http.functions.BaseHandlerTest;
-import org.jclouds.route53.domain.Zone;
-import org.jclouds.route53.domain.ZoneAndNameServers;
+import org.jclouds.route53.domain.HostedZone;
+import org.jclouds.route53.domain.HostedZoneAndNameServers;
 import org.jclouds.route53.xml.GetHostedZoneResponseHandler;
 import org.testng.annotations.Test;
 
@@ -40,16 +40,16 @@ public class GetHostedZoneResponseTest extends BaseHandlerTest {
    public void test() {
       InputStream is = getClass().getResourceAsStream("/hosted_zone.xml");
 
-      ZoneAndNameServers expected = expected();
+      HostedZoneAndNameServers expected = expected();
 
       GetHostedZoneResponseHandler handler = injector.getInstance(GetHostedZoneResponseHandler.class);
-      ZoneAndNameServers result = factory.create(handler).parse(is);
+      HostedZoneAndNameServers result = factory.create(handler).parse(is);
 
       assertEquals(result, expected);
    }
 
-   public ZoneAndNameServers expected() {
-      return ZoneAndNameServers.create(Zone.builder()
+   public HostedZoneAndNameServers expected() {
+      return HostedZoneAndNameServers.create(HostedZone.builder()
                                            .id("Z21DW1QVGID6NG")
                                            .name("example.com.")
                                            .callerReference("a_unique_reference")

--- a/apis/route53/src/test/java/org/jclouds/route53/parse/ListHostedZonesResponseTest.java
+++ b/apis/route53/src/test/java/org/jclouds/route53/parse/ListHostedZonesResponseTest.java
@@ -25,7 +25,7 @@ import java.io.InputStream;
 import org.jclouds.collect.IterableWithMarker;
 import org.jclouds.collect.IterableWithMarkers;
 import org.jclouds.http.functions.BaseHandlerTest;
-import org.jclouds.route53.domain.Zone;
+import org.jclouds.route53.domain.HostedZone;
 import org.jclouds.route53.xml.ListHostedZonesResponseHandler;
 import org.testng.annotations.Test;
 
@@ -41,25 +41,25 @@ public class ListHostedZonesResponseTest extends BaseHandlerTest {
    public void test() {
       InputStream is = getClass().getResourceAsStream("/hosted_zones.xml");
 
-      IterableWithMarker<Zone> expected = expected();
+      IterableWithMarker<HostedZone> expected = expected();
 
       ListHostedZonesResponseHandler handler = injector.getInstance(ListHostedZonesResponseHandler.class);
-      IterableWithMarker<Zone> result = factory.create(handler).parse(is);
+      IterableWithMarker<HostedZone> result = factory.create(handler).parse(is);
 
       assertEquals(result.toString(), expected.toString());
 
    }
 
-   public IterableWithMarker<Zone> expected() {
+   public IterableWithMarker<HostedZone> expected() {
       return IterableWithMarkers.from(
             ImmutableSet.of(
-                  Zone.builder()
+                  HostedZone.builder()
                       .id("Z21DW1QVGID6NG")
                       .name("example.com.")
                       .callerReference("a_unique_reference")
                       .resourceRecordSetCount(17)
                       .comment("Migrate an existing domain to Route 53").build(),
-                  Zone.builder()
+                  HostedZone.builder()
                       .id("Z2682N5HXP0BZ4")
                       .name("example2.com.")
                       .callerReference("a_unique_reference2")

--- a/apis/route53/src/test/java/org/jclouds/route53/parse/ListResourceRecordSetsResponseTest.java
+++ b/apis/route53/src/test/java/org/jclouds/route53/parse/ListResourceRecordSetsResponseTest.java
@@ -23,9 +23,8 @@ import static org.testng.Assert.assertEquals;
 import java.io.InputStream;
 
 import org.jclouds.http.functions.BaseHandlerTest;
-import org.jclouds.route53.domain.RecordSet;
-import org.jclouds.route53.domain.RecordSet.Type;
-import org.jclouds.route53.domain.RecordSetIterable;
+import org.jclouds.route53.domain.ResourceRecordSet;
+import org.jclouds.route53.domain.ResourceRecordSetIterable;
 import org.jclouds.route53.xml.ListResourceRecordSetsResponseHandler;
 import org.testng.annotations.Test;
 
@@ -40,26 +39,26 @@ public class ListResourceRecordSetsResponseTest extends BaseHandlerTest {
    public void test() {
       InputStream is = getClass().getResourceAsStream("/rrsets.xml");
 
-      RecordSetIterable expected = expected();
+      ResourceRecordSetIterable expected = expected();
 
       ListResourceRecordSetsResponseHandler handler = injector.getInstance(ListResourceRecordSetsResponseHandler.class);
-      RecordSetIterable result = factory.create(handler).parse(is);
+      ResourceRecordSetIterable result = factory.create(handler).parse(is);
 
       assertEquals(result.toString(), expected.toString());
 
    }
 
-   public RecordSetIterable expected() {
-      return RecordSetIterable.builder()
-            .add(RecordSet.builder()
+   public ResourceRecordSetIterable expected() {
+      return ResourceRecordSetIterable.builder()
+            .add(ResourceRecordSet.builder()
                                   .name("example.com.")
-                                  .type(Type.SOA)
+                                  .type("SOA")
                                   .ttl(900)
                                   .add("ns-2048.awsdns-64.net. hostmaster.awsdns.com. 1 7200 900 1209600 86400")
                                   .build())
-            .add(RecordSet.builder()
+            .add(ResourceRecordSet.builder()
                                   .name("example.com.")
-                                  .type(Type.NS)
+                                  .type("NS")
                                   .ttl(172800)
                                   .add("ns-2048.awsdns-64.com.")
                                   .add("ns-2049.awsdns-65.net.")
@@ -67,6 +66,6 @@ public class ListResourceRecordSetsResponseTest extends BaseHandlerTest {
                                   .add("ns-2051.awsdns-67.co.uk.")
                                   .build())
             .nextRecordName("testdoc2.example.com")
-            .nextRecordType(Type.NS).build();
+            .nextRecordType("NS").build();
    }
 }

--- a/apis/route53/src/test/java/org/jclouds/route53/predicates/HostedZonePredicatesTest.java
+++ b/apis/route53/src/test/java/org/jclouds/route53/predicates/HostedZonePredicatesTest.java
@@ -18,35 +18,26 @@
  */
 package org.jclouds.route53.predicates;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static org.jclouds.route53.predicates.HostedZonePredicates.nameEquals;
 
-import org.jclouds.route53.domain.Zone;
-
-import com.google.common.base.Predicate;
+import org.jclouds.route53.domain.HostedZone;
+import org.testng.annotations.Test;
 
 /**
- * Predicates handy when working with Zones
  * 
  * @author Adrian Cole
  */
-public class ZonePredicates {
+@Test(groups = "unit", testName = "HostedZonePredicatesTest")
+public class HostedZonePredicatesTest {
+   HostedZone zone = HostedZone.builder().id("EEEFFFEEE").callerReference("goog").name("jclouds.org.").build();
 
-   /**
-    * matches zones of the given name
-    */
-   public static Predicate<Zone> nameEquals(final String name) {
-      checkNotNull(name, "name must be defined");
+   @Test
+   public void testNameEqualsWhenEqual() {
+      assert nameEquals("jclouds.org.").apply(zone);
+   }
 
-      return new Predicate<Zone>() {
-         @Override
-         public boolean apply(Zone zone) {
-            return name.equals(zone.getName());
-         }
-
-         @Override
-         public String toString() {
-            return "nameEquals(" + name + ")";
-         }
-      };
+   @Test
+   public void testNameEqualsWhenNotEqual() {
+      assert !nameEquals("kclouds.org.").apply(zone);
    }
 }

--- a/apis/route53/src/test/java/org/jclouds/route53/predicates/ResourceRecordSetPredicatesTest.java
+++ b/apis/route53/src/test/java/org/jclouds/route53/predicates/ResourceRecordSetPredicatesTest.java
@@ -18,26 +18,27 @@
  */
 package org.jclouds.route53.predicates;
 
-import static org.jclouds.route53.predicates.ZonePredicates.nameEquals;
+import static org.jclouds.route53.predicates.ResourceRecordSetPredicates.typeEquals;
 
-import org.jclouds.route53.domain.Zone;
+import org.jclouds.route53.domain.ResourceRecordSet;
 import org.testng.annotations.Test;
 
 /**
  * 
  * @author Adrian Cole
  */
-@Test(groups = "unit", testName = "ZonePredicatesTest")
-public class ZonePredicatesTest {
-   Zone zone = Zone.builder().id("EEEFFFEEE").callerReference("goog").name("jclouds.org.").build();
+@Test(groups = "unit", testName = "ResourceRecordSetPredicatesTest")
+public class ResourceRecordSetPredicatesTest {
+   ResourceRecordSet rrs = ResourceRecordSet.builder().name("jclouds.org.").type("NS").add("ns-119.awsdns-14.com.")
+         .build();
 
    @Test
-   public void testNameEqualsWhenEqual() {
-      assert nameEquals("jclouds.org.").apply(zone);
+   public void testTypeEqualsWhenEqual() {
+      assert typeEquals("NS").apply(rrs);
    }
 
    @Test
-   public void testNameEqualsWhenNotEqual() {
-      assert !nameEquals("kclouds.org.").apply(zone);
+   public void testTypeEqualsWhenNotEqual() {
+      assert !typeEquals("AAAA").apply(rrs);
    }
 }

--- a/providers/aws-route53/src/test/java/org/jclouds/aws/route53/features/AWSHostedZoneApiLiveTest.java
+++ b/providers/aws-route53/src/test/java/org/jclouds/aws/route53/features/AWSHostedZoneApiLiveTest.java
@@ -16,31 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.jclouds.route53.predicates;
+package org.jclouds.aws.route53.features;
 
-import static org.jclouds.route53.domain.RecordSet.Type.AAAA;
-import static org.jclouds.route53.domain.RecordSet.Type.NS;
-import static org.jclouds.route53.predicates.RecordSetPredicates.typeEquals;
-
-import org.jclouds.route53.domain.RecordSet;
+import org.jclouds.route53.features.HostedZoneApiLiveTest;
 import org.testng.annotations.Test;
 
 /**
- * 
  * @author Adrian Cole
  */
-@Test(groups = "unit", testName = "ResourceRecordSetPredicatesTest")
-public class RecordSetPredicatesTest {
-   RecordSet rrs = RecordSet.builder().name("jclouds.org.").type(NS).add("ns-119.awsdns-14.com.")
-         .build();
-
-   @Test
-   public void testTypeEqualsWhenEqual() {
-      assert typeEquals(NS).apply(rrs);
-   }
-
-   @Test
-   public void testTypeEqualsWhenNotEqual() {
-      assert !typeEquals(AAAA).apply(rrs);
+@Test(groups = "live", testName = "AWSHostedZoneApiLiveTest")
+public class AWSHostedZoneApiLiveTest extends HostedZoneApiLiveTest {
+   public AWSHostedZoneApiLiveTest() {
+      provider = "aws-route53";
    }
 }

--- a/providers/aws-route53/src/test/java/org/jclouds/aws/route53/features/AWSResourceRecordSetApiLiveTest.java
+++ b/providers/aws-route53/src/test/java/org/jclouds/aws/route53/features/AWSResourceRecordSetApiLiveTest.java
@@ -18,15 +18,15 @@
  */
 package org.jclouds.aws.route53.features;
 
-import org.jclouds.route53.features.RecordSetApiLiveTest;
+import org.jclouds.route53.features.ResourceRecordSetApiLiveTest;
 import org.testng.annotations.Test;
 
 /**
  * @author Adrian Cole
  */
-@Test(groups = "live", testName = "AWSResourceRecordSetApiLiveTest")
-public class AWSRecordSetApiLiveTest extends RecordSetApiLiveTest {
-   public AWSRecordSetApiLiveTest() {
+@Test(groups = "live", testName = "AWSResourceResourceRecordSetApiLiveTest")
+public class AWSResourceRecordSetApiLiveTest extends ResourceRecordSetApiLiveTest {
+   public AWSResourceRecordSetApiLiveTest() {
       provider = "aws-route53";
    }
 }


### PR DESCRIPTION
synchronized naming of route53 with aws sdk, and changed resource record type from enum to string
