### PR TITLE
Correct Keystone 1.1 authentication token timeout

### DIFF
--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/NovaApiMetadata.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/NovaApiMetadata.java
@@ -86,7 +86,7 @@ public class NovaApiMetadata extends BaseRestApiMetadata {
       // Keystone 1.1 expires tokens after 24 hours and allows renewal 1 hour
       // before expiry by default.  We choose a value less than the latter
       // since the former persists between jclouds invocations.
-      properties.setProperty(PROPERTY_SESSION_INTERVAL, 30 * 60 * 60 + "");
+      properties.setProperty(PROPERTY_SESSION_INTERVAL, 30 * 60 + "");
       return properties;
    }
 

--- a/apis/swift/src/main/java/org/jclouds/openstack/swift/SwiftApiMetadata.java
+++ b/apis/swift/src/main/java/org/jclouds/openstack/swift/SwiftApiMetadata.java
@@ -71,7 +71,7 @@ public class SwiftApiMetadata extends BaseRestApiMetadata {
       // Keystone 1.1 expires tokens after 24 hours and allows renewal 1 hour
       // before expiry by default.  We choose a value less than the latter
       // since the former persists between jclouds invocations.
-      properties.setProperty(PROPERTY_SESSION_INTERVAL, 30 * 60 * 60 + "");
+      properties.setProperty(PROPERTY_SESSION_INTERVAL, 30 * 60 + "");
       return properties;
    }
 


### PR DESCRIPTION
We should renew after 30 minutes, not 30 hours.
