### PR TITLE
Disabled Abiquo build until deps are in Maven central

### DIFF
--- a/labs/pom.xml
+++ b/labs/pom.xml
@@ -59,7 +59,7 @@
        <module>fgcp</module>
        <module>fgcp-au</module>
        <module>fgcp-de</module>
-       <!--
+       <!-- Disabled until Abiquo deps are in Maven Central
        <module>abiquo</module>
        -->
        <module>oauth</module>


### PR DESCRIPTION
Disable the Abiquo build until the dependencies are in Maven Central.
The repository where the dependencies are right now is experiencing some issues making the dependencies inaccessible.

We should not depend on other Maven repositories rather than Maven Central, so this build should be disabled until the dependencies are properly populated.
