### PR TITLE
Fix #1379: Use dependencies from Maven Central

### DIFF
--- a/labs/abiquo/pom.xml
+++ b/labs/abiquo/pom.xml
@@ -15,8 +15,8 @@
     <packaging>bundle</packaging>
     
     <properties>
-        <abiquomodel.version>2.2.0</abiquomodel.version>
-        <abiquoam.version>2.1.2</abiquoam.version>
+        <abiquomodel.version>2.2.0.1</abiquomodel.version>
+        <abiquoam.version>2.1.2.1</abiquoam.version>
         <test.abiquo.endpoint>http://localhost/api</test.abiquo.endpoint>
         <test.abiquo.identity>FIXME</test.abiquo.identity>
         <test.abiquo.credential>FIXME</test.abiquo.credential>
@@ -25,15 +25,6 @@
         <jclouds.osgi.export>org.jclouds.abiquo*;version="${project.version}"</jclouds.osgi.export>
         <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
     </properties>
-    
-    <!-- To be removed when the Abiquo deps are in Maven Central -->
-    <repositories>
-        <repository>
-            <id>abiquo-repo</id>
-            <name>Abiquo Maven Repository</name>
-            <url>http://repo.community.abiquo.com/repo</url>
-        </repository>
-    </repositories>
     
     <dependencies>
         <dependency>

--- a/labs/pom.xml
+++ b/labs/pom.xml
@@ -59,9 +59,7 @@
        <module>fgcp</module>
        <module>fgcp-au</module>
        <module>fgcp-de</module>
-       <!-- Disabled until Abiquo deps are in Maven Central
        <module>abiquo</module>
-       -->
        <module>oauth</module>
        <module>openstack-quantum</module>
        <module>openstack-glance</module>


### PR DESCRIPTION
Get Abiquo dependencies from Maven Central.
