### PR TITLE
Remove InputSuppliers.of(InputStream)

### DIFF
--- a/apis/filesystem/src/test/java/org/jclouds/filesystem/FilesystemAsyncBlobStoreTest.java
+++ b/apis/filesystem/src/test/java/org/jclouds/filesystem/FilesystemAsyncBlobStoreTest.java
@@ -52,7 +52,6 @@ import org.jclouds.filesystem.reference.FilesystemConstants;
 import org.jclouds.filesystem.util.Utils;
 import org.jclouds.filesystem.utils.TestUtils;
 import org.jclouds.http.HttpRequest;
-import org.jclouds.io.InputSuppliers;
 import org.jclouds.io.Payload;
 import org.jclouds.io.payloads.PhantomPayload;
 import org.jclouds.io.payloads.StringPayload;
@@ -603,9 +602,7 @@ public class FilesystemAsyncBlobStoreTest {
         InputSupplier<FileInputStream> expectedFile =
                 Files.newInputStreamSupplier(new File(
                 TARGET_CONTAINER_NAME, blobKey));
-        InputSupplier<? extends InputStream> actualFile =
-                InputSuppliers.of(resultBlob.getPayload().getInput());
-        assertTrue(ByteStreams.equal(expectedFile, actualFile),
+        assertTrue(ByteStreams.equal(expectedFile, resultBlob.getPayload()),
                 "Blob payload differs from file content");
         // metadata are verified in the test for blobMetadata, so no need to
         // perform a complete test here

--- a/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobIntegrationTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/integration/internal/BaseBlobIntegrationTest.java
@@ -63,7 +63,6 @@ import org.jclouds.crypto.Crypto;
 import org.jclouds.encryption.internal.JCECrypto;
 import org.jclouds.http.BaseJettyTest;
 import org.jclouds.http.HttpResponseException;
-import org.jclouds.io.InputSuppliers;
 import org.jclouds.io.Payload;
 import org.jclouds.io.Payloads;
 import org.jclouds.io.WriteTo;
@@ -130,7 +129,7 @@ public class BaseBlobIntegrationTest extends BaseBlobStoreIntegrationTest {
    public void testPutFileParallel() throws InterruptedException, IOException, TimeoutException {
 
       File payloadFile = File.createTempFile("testPutFileParallel", "png");
-      Files.copy(InputSuppliers.of(createTestInput()), payloadFile);
+      Files.copy(createTestInput(), payloadFile);
       payloadFile.deleteOnExit();
       
       final Payload testPayload = Payloads.newFilePayload(payloadFile);
@@ -607,13 +606,13 @@ public class BaseBlobIntegrationTest extends BaseBlobStoreIntegrationTest {
       assertEquals(metadata.getContentMetadata().getContentMD5(), md5().hashString(TEST_STRING, UTF_8).asBytes());
    }
 
-   private InputStream createTestInput() throws IOException {
+   private File createTestInput() throws IOException {
       File file = File.createTempFile("testimg", "png");
       file.deleteOnExit();
       Random random = new Random();
       byte[] buffer = new byte[random.nextInt(2 * 1024 * 1024)];
       random.nextBytes(buffer);
       Files.copy(ByteStreams.newInputStreamSupplier(buffer), file);
-      return new FileInputStream(file);
+      return file;
    }
 }

--- a/core/src/main/java/org/jclouds/io/InputSuppliers.java
+++ b/core/src/main/java/org/jclouds/io/InputSuppliers.java
@@ -20,7 +20,6 @@ package org.jclouds.io;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.io.IOException;
 import java.io.InputStream;
 
 import com.google.common.annotations.Beta;
@@ -36,18 +35,6 @@ import com.google.common.io.InputSupplier;
 @Beta
 public class InputSuppliers {
    
-   public static InputSupplier<? extends InputStream> of(final InputStream in) {
-      checkNotNull(in, "in");
-      return new InputSupplier<InputStream>() {
-
-         @Override
-         public InputStream getInput() throws IOException {
-            return in;
-         }
-
-      };
-   }
-
    public static InputSupplier<? extends InputStream> of(String in) {
       byte[] bytes = checkNotNull(in, "in").getBytes(Charsets.UTF_8);
       return ByteStreams.newInputStreamSupplier(bytes);


### PR DESCRIPTION
This method breaks the contract of an InputSupplier since every call
to getInput returns the same InputStream instance.  This is
particularly dangerous when one of the callers mutates or closes the
InputStream which causes all others callers to fail.
