### PR TITLE
Use multi-object delete for AWS-S3.

### DIFF
--- a/providers/aws-s3/src/main/java/org/jclouds/aws/s3/blobstore/config/AWSS3BlobStoreContextModule.java
+++ b/providers/aws-s3/src/main/java/org/jclouds/aws/s3/blobstore/config/AWSS3BlobStoreContextModule.java
@@ -21,11 +21,14 @@ package org.jclouds.aws.s3.blobstore.config;
 import org.jclouds.aws.s3.AWSS3AsyncClient;
 import org.jclouds.aws.s3.blobstore.AWSS3AsyncBlobStore;
 import org.jclouds.aws.s3.blobstore.AWSS3BlobStore;
+import org.jclouds.aws.s3.blobstore.strategy.AWSS3DeleteAllKeysInList;
 import org.jclouds.aws.s3.blobstore.strategy.AsyncMultipartUploadStrategy;
 import org.jclouds.aws.s3.blobstore.strategy.MultipartUploadStrategy;
 import org.jclouds.aws.s3.blobstore.strategy.internal.ParallelMultipartUploadStrategy;
 import org.jclouds.aws.s3.blobstore.strategy.internal.SequentialMultipartUploadStrategy;
 import org.jclouds.blobstore.BlobRequestSigner;
+import org.jclouds.blobstore.strategy.ClearContainerStrategy;
+import org.jclouds.blobstore.strategy.ClearListStrategy;
 import org.jclouds.s3.blobstore.S3AsyncBlobStore;
 import org.jclouds.s3.blobstore.S3BlobRequestSigner;
 import org.jclouds.s3.blobstore.S3BlobStore;
@@ -48,6 +51,8 @@ public class AWSS3BlobStoreContextModule extends S3BlobStoreContextModule {
       bind(S3BlobStore.class).to(AWSS3BlobStore.class).in(Scopes.SINGLETON);
       bind(MultipartUploadStrategy.class).to(SequentialMultipartUploadStrategy.class);
       bind(AsyncMultipartUploadStrategy.class).to(ParallelMultipartUploadStrategy.class);
+      bind(ClearListStrategy.class).to(AWSS3DeleteAllKeysInList.class);
+      bind(ClearContainerStrategy.class).to(AWSS3DeleteAllKeysInList.class);
    }
 
    @Override

