### PR TITLE
Fixing S3ClientMockTest hanging on Java 7 since 843ed57

### DIFF
--- a/apis/s3/src/test/java/org/jclouds/s3/S3ClientMockTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/S3ClientMockTest.java
@@ -70,14 +70,16 @@ public class S3ClientMockTest {
 
    public void testZeroLengthPutHasContentLengthHeader() throws IOException, InterruptedException {
       MockWebServer server = new MockWebServer();
-      server.enqueue(new MockResponse().setBody("").addHeader(ETAG, "ABCDEF"));
+      server.enqueue(new MockResponse().addHeader(ETAG, "ABCDEF"));
+      // hangs on Java 7 without this additional response ?!?
+      server.enqueue(new MockResponse().addHeader(ETAG, "ABCDEF"));
       server.play();
 
       S3Client client = getS3Client(server.getUrl("/"));
       S3Object nada = client.newS3Object();
       nada.getMetadata().setKey("object");
       nada.setPayload(new byte[] {});
-      
+
       assertEquals(client.putObject("bucket", nada), "ABCDEF");
 
       RecordedRequest request = server.takeRequest();


### PR DESCRIPTION
1.6.x version of https://github.com/jclouds/jclouds/pull/1517
