### PR TITLE
Correct Guice circular dependency for Keystone 1.1

### DIFF
--- a/common/openstack/src/main/java/org/jclouds/openstack/keystone/v1_1/config/AuthenticationServiceModule.java
+++ b/common/openstack/src/main/java/org/jclouds/openstack/keystone/v1_1/config/AuthenticationServiceModule.java
@@ -113,7 +113,7 @@ public class AuthenticationServiceModule extends AbstractModule {
 
    @Provides
    @Singleton
-   protected LoadingCache<Credentials, Auth> provideAuthCache(GetAuth getAuth,
+   public LoadingCache<Credentials, Auth> provideAuthCache(Function<Credentials, Auth> getAuth,
          @Named(PROPERTY_SESSION_INTERVAL) long sessionInterval) {
       return CacheBuilder.newBuilder().expireAfterWrite(sessionInterval, TimeUnit.SECONDS).build(CacheLoader.from(getAuth));
    }


### PR DESCRIPTION
This commit reverts the parameter type to the same as d54c269.
