### PR TITLE
Reduce Keystone 1.1 auth token renewal timer

### DIFF
--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/NovaApiMetadata.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/NovaApiMetadata.java
@@ -18,6 +18,7 @@
  */
 package org.jclouds.openstack.nova.v2_0;
 
+import static org.jclouds.Constants.PROPERTY_SESSION_INTERVAL;
 import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
 import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.SERVICE_TYPE;
 import static org.jclouds.openstack.nova.v2_0.config.NovaProperties.AUTO_ALLOCATE_FLOATING_IPS;
@@ -78,6 +79,10 @@ public class NovaApiMetadata extends BaseRestApiMetadata {
       properties.setProperty(AUTO_ALLOCATE_FLOATING_IPS, "false");
       properties.setProperty(AUTO_GENERATE_KEYPAIRS, "false");
       properties.setProperty(TIMEOUT_SECURITYGROUP_PRESENT, "500");
+      // Keystone 1.1 expires tokens after 24 hours and allows renewal 1 hour
+      // before expiry by default.  We choose a value less than the latter
+      // since the former persists between jclouds invocations.
+      properties.setProperty(PROPERTY_SESSION_INTERVAL, 30 * 60 * 60 + "");
       return properties;
    }
 

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/SwiftApiMetadata.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/SwiftApiMetadata.java
@@ -18,6 +18,7 @@
  */
 package org.jclouds.openstack.swift;
 
+import static org.jclouds.Constants.PROPERTY_SESSION_INTERVAL;
 import static org.jclouds.blobstore.reference.BlobStoreConstants.PROPERTY_USER_METADATA_PREFIX;
 import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGIONS;
 import static org.jclouds.reflect.Reflection2.typeToken;
@@ -66,6 +67,10 @@ public class SwiftApiMetadata extends BaseRestApiMetadata {
       Properties properties = BaseRestApiMetadata.defaultProperties();
       properties.setProperty(PROPERTY_USER_METADATA_PREFIX, "X-Object-Meta-");
       properties.setProperty(PROPERTY_REGIONS, "DEFAULT");
+      // Keystone 1.1 expires tokens after 24 hours and allows renewal 1 hour
+      // before expiry by default.  We choose a value less than the latter
+      // since the former persists between jclouds invocations.
+      properties.setProperty(PROPERTY_SESSION_INTERVAL, 30 * 60 * 60 + "");
       return properties;
    }
 

--- a/common/openstack/src/main/java/org/jclouds/openstack/keystone/v1_1/config/AuthenticationServiceModule.java
+++ b/common/openstack/src/main/java/org/jclouds/openstack/keystone/v1_1/config/AuthenticationServiceModule.java
@@ -19,6 +19,7 @@
 package org.jclouds.openstack.keystone.v1_1.config;
 
 import static org.jclouds.rest.config.BinderUtils.bindHttpApi;
+import static org.jclouds.Constants.PROPERTY_SESSION_INTERVAL;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -46,6 +47,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.inject.AbstractModule;
+import com.google.inject.name.Named;
 import com.google.inject.Provides;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 
@@ -104,8 +106,9 @@ public class AuthenticationServiceModule extends AbstractModule {
 
    @Provides
    @Singleton
-   protected LoadingCache<Credentials, Auth> provideAuthCache(GetAuth getAuth) {
-      return CacheBuilder.newBuilder().expireAfterWrite(23, TimeUnit.HOURS).build(getAuth);
+   protected LoadingCache<Credentials, Auth> provideAuthCache(GetAuth getAuth,
+         @Named(PROPERTY_SESSION_INTERVAL) long sessionInterval) {
+      return CacheBuilder.newBuilder().expireAfterWrite(sessionInterval, TimeUnit.SECONDS).build(getAuth);
    }
 
    @Provides


### PR DESCRIPTION
This prevents a situation where we used an expired token.  I saw
symptoms where CloudFiles temporary signed URLs worked for hours 0-23,
renewed the token, worked for hours 23-24, then failed for hours
24-46.  The cycle then repeats.