--- a/providers/aws-s3/src/main/java/org/jclouds/aws/s3/blobstore/strategy/AWSS3DeleteAllKeysInList.java
+++ b/providers/aws-s3/src/main/java/org/jclouds/aws/s3/blobstore/strategy/AWSS3DeleteAllKeysInList.java
@@ -1,0 +1,200 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.aws.s3.blobstore.strategy;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.jclouds.blobstore.options.ListContainerOptions.Builder.recursive;
+import static org.jclouds.concurrent.FutureIterables.awaitCompletion;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.annotation.Resource;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.jclouds.Constants;
+import org.jclouds.aws.s3.AWSS3ApiMetadata;
+import org.jclouds.aws.s3.AWSS3AsyncClient;
+import org.jclouds.blobstore.AsyncBlobStore;
+import org.jclouds.blobstore.domain.PageSet;
+import org.jclouds.blobstore.domain.StorageMetadata;
+import org.jclouds.blobstore.internal.BlobRuntimeException;
+import org.jclouds.blobstore.options.ListContainerOptions;
+import org.jclouds.blobstore.reference.BlobStoreConstants;
+import org.jclouds.blobstore.strategy.ClearContainerStrategy;
+import org.jclouds.blobstore.strategy.ClearListStrategy;
+import org.jclouds.http.handlers.BackoffLimitedRetryHandler;
+import org.jclouds.logging.Logger;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.inject.Inject;
+
+/**
+ * Deletes all keys in the container
+ *
+ * @author Shrinand Javadekar
+ */
+@Singleton
+public class AWSS3DeleteAllKeysInList implements ClearListStrategy, ClearContainerStrategy {
+   @Resource
+   @Named(BlobStoreConstants.BLOBSTORE_LOGGER)
+   private final Logger logger = Logger.NULL;
+   private final ListeningExecutorService userExecutor;
+   protected final AsyncBlobStore connection;
+
+   /** Maximum duration in milliseconds of a request. */
+   @Inject(optional = true)
+   @Named(Constants.PROPERTY_REQUEST_TIMEOUT)
+   protected Long maxTime = Long.MAX_VALUE;
+
+   @Inject
+   public AWSS3DeleteAllKeysInList(@Named(Constants.PROPERTY_USER_THREADS) ListeningExecutorService userExecutor,
+         AsyncBlobStore connection, BackoffLimitedRetryHandler retryHandler) {
+      this.userExecutor = checkNotNull(userExecutor, "userExecutor");
+      this.connection = checkNotNull(connection, "connection");
+   }
+
+   @Override
+   public void execute(String containerName) {
+      execute(containerName, recursive());
+   }
+
+   @Override
+   public void execute(final String containerName, ListContainerOptions options) {
+      String message = options.getDir() != null ? String.format("clearing path %s/%s",
+               containerName, options.getDir()) : String.format("clearing container %s",
+               containerName);
+      options = options.clone();
+      if (options.isRecursive())
+         message += " recursively";
+      logger.debug(message);
+      Map<Set<String>, Exception> exceptions = Maps.newHashMap();
+      Map<Set<String>, ListenableFuture<?>> responses = Maps.newHashMap();
+
+      boolean moreBlobsToDelete = true;
+      while (moreBlobsToDelete) {
+	      // fetch partial directory listing
+	      PageSet<? extends StorageMetadata> listing = null;
+	      ListenableFuture<PageSet<? extends StorageMetadata>> listFuture =
+	    		  connection.list(containerName, options);
+
+	      try {
+	          listing = listFuture.get(maxTime, TimeUnit.MILLISECONDS);
+	      } catch (InterruptedException ie) {
+	    	  logger.debug("Interrupted when listing container: {}", ie.getMessage());
+	    	  return;
+	      } catch (ExecutionException ee) {
+	    	  logger.debug("Exception when listing container: {}", ee.getMessage());
+	    	  return;
+	      } catch (TimeoutException te) {
+	    	  logger.debug("TimedOut when listing container: {}", te.getMessage());
+	    	  return;
+	      } finally {
+	          listFuture.cancel(true);
+	      }
+
+	      int count = 0;
+	      ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+	      Set<String> keys = null;
+
+	      // AWS S3 currently supports multi-delete of 1000 keys in one request.
+	      // Ref: http://docs.aws.amazon.com/AmazonS3/latest/API/multiobjectdeleteapi.html
+	      int maxMultiDeleteKeys = 1000;
+
+	      for (StorageMetadata md : listing) {
+	     	 String fullPath = null;
+
+	     	 switch (md.getType()) {
+	      	   case FOLDER:
+	       	   case RELATIVE_PATH:
+	       	 		fullPath = md.getName() + "/";
+	       	 		break;
+	       	   case BLOB:
+	       	 	   fullPath = parentIsFolder(options, md) ? options.getDir() + "/"
+	       	 				+ md.getName() : md.getName();
+	       	 	   break;
+	       	   case CONTAINER:
+	       		   throw new IllegalArgumentException("Container type not supported");
+	       	   default:
+	       		   throw new UnsupportedOperationException("Multi-delete can currently only process folders, " +
+	       	   			"relative paths, blobs or containers");
+	       	 }
+
+	  	     builder.add(fullPath);
+	   	     count++;
+
+	         if (count % maxMultiDeleteKeys == 0) {
+	             keys = builder.build();
+	       	     deleteKeys(containerName, keys, responses);
+
+	       	     // Create a new builder object for the next set of keys.
+	       	     builder = ImmutableSet.builder();
+	       	     count = 0;
+	         }
+	     }
+
+	     // There may be keys added to the builder that haven't been deleted yet. Do that now.
+	     keys = builder.build();
+	     if (!keys.isEmpty()) {
+	    	 deleteKeys(containerName, keys, responses);
+	     }
+
+	     String marker = listing.getNextMarker();
+	     if (marker == null) {
+	    	 moreBlobsToDelete = false;
+	     } else {
+		     logger.debug("%s with marker %s", message, marker);
+		     options = options.afterMarker(marker);
+	     }
+
+	     try {
+	         exceptions = awaitCompletion(responses, userExecutor, maxTime, logger, message);
+	     } catch (TimeoutException e) {
+	    	 logger.debug("Time out waiting for deleting blobs: {}", e.getMessage());
+	    	 return;
+		 } finally {
+			 for (ListenableFuture<?> future : responses.values()) {
+	           future.cancel(true);
+		     }
+	     }
+
+	     if (!exceptions.isEmpty()) {
+	         throw new BlobRuntimeException(String.format("error %s: %s", message, exceptions));
+	     }
+      }
+   }
+
+   private boolean parentIsFolder(final ListContainerOptions options, final StorageMetadata md) {
+      return options.getDir() != null && md.getName().indexOf('/') == -1;
+   }
+
+   private void deleteKeys(final String containerName, final Set<String> keys, Map<Set<String>,
+		   ListenableFuture<?>> responses) {
+ 	  AWSS3AsyncClient asyncClient = connection.getContext().unwrap(AWSS3ApiMetadata.CONTEXT_TOKEN).getAsyncApi();
+ 	  ListenableFuture<?> deleteFuture = asyncClient.deleteObjects(containerName, keys);
+ 	  responses.put(keys, deleteFuture);
+   }
+}

