### PR TITLE
Enforce the use of builders in Ruby and Chef statements

### DIFF
--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/chef/ChefSolo.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/chef/ChefSolo.java
@@ -271,7 +271,7 @@ public class ChefSolo implements Statement {
    private RunList runlist;
    private final InstallChefGems installChefGems;
 
-   public ChefSolo(Optional<String> fileCachePath, Optional<String> rolePath, Optional<String> databagPath,
+   protected ChefSolo(Optional<String> fileCachePath, Optional<String> rolePath, Optional<String> databagPath,
          Optional<ImmutableList<String>> cookbookPath, Optional<String> cookbooksArchiveLocation,
          Optional<String> jsonAttributes, Optional<String> group, Optional<Integer> interval,
          Optional<String> logLevel, Optional<String> logFile, Optional<String> nodeName, Optional<Integer> splay,

--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/chef/InstallChefGems.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/chef/InstallChefGems.java
@@ -58,7 +58,7 @@ public class InstallChefGems implements Statement {
 
    private Optional<String> version;
 
-   public InstallChefGems(Optional<String> version) {
+   protected InstallChefGems(Optional<String> version) {
       this.version = version;
    }
 

--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/ruby/InstallRuby.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/ruby/InstallRuby.java
@@ -30,7 +30,17 @@ import org.jclouds.scriptbuilder.domain.StatementList;
  */
 public class InstallRuby extends StatementList {
 
-   public InstallRuby() {
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public static class Builder {
+      public InstallRuby build() {
+         return new InstallRuby();
+      }
+   }
+
+   protected InstallRuby() {
       super(call("setupPublicCurl"), call("installRuby"));
    }
 

--- a/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/ruby/InstallRubyGems.java
+++ b/scriptbuilder/src/main/java/org/jclouds/scriptbuilder/statements/ruby/InstallRubyGems.java
@@ -99,7 +99,7 @@ public class InstallRubyGems implements Statement {
    private Optional<String> updateSystemVersion;
    private boolean updateExistingGems;
 
-   public InstallRubyGems(Optional<String> version, boolean updateSystem, Optional<String> updateSystemVersion,
+   protected InstallRubyGems(Optional<String> version, boolean updateSystem, Optional<String> updateSystemVersion,
          boolean updateExistingGems) {
       this.version = checkNotNull(version, "version must be set");
       this.updateSystem = updateSystem;

--- a/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/ruby/InstallRubyTest.java
+++ b/scriptbuilder/src/test/java/org/jclouds/scriptbuilder/statements/ruby/InstallRubyTest.java
@@ -38,19 +38,19 @@ import com.google.common.io.Resources;
 @Test(groups = "unit", testName = "InstallRubyTest")
 public class InstallRubyTest {
 
-   @Test(expectedExceptions = UnsupportedOperationException.class,
-         expectedExceptionsMessageRegExp = "windows not yet implemented")
+   @Test(expectedExceptions = UnsupportedOperationException.class, expectedExceptionsMessageRegExp = "windows not yet implemented")
    public void installRubyInWindows() {
-      new InstallRuby().render(OsFamily.WINDOWS);
+      InstallRuby.builder().build().render(OsFamily.WINDOWS);
    }
 
    public void installRubyUnix() throws IOException {
-      assertEquals(new InstallRuby().render(OsFamily.UNIX), Resources.toString(
+      assertEquals(InstallRuby.builder().build().render(OsFamily.UNIX), Resources.toString(
             Resources.getResource("test_install_ruby." + ShellToken.SH.to(OsFamily.UNIX)), Charsets.UTF_8));
    }
 
    public void installRubyUnixInScriptBuilderSourcesSetupPublicCurl() throws IOException {
-      assertEquals(InitScript.builder().name("install_ruby").run(new InstallRuby()).build().render(OsFamily.UNIX),
+      assertEquals(
+            InitScript.builder().name("install_ruby").run(InstallRuby.builder().build()).build().render(OsFamily.UNIX),
             Resources.toString(
                   Resources.getResource("test_install_ruby_scriptbuilder." + ShellToken.SH.to(OsFamily.UNIX)),
                   Charsets.UTF_8));


### PR DESCRIPTION
Enforce the use of builders in Ruby and Chef statements, as proposed [here](https://github.com/jclouds/jclouds-examples/pull/27/files#r3608314).

Once this has been merged, the [corresponding changes in jclouds-chef](https://github.com/nacx/jclouds-chef/commit/b0302109484c4fbf8b49e908837fa3b44761a622) should be merged too.

/cc @everett-toews
