### PR TITLE
Fixing S3ClientMockTest hanging on Java 7 since 843ed57

### DIFF
--- a/apis/s3/src/test/java/org/jclouds/s3/S3ClientMockTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/S3ClientMockTest.java
@@ -70,9 +70,9 @@ public class S3ClientMockTest {
 
    public void testZeroLengthPutHasContentLengthHeader() throws IOException, InterruptedException {
       MockWebServer server = new MockWebServer();
-      server.enqueue(new MockResponse().setBody("").addHeader(ETAG, "ABCDEF"));
+      server.enqueue(new MockResponse().addHeader(ETAG, "ABCDEF"));
       // hangs on Java 7 without this additional response ?!?
-      server.enqueue(new MockResponse());
+      server.enqueue(new MockResponse().addHeader(ETAG, "ABCDEF"));
       server.play();
 
       S3Client client = getS3Client(server.getUrl("/"));


### PR DESCRIPTION
I have no idea why MockWebServer would need this, but it seems to fix the problem..? Let's see what the PR builder says.
