### PR TITLE
Identity support for openstack-reddwarf

### DIFF
--- a/apis/openstack-keystone/src/main/java/org/jclouds/openstack/v2_0/ServiceType.java
+++ b/apis/openstack-keystone/src/main/java/org/jclouds/openstack/v2_0/ServiceType.java
@@ -33,24 +33,34 @@ public interface ServiceType {
     * Object Storage (Swift)
     */
    public static final String OBJECT_STORE = "object-store";
+   
    /**
     * Compute (Nova)
     */
    public static final String COMPUTE = "compute";
+   
    /**
     * Image Service (Glance)
     */
    public static final String IMAGE = "image";
+   
    /**
     * Identity Service (Keystone)
     */
    public static final String IDENTITY = "identity";
+   
    /**
     * Network Service (Quantum)
     */
    public static final String NETWORK = "network";
+   
    /**
     * Block Storage (Cinder)
     */
    public static final String BLOCK_STORAGE = "volume";
+   
+   /**
+    * Database Service (RedDwarf)
+    */
+   public static final String DATABASE_SERVICE = "databases";
 }

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/parse/ParseAccessTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/parse/ParseAccessTest.java
@@ -33,6 +33,15 @@ import org.jclouds.openstack.keystone.v2_0.domain.User;
 import org.jclouds.rest.annotations.SelectJson;
 import org.testng.annotations.Test;
 
+import static org.jclouds.openstack.v2_0.ServiceType.BLOCK_STORAGE;
+import static org.jclouds.openstack.v2_0.ServiceType.COMPUTE;
+import static org.jclouds.openstack.v2_0.ServiceType.DATABASE_SERVICE;
+import static org.jclouds.openstack.v2_0.ServiceType.IDENTITY;
+import static org.jclouds.openstack.v2_0.ServiceType.IMAGE;
+import static org.jclouds.openstack.v2_0.ServiceType.NETWORK;
+import static org.jclouds.openstack.v2_0.ServiceType.OBJECT_STORE;
+
+
 /**
  * @author Adrian Cole
  */
@@ -59,27 +68,27 @@ public class ParseAccessTest extends BaseItemParserTest<Access> {
                              .role(Role.builder().id("00000000004024").serviceId("140").name("user").tenantId("40806637803162").build())
                              .role(Role.builder().id("00000000004004").serviceId("100").name("domainuser").build())
                              .role(Role.builder().id("00000000004016").serviceId("120").name("netadmin").tenantId("40806637803162").build()).build())
-                   .service(Service.builder().name("Object Storage").type("object-store")
+                   .service(Service.builder().name("Object Storage").type(OBJECT_STORE)
                                    .endpoint(Endpoint.builder()
                                                      .tenantId("40806637803162")
                                                      .publicURL("https://objects.jclouds.org/v1.0/40806637803162")
                                                      .adminURL("https://objects.jclouds.org/v1.0/")
                                                      .id("1.0")
                                                      .region("region-a.geo-1").build()).build())
-                   .service(Service.builder().name("Identity").type("identity")
+                   .service(Service.builder().name("Identity").type(IDENTITY)
                                    .endpoint(Endpoint.builder()
                                                      .publicURL("https://csnode.jclouds.org/v2.0/")
                                                      .adminURL("https://csnode.jclouds.org:35357/v2.0/")
                                                      .region("region-a.geo-1")
                                                      .id("2.0")
                                                      .versionId("2.0").build()).build())
-                   .service(Service.builder().name("Image Management").type("image")
+                   .service(Service.builder().name("Image Management").type(IMAGE)
                                    .endpoint(Endpoint.builder()
                                                      .tenantId("40806637803162")
                                                      .publicURL("https://glance.jclouds.org:9292/v1.0")
                                                      .region("az-1.region-a.geo-1")
                                                      .id("1.0").build()).build())
-                   .service(Service.builder().name("Compute").type("compute")
+                   .service(Service.builder().name("Compute").type(COMPUTE)
                                    .endpoint(Endpoint.builder()
                                                      .tenantId("3456")
                                                      .publicURL("https://az-1.region-a.geo-1.compute.hpcloudsvc.com/v1.1/3456")
@@ -101,7 +110,7 @@ public class ParseAccessTest extends BaseItemParserTest<Access> {
                                                      .versionId("1.1")
                                                      .versionInfo("https://az-3.region-a.geo-1.compute.hpcloudsvc.com/v1.1/")
                                                      .versionList("https://az-3.region-a.geo-1.compute.hpcloudsvc.com").build()).build())
-                   .service(Service.builder().name("Quantum Service").type("network")
+                   .service(Service.builder().name("Quantum Service").type(NETWORK)
                                    .endpoint(Endpoint.builder()
                                                      .tenantId("3456")
                                                      .publicURL("https://csnode.jclouds.org:9696/v1.0/tenants/3456")
@@ -109,12 +118,17 @@ public class ParseAccessTest extends BaseItemParserTest<Access> {
                                                      .adminURL("https://csnode.jclouds.org:9696/v1.0")
                                                      .region("region-a.geo-1")
                                                      .versionId("1.0").build()).build())
-                  .service(Service.builder().name("cinder").type("volume")
+                  .service(Service.builder().name("cinder").type(BLOCK_STORAGE)
                         .endpoint(Endpoint.builder()
                                           .id("08330c2dcbfc4c6c8dc7a0949fbf5da7")
                                           .publicURL("http://172.16.0.1:8776/v1/50cdb4c60374463198695d9f798fa34d")
                                           .internalURL("http://10.0.2.15:8776/v1/50cdb4c60374463198695d9f798fa34d")
                                           .adminURL("http://10.0.2.15:8776/v1/50cdb4c60374463198695d9f798fa34d")
+                                          .region("RegionOne").build()).build())
+                  .service(Service.builder().name("reddwarf").type(DATABASE_SERVICE)
+                        .endpoint(Endpoint.builder()
+                                          .publicURL("http://172.16.0.1:8776/v1/3456")
+                                          .tenantId("123123")
                                           .region("RegionOne").build()).build())
                   .service(Service.builder().name("dns").type("dns")
                         .endpoint(Endpoint.builder()

--- a/apis/openstack-keystone/src/test/resources/keystoneAuthResponse.json
+++ b/apis/openstack-keystone/src/test/resources/keystoneAuthResponse.json
@@ -140,6 +140,17 @@
                 "endpoints_links": []
             },
             {
+                "type": "databases",
+                "name": "reddwarf",
+                "endpoints": [
+                  {
+                    "publicURL": "http://172.16.0.1:8776/v1/3456",
+                    "tenantId": "123123",
+                    "region": "RegionOne"
+                  }
+                ]
+            },
+            {
                 "type": "dns",
                 "name": "dns",
                 "endpoints": [


### PR DESCRIPTION
Adds basic plumbing that will allow adding support for openstack-reddwarf and rackspace clouddatabases as per https://github.com/jclouds/jclouds/issues/1475