--- a/providers/aws-s3/src/test/java/org/jclouds/aws/s3/AWSS3DeleteAllKeysInListTest.java
+++ b/providers/aws-s3/src/test/java/org/jclouds/aws/s3/AWSS3DeleteAllKeysInListTest.java
@@ -1,0 +1,271 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.aws.s3;
+
+import static org.easymock.EasyMock.createMock;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.easymock.EasyMock;
+import org.jclouds.aws.s3.blobstore.AWSS3AsyncBlobStore;
+import org.jclouds.aws.s3.blobstore.strategy.AWSS3DeleteAllKeysInList;
+import org.jclouds.blobstore.BlobStoreContext;
+import org.jclouds.blobstore.domain.PageSet;
+import org.jclouds.blobstore.domain.StorageMetadata;
+import org.jclouds.blobstore.domain.StorageType;
+import org.jclouds.blobstore.domain.internal.PageSetImpl;
+import org.jclouds.blobstore.options.ListContainerOptions;
+import org.jclouds.http.handlers.BackoffLimitedRetryHandler;
+import org.jclouds.rest.RestContext;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+
+@Test(singleThreaded = true, testName = "AWSS3DeleteAllKeysInListTest")
+public class AWSS3DeleteAllKeysInListTest {
+	   private static final String containerName = "container";
+	   AWSS3AsyncBlobStore connection = null;
+	   BackoffLimitedRetryHandler retryHandler = null;
+	   ListeningExecutorService userExecutor =
+			   MoreExecutors.listeningDecorator(
+					   Executors.newFixedThreadPool(2));
+	   ListenableFuture<PageSet<? extends StorageMetadata>> listFuture = null;
+	   StorageMetadata storageMetadata = null;
+	   ListContainerOptions recOptions =
+			   ListContainerOptions.Builder.recursive();
+	   BlobStoreContext blobStoreContext = null;
+	   RestContext<AWSS3Client, AWSS3AsyncClient> restContext = null;
+	   AWSS3AsyncClient asyncClient = null;
+	   Set<String> keys = null;
+	   ListenableFuture<?> immediateFuture = Futures.immediateFuture(null);
+	   Long maxTime = Long.MAX_VALUE;
+       AWSS3DeleteAllKeysInList deleter = null;
+       List<StorageMetadata> mdList = null;
+
+	   @SuppressWarnings("unchecked")
+	   @BeforeMethod
+	   protected void setUp() throws IOException {
+		   connection = createMock(AWSS3AsyncBlobStore.class);
+		   retryHandler = createMock(BackoffLimitedRetryHandler.class);
+		   listFuture = EasyMock.createNiceMock(ListenableFuture.class);
+		   storageMetadata = createMock(StorageMetadata.class);
+		   blobStoreContext = createMock(BlobStoreContext.class);
+		   restContext = createMock(RestContext.class);
+		   asyncClient = createMock(AWSS3AsyncClient.class);
+           deleter = new AWSS3DeleteAllKeysInList(userExecutor, connection,
+        		   retryHandler);
+	   }
+
+	   @AfterMethod
+	   protected void resetTest() {
+		   EasyMock.reset(connection, retryHandler, listFuture, storageMetadata,
+				   blobStoreContext, restContext, asyncClient);
+	   }
+
+	   /**
+	    * Private method used record the behavior when deleting a set of keys.
+	    *
+	    * @param keys
+	    */
+	   private void deleteKeys(Set<String> keys)
+	   {
+		   EasyMock.<BlobStoreContext> expect(connection.getContext()).andReturn(blobStoreContext);
+		   EasyMock.<RestContext<AWSS3Client, AWSS3AsyncClient>>
+		       expect(blobStoreContext.unwrap(AWSS3ApiMetadata.CONTEXT_TOKEN)).andReturn(restContext);
+		   EasyMock.<AWSS3AsyncClient> expect(restContext.getAsyncApi()).andReturn(asyncClient);
+		   EasyMock.<ListenableFuture<?>>
+               expect(asyncClient.deleteObjects(containerName, keys)).andReturn(immediateFuture);
+	   }
+
+	   /**
+	    * Tests the deletion of a single blob.
+	    *
+	    * @throws InterruptedException
+	    * @throws ExecutionException
+	    * @throws TimeoutException
+	    */
+	   @Test
+	   public void testDeleterSingleBlob() throws InterruptedException,
+	   		ExecutionException, TimeoutException {
+		   ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+		   PageSet<? extends StorageMetadata> listing = new PageSetImpl<StorageMetadata>(
+						   ImmutableList.of(storageMetadata), null);
+		   EasyMock.<ListenableFuture<PageSet<? extends StorageMetadata>>>
+	   			expect(connection.list(containerName, recOptions)).andReturn(listFuture);
+		   EasyMock.<PageSet<? extends StorageMetadata>>
+		   		expect(listFuture.get(maxTime, TimeUnit.MILLISECONDS)).andReturn(listing);
+		   EasyMock.<StorageType> expect(storageMetadata.getType()).andReturn(StorageType.BLOB);
+		   EasyMock.<String> expect(storageMetadata.getName()).andReturn("ABCD");
+		   builder.add("ABCD");
+		   keys = builder.build();
+		   deleteKeys(keys);
+
+		   EasyMock.replay(connection);
+		   EasyMock.replay(retryHandler);
+		   EasyMock.replay(listFuture);
+		   EasyMock.replay(storageMetadata);
+		   EasyMock.replay(blobStoreContext);
+		   EasyMock.replay(restContext);
+		   EasyMock.replay(asyncClient);
+
+		   deleter.execute(containerName);
+	   }
+
+	   /**
+	    * Tests the deletion of blobs returned by two PageSets.
+	    *
+	    * @throws InterruptedException
+	    * @throws ExecutionException
+	    * @throws TimeoutException
+	    */
+	   @SuppressWarnings("unchecked")
+	   @Test
+	   public void testDeleterTwoPages() throws InterruptedException,
+	   		ExecutionException, TimeoutException {
+		   ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+		   String marker = "page2";
+		   PageSet<? extends StorageMetadata> listing =
+				   new PageSetImpl<StorageMetadata>(ImmutableList.of(storageMetadata), marker);
+
+		   EasyMock.<ListenableFuture<PageSet<? extends StorageMetadata>>>
+	   			expect(connection.list(containerName, recOptions)).andReturn(listFuture).once();
+		   EasyMock.<PageSet<? extends StorageMetadata>>
+		   		expect(listFuture.get(maxTime, TimeUnit.MILLISECONDS)).andReturn(listing);
+		   EasyMock.<StorageType> expect(storageMetadata.getType()).andReturn(StorageType.BLOB);
+		   EasyMock.<String> expect(storageMetadata.getName()).andReturn("ABCD");
+		   builder.add("ABCD");
+		   keys = builder.build();
+		   deleteKeys(keys);
+
+		   // All for "page2"
+		   ImmutableSet.Builder<String> builder2 = ImmutableSet.builder();
+		   StorageMetadata storageMetadata2 = createMock(StorageMetadata.class);
+		   ListContainerOptions recOptions2 =
+				   ListContainerOptions.Builder.afterMarker(marker).recursive();
+		   PageSet<? extends StorageMetadata> listing2 =
+				   new PageSetImpl<StorageMetadata>(ImmutableList.of(storageMetadata2), null);
+		   ListenableFuture<PageSet<? extends StorageMetadata>> listFuture2 =
+				   EasyMock.createNiceMock(ListenableFuture.class);
+
+		   EasyMock.<ListenableFuture<PageSet<? extends StorageMetadata>>>
+	  			expect(connection.list(containerName, recOptions2)).andReturn(listFuture2).once();
+		   EasyMock.<PageSet<? extends StorageMetadata>>
+		   		expect(listFuture2.get(maxTime, TimeUnit.MILLISECONDS)).andReturn(listing2);
+		   EasyMock.<StorageType> expect(storageMetadata2.getType()).andReturn(StorageType.BLOB);
+		   EasyMock.<String> expect(storageMetadata2.getName()).andReturn("ABCD2");
+		   builder2.add("ABCD2");
+		   Set<String> keys2 = builder2.build();
+		   deleteKeys(keys2);
+
+		   EasyMock.replay(connection);
+		   EasyMock.replay(retryHandler);
+		   EasyMock.replay(listFuture);
+		   EasyMock.replay(storageMetadata);
+		   EasyMock.replay(blobStoreContext);
+		   EasyMock.replay(restContext);
+		   EasyMock.replay(asyncClient);
+		   EasyMock.replay(listFuture2);
+		   EasyMock.replay(storageMetadata2);
+
+		   deleter.execute(containerName);
+	   }
+
+	   /**
+	    * Tests the deletion of > 1000 blobs. There are two delete requests
+	    * generated in this case. One for blobs 0-999 and another for 1000+.
+	    *
+	    * @throws InterruptedException
+	    * @throws ExecutionException
+	    * @throws TimeoutException
+	    */
+	   @Test
+	   public void testDeleterThousandsOfBlob() throws InterruptedException,
+	   		ExecutionException, TimeoutException {
+		   ImmutableSet.Builder<String> builder1 = ImmutableSet.builder();
+		   ImmutableSet.Builder<String> builder2 = ImmutableSet.builder();
+		   ImmutableSet.Builder<String> builder = builder1;
+
+		   // Some number > 1000.
+           int TOTAL_KEYS = 1005;
+           mdList = Lists.newArrayListWithCapacity(TOTAL_KEYS);
+           for (int i = 0; i < TOTAL_KEYS; i++) {
+        	   mdList.add(createMock(StorageMetadata.class));
+           }
+
+		   PageSet<? extends StorageMetadata> listing =
+				   new PageSetImpl<StorageMetadata>(mdList, null);
+		   EasyMock.<ListenableFuture<PageSet<? extends StorageMetadata>>>
+	   			expect(connection.list(containerName, recOptions))
+	   				.andReturn(listFuture);
+		   EasyMock.<PageSet<? extends StorageMetadata>>
+		   		expect(listFuture.get(maxTime, TimeUnit.MILLISECONDS))
+		   			.andReturn(listing);
+
+		   int i = 0;
+		   int maxMultiDeleteKeys = 1000;
+		   for (StorageMetadata md : listing) {
+			   String keyName = "ABCD_" + i;
+			   EasyMock.<StorageType> expect(md.getType())
+		   			.andReturn(StorageType.BLOB);
+			   EasyMock.<String> expect(md.getName()).andReturn(keyName);
+
+   		       builder.add(keyName);
+			   i++;
+
+			   if (i % maxMultiDeleteKeys == 0) {
+				   keys = builder.build();
+				   deleteKeys(keys);
+
+		       	   builder = builder2;
+			   }
+		   }
+
+		   keys = builder.build();
+		   if (!keys.isEmpty()) {
+			   deleteKeys(keys);
+		   }
+
+		   EasyMock.replay(connection);
+		   EasyMock.replay(retryHandler);
+		   EasyMock.replay(listFuture);
+		   EasyMock.replay(storageMetadata);
+		   EasyMock.replay(blobStoreContext);
+		   EasyMock.replay(restContext);
+		   EasyMock.replay(asyncClient);
+		   for (i = 0; i < TOTAL_KEYS; i++) {
+			   EasyMock.replay(mdList.get(i));
+		   }
+
+		   deleter.execute(containerName);
+	   }
+}


### PR DESCRIPTION
This commit implements a clearContainer strategy (as well as a clearList strategy) specifically for AWS-S3. It uses the multi-object delete option already exported by the S3 api. This way, 1000 keys can be deleted with one single http request.

Also added unit tests using EasyMock.
