### PR TITLE
Emit Content-Length: 0 for empty PUTs

### DIFF
--- a/core/src/main/java/org/jclouds/http/internal/JavaUrlHttpCommandExecutorService.java
+++ b/core/src/main/java/org/jclouds/http/internal/JavaUrlHttpCommandExecutorService.java
@@ -231,8 +231,9 @@ public class JavaUrlHttpCommandExecutorService extends BaseHttpCommandExecutorSe
    protected void writeNothing(HttpURLConnection connection) {
       if (!HttpRequest.NON_PAYLOAD_METHODS.contains(connection.getRequestMethod())) {
          connection.setRequestProperty(CONTENT_LENGTH, "0");
-         // support zero length posts.
-         if ("POST".equals(connection.getRequestMethod())) {
+         // HttpUrlConnection strips Content-Length: 0 without setDoOutput(true)
+         String method = connection.getRequestMethod();
+         if ("POST".equals(method) || "PUT".equals(method)) {
             connection.setFixedLengthStreamingMode(0);
             connection.setDoOutput(true);
          }


### PR DESCRIPTION
HttpUrlConnection reverts Content-Length: 0 on PUT without
doOutput(true), similar to POST.  This commit allows Azure container
create to succeed.  Closes #1420.
