### PR TITLE
Add directory specific live test to AWS-S3.

### DIFF
--- a/providers/aws-s3/src/test/java/org/jclouds/aws/s3/AWSS3ClientLiveTest.java
+++ b/providers/aws-s3/src/test/java/org/jclouds/aws/s3/AWSS3ClientLiveTest.java
@@ -288,4 +288,23 @@ public class AWSS3ClientLiveTest extends S3ClientLiveTest {
       }
    }
 
+   public void testDirectoryEndingWithSlash() throws InterruptedException {
+	   String containerName = getContainerName();
+	   try {
+		   BlobStore blobStore = view.getBlobStore();
+		   blobStore.createDirectory(containerName, "someDir");
+
+		   // According to the S3 documentation, a directory is nothing but a blob
+		   // whose name ends with a '/'. So let's try to remove the blob we just
+		   // created.
+		   blobStore.removeBlob(containerName, "someDir/");
+
+		   // The directory "someDir" shouldn't exist since we removed it. If this
+		   // test succeeds, it confirms that a directory (or folder) is nothing
+		   // but a blob with a name ending in '/'.
+		   assertEquals(blobStore.directoryExists(containerName, "someDir"), false);
+	   } finally {
+		   returnContainer(containerName);
+	   }
+   }
 }


### PR DESCRIPTION
This patch adds a test to the AWS live test suite for making sure
that a directory is basically a blob with a trailing '/'.
