### PR TITLE
Nova : Allocate a floating IP from a specified pool instead of the default one

### DIFF
--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/extensions/FloatingIPApi.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/extensions/FloatingIPApi.java
@@ -64,7 +64,7 @@ public interface FloatingIPApi {
     *         Pool to allocate IP address from
     * @return a newly created FloatingIP
     */
-   FloatingIP create(String pool);
+   FloatingIP allocateFromPool(String pool);
 
    /**
     * Decreate a Floating IP address

--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/extensions/FloatingIPAsyncApi.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/extensions/FloatingIPAsyncApi.java
@@ -98,7 +98,7 @@ public interface FloatingIPAsyncApi {
    ListenableFuture<? extends FloatingIP> create();
 
    /**
-    * @see org.jclouds.openstack.nova.v2_0.extensions.FloatingIPApi#create
+    * @see org.jclouds.openstack.nova.v2_0.extensions.FloatingIPApi#allocateFromPool
     */
    @Named("floatingip:create")
    @POST
@@ -108,7 +108,7 @@ public interface FloatingIPAsyncApi {
    @Produces(MediaType.APPLICATION_JSON)
    @Fallback(NullOnNotFoundOr404.class)
    @Payload("%7B\"pool\":\"{pool}\"%7D")
-   ListenableFuture<? extends FloatingIP> create(@PayloadParam("pool") String pool);
+   ListenableFuture<? extends FloatingIP> allocateFromPool(@PayloadParam("pool") String pool);
 
 
    /**

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/extensions/FloatingIPApiExpectTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/extensions/FloatingIPApiExpectTest.java
@@ -187,7 +187,7 @@ public class FloatingIPApiExpectTest extends BaseNovaApiExpectTest {
             responseWithKeystoneAccess, extensionsOfNovaRequest, extensionsOfNovaResponse, createFloatingIP,
             createFloatingIPResponse);
 
-      assertEquals(apiWhenFloatingIPsExist.getFloatingIPExtensionForZone("az-1.region-a.geo-1").get().create("myPool").toString(),
+      assertEquals(apiWhenFloatingIPsExist.getFloatingIPExtensionForZone("az-1.region-a.geo-1").get().allocateFromPool("myPool").toString(),
             new ParseFloatingIPTest().expected().toString());
    }
 }

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/extensions/FloatingIPAsyncApiExpectTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/extensions/FloatingIPAsyncApiExpectTest.java
@@ -189,7 +189,7 @@ public class FloatingIPAsyncApiExpectTest extends BaseNovaAsyncApiExpectTest {
               responseWithKeystoneAccess, extensionsOfNovaRequest, extensionsOfNovaResponse, createFloatingIP,
               createFloatingIPResponse);
 
-      assertEquals(apiWhenFloatingIPsExist.getFloatingIPExtensionForZone("az-1.region-a.geo-1").get().create("myPool")
+      assertEquals(apiWhenFloatingIPsExist.getFloatingIPExtensionForZone("az-1.region-a.geo-1").get().allocateFromPool("myPool")
               .get()
               .toString(), new ParseFloatingIPTest().expected().toString());
    }


### PR DESCRIPTION
Use the optional pool parameter to allocate a new floating IP.
