### PR TITLE
Makes AWS-S3 use the right directory suffix

### DIFF
--- a/apis/s3/src/main/java/org/jclouds/s3/S3ApiMetadata.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/S3ApiMetadata.java
@@ -88,7 +88,7 @@ public class S3ApiMetadata extends BaseRestApiMetadata {
       properties.setProperty(PROPERTY_S3_SERVICE_PATH, "/");
       properties.setProperty(PROPERTY_S3_VIRTUAL_HOST_BUCKETS, "true");
       properties.setProperty(PROPERTY_RELAX_HOSTNAME, "true");
-      properties.setProperty(PROPERTY_BLOBSTORE_DIRECTORY_SUFFIX, DIRECTORY_SUFFIX_FOLDER);
+      properties.setProperty(PROPERTY_BLOBSTORE_DIRECTORY_SUFFIX, "/");
       properties.setProperty(PROPERTY_USER_METADATA_PREFIX, String.format("x-${%s}-meta-", PROPERTY_HEADER_TAG));
       return properties;
    }

--- a/apis/s3/src/test/java/org/jclouds/s3/S3ClientMockTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/S3ClientMockTest.java
@@ -81,4 +81,22 @@ public class S3ClientMockTest {
       assertEquals(request.getHeaders(CONTENT_LENGTH), ImmutableList.of("0"));
       server.shutdown();
    }
+
+   public void testDirectorySeparator() throws IOException, InterruptedException {
+	      MockWebServer server = new MockWebServer();
+	      server.enqueue(new MockResponse().setBody("").addHeader(ETAG, "ABCDEF"));
+	      server.play();
+
+	      S3Client client = getContext(server.getUrl("/")).getApi();
+	      S3Object fileInDir = client.newS3Object();
+	      fileInDir.getMetadata().setKey("someDir/fileName");
+	      fileInDir.setPayload(new byte[] {});
+
+	      assertEquals(client.putObject("bucket", fileInDir), "ABCDEF");
+
+	      RecordedRequest request = server.takeRequest();
+	      assertEquals(request.getRequestLine(), "PUT /bucket/someDir/fileName HTTP/1.1");
+
+	      server.shutdown();
+	   }
 }


### PR DESCRIPTION
This change makes AWS-S3 use the right directory suffix. Without this change, calling createDirectory on AWS-S3 with say directory name "someDir" causes it to create a blob named "someDir_$folder_".

This is different from what happens when one goes through the "Create Folder" workflow from the management console. The AWS-S3 documentation says that when a user creates a folder from the management console, , the console creates an object with the key "/". Note the trailing '/' delimiter. See "Basics of Buckets and Folders" at http://awsdocs.s3.amazonaws.com/S3/latest/s3-dg.pdf.

Fixes #1336.
