### PR TITLE
There is no need to force the Chef version anymore

### DIFF
--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/chef/InstallChefGems.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/chef/InstallChefGems.java
@@ -34,7 +34,7 @@ public class InstallChefGems extends StatementList {
    public InstallChefGems() {
       // Chef versions prior to 10.16.4 install an incompatible moneta gem.
       // See: http://tickets.opscode.com/browse/CHEF-3721
-      super(new InstallRuby(), exec("gem install chef -v '>= 10.16.4' --no-rdoc --no-ri"));
+      super(new InstallRuby(), exec("gem install chef --no-rdoc --no-ri"));
    }
 
    @Override

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/chef/ChefSoloTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/chef/ChefSoloTest.java
@@ -382,7 +382,7 @@ public class ChefSoloTest {
 
    private static String installChefGems() throws IOException {
       return Resources.toString(Resources.getResource("test_install_ruby." + ShellToken.SH.to(OsFamily.UNIX)),
-            Charsets.UTF_8) + "gem install chef -v '>= 10.16.4' --no-rdoc --no-ri\n";
+            Charsets.UTF_8) + "gem install chef --no-rdoc --no-ri\n";
    }
 
    private static String createConfigFile() {

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/chef/InstallChefGemsTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/chef/InstallChefGemsTest.java
@@ -47,7 +47,7 @@ public class InstallChefGemsTest {
       assertEquals(
             new InstallChefGems().render(OsFamily.UNIX),
             Resources.toString(Resources.getResource("test_install_ruby." + ShellToken.SH.to(OsFamily.UNIX)),
-                  Charsets.UTF_8) + "gem install chef -v '>= 10.16.4' --no-rdoc --no-ri\n");
+                  Charsets.UTF_8) + "gem install chef --no-rdoc --no-ri\n");
    }
 
    public void installChefGemsUnixInScriptBuilderSourcesSetupPublicCurl() throws IOException {

--- a/scriptbuilder/src/test/resources/test_install_chef_gems_scriptbuilder.sh
+++ b/scriptbuilder/src/test/resources/test_install_chef_gems_scriptbuilder.sh
@@ -184,7 +184,7 @@ END_OF_JCLOUDS_SCRIPT
 	gem update --system
 	gem update --no-rdoc --no-ri
 	
-	gem install chef -v '>= 10.16.4' --no-rdoc --no-ri
+	gem install chef --no-rdoc --no-ri
 	
 END_OF_JCLOUDS_SCRIPT
    


### PR DESCRIPTION
[The issue](http://tickets.opscode.com/browse/CHEF-3721) that motivated the change has been fixed, so there is no need to force the Chef version anymore.
