### PR TITLE
Make the URI of Servers and Load Balancers available.

### DIFF
--- a/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/compute/functions/ServerInZoneToNodeMetadata.java
+++ b/apis/openstack-nova/src/main/java/org/jclouds/openstack/nova/v2_0/compute/functions/ServerInZoneToNodeMetadata.java
@@ -52,6 +52,7 @@ import org.jclouds.openstack.nova.v2_0.domain.Server;
 import org.jclouds.openstack.nova.v2_0.domain.Server.Status;
 import org.jclouds.openstack.nova.v2_0.domain.zonescoped.ServerInZone;
 import org.jclouds.openstack.nova.v2_0.domain.zonescoped.ZoneAndId;
+import org.jclouds.openstack.v2_0.domain.Link;
 import org.jclouds.util.InetAddresses2;
 
 import com.google.common.base.Function;
@@ -112,7 +113,13 @@ public class ServerInZoneToNodeMetadata implements Function<ServerInZone, NodeMe
                   AddressToStringTransformationFunction.INSTANCE), isInet4Address));
       builder.privateAddresses(filter(
             transform(filter(from.getAddresses().values(), isPrivateAddress), AddressToStringTransformationFunction.INSTANCE), isInet4Address));
-
+      
+      for (Link link: from.getLinks()) {
+         if (link.getRelation().equals(Link.Relation.SELF)) {
+            builder.uri(link.getHref());
+         }
+      }
+      
       return builder.build();
    }
    

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/compute/functions/ServerInZoneToNodeMetadataTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/compute/functions/ServerInZoneToNodeMetadataTest.java
@@ -143,6 +143,9 @@ public class ServerInZoneToNodeMetadataTest {
       assertNotNull(convertedNodeMetadata.getUserMetadata());
       assertEquals(convertedNodeMetadata.getUserMetadata(),
             ImmutableMap.<String, String> of("Server Label", "Web Head 1", "Image Version", "2.1"));
+      
+      URI expectedURI = URI.create("http://servers.api.openstack.org/v1.1/1234/servers/52415800-8b69-11e0-9b19-734f6f006e54");
+      assertEquals(convertedNodeMetadata.getUri(), expectedURI);
    }
 
    @Test
@@ -167,6 +170,8 @@ public class ServerInZoneToNodeMetadataTest {
 
       assertEquals(convertedNodeMetadata.getLocation(), zone);
 
+      URI expectedURI = URI.create("https://az-1.region-a.geo-1.compute.hpcloudsvc.com/v1.1/37936628937291/servers/71752");
+      assertEquals(convertedNodeMetadata.getUri(), expectedURI);
    }
 
    public Server expectedServer() {

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/parse/ParseServerDiagnostics.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/parse/ParseServerDiagnostics.java
@@ -4,11 +4,12 @@
  */
 package org.jclouds.openstack.nova.v2_0.parse;
 
+import java.util.Map;
+
+import org.jclouds.json.BaseItemParserTest;
+
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
-import java.util.Map;
-import java.util.TreeMap;
-import org.jclouds.json.BaseItemParserTest;
 
 /**
  *

--- a/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/parse/ParseServerTest.java
+++ b/apis/openstack-nova/src/test/java/org/jclouds/openstack/nova/v2_0/parse/ParseServerTest.java
@@ -101,8 +101,13 @@ public class ParseServerTest extends BaseItemParserTest<Server> {
                   .putAll("public", Address.createV4("67.23.10.132"), Address.createV6("::babe:67.23.10.132"),
                   Address.createV4("67.23.10.131"), Address.createV6("::babe:4317:0A83"))
                   .putAll("private", Address.createV4("10.176.42.16"), Address.createV6("::babe:10.176.42.16"))
-                  .build()).build();
-
+                  .build())
+            .links(Link.create(
+                        Relation.SELF, URI.create("http://servers.api.openstack.org/v1.1/1234/servers/52415800-8b69-11e0-9b19-734f6f006e54")),
+                   Link.create(
+                        Relation.BOOKMARK,
+                        URI.create("http://servers.api.openstack.org/1234/servers/52415800-8b69-11e0-9b19-734f6f006e54")))
+            .build();
    }
 
    protected Injector injector() {

--- a/apis/openstack-nova/src/test/resources/server_details.json
+++ b/apis/openstack-nova/src/test/resources/server_details.json
@@ -72,6 +72,14 @@
             "Image Version": "2.1"
         },
         "links": [
-        ]
+           {
+               "rel": "self",
+               "href": "http://servers.api.openstack.org/v1.1/1234/servers/52415800-8b69-11e0-9b19-734f6f006e54"
+           },
+           {
+               "rel": "bookmark",
+               "href": "http://servers.api.openstack.org/1234/servers/52415800-8b69-11e0-9b19-734f6f006e54"
+           }
+       ]
     }
 }

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/v1/domain/LoadBalancer.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/v1/domain/LoadBalancer.java
@@ -21,6 +21,7 @@ package org.jclouds.rackspace.cloudloadbalancers.v1.domain;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.net.URI;
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
@@ -51,6 +52,7 @@ public class LoadBalancer extends BaseLoadBalancer<Node, LoadBalancer> {
    private final SourceAddresses sourceAddresses;
    private final Set<AccessRuleWithId> accessRules;
    private final Metadata metadata;
+   private final URI uri;
 
    public LoadBalancer(String region, int id, String name, String protocol, @Nullable Integer port, Set<Node> nodes,
          @Nullable Integer timeout, @Nullable Boolean halfClosed, @Nullable Algorithm algorithm, Status status,
@@ -58,7 +60,7 @@ public class LoadBalancer extends BaseLoadBalancer<Node, LoadBalancer> {
          String clusterName, Date created, Date updated, @Nullable Map<String, Boolean> connectionLogging,
          @Nullable ConnectionThrottle connectionThrottle, boolean contentCaching, int nodeCount,
          @Nullable HealthMonitor healthMonitor, @Nullable SSLTermination sslTermination,
-         SourceAddresses sourceAddresses, Set<AccessRuleWithId> accessRules, Metadata metadata) {
+         SourceAddresses sourceAddresses, Set<AccessRuleWithId> accessRules, Metadata metadata, URI uri) {
       super(name, protocol, port, nodes, algorithm, timeout, halfClosed, sessionPersistenceType, connectionLogging,
             connectionThrottle, healthMonitor);
       this.region = checkNotNull(region, "region");
@@ -75,6 +77,7 @@ public class LoadBalancer extends BaseLoadBalancer<Node, LoadBalancer> {
       this.sourceAddresses = sourceAddresses;
       this.accessRules = accessRules == null ? ImmutableSet.<AccessRuleWithId> of() : ImmutableSet.copyOf(accessRules);
       this.metadata = metadata == null ? new Metadata() : metadata;
+      this.uri = uri;
    }
 
    public String getRegion() {
@@ -167,6 +170,10 @@ public class LoadBalancer extends BaseLoadBalancer<Node, LoadBalancer> {
    public Metadata getMetadata() {
       return metadata;
    }
+   
+   public URI getUri() {
+      return uri;
+   }
 
    protected ToStringHelper string() {
       return Objects.toStringHelper(this).omitNullValues().add("id", id).add("region", region).add("status", status)
@@ -176,7 +183,7 @@ public class LoadBalancer extends BaseLoadBalancer<Node, LoadBalancer> {
             .add("contentCaching", contentCaching).add("sessionPersistenceType", getSessionPersistenceType())
             .add("sslTermination", sslTermination).add("connectionLogging", isConnectionLogging())
             .add("connectionThrottle", connectionThrottle).add("healthMonitor", healthMonitor)
-            .add("accessRules", accessRules).add("metadata", getMetadata()).add("sourceAddresses", sourceAddresses)
+            .add("accessRules", accessRules).add("metadata", getMetadata()).add("uri", uri).add("sourceAddresses", sourceAddresses)
             .add("virtualIPs", virtualIPs);
    }
 
@@ -272,6 +279,7 @@ public class LoadBalancer extends BaseLoadBalancer<Node, LoadBalancer> {
       private SourceAddresses sourceAddresses;
       private Set<AccessRuleWithId> accessRules;
       private Metadata metadata;
+      private URI uri;
 
       public Builder region(String region) {
          this.region = region;
@@ -340,11 +348,16 @@ public class LoadBalancer extends BaseLoadBalancer<Node, LoadBalancer> {
          this.metadata = checkNotNull(metadata, "metadata");
          return this;
       }
+      
+      public Builder uri(URI uri) {
+         this.uri = uri;
+         return this;
+      }
 
       public LoadBalancer build() {
          return new LoadBalancer(region, id, name, protocol, port, nodes, timeout, halfClosed, algorithm, status,
                virtualIPs, sessionPersistence, clusterName, created, updated, connectionLogging, connectionThrottle,
-               contentCaching, nodeCount, healthMonitor, sslTermination, sourceAddresses, accessRules, metadata);
+               contentCaching, nodeCount, healthMonitor, sslTermination, sourceAddresses, accessRules, metadata, uri);
       }
 
       /**
@@ -450,7 +463,8 @@ public class LoadBalancer extends BaseLoadBalancer<Node, LoadBalancer> {
          return Builder.class.cast(super.from(in)).region(in.getRegion()).id(in.getId()).status(in.getStatus())
                .virtualIPs(in.getVirtualIPs()).clusterName(in.getClusterName()).created(in.getCreated())
                .updated(in.getUpdated()).contentCaching(in.isContentCaching()).nodeCount(in.getNodeCount())
-               .sslTermination(in.getSSLTermination()).sourceAddresses(in.getSourceAddresses());
+               .sslTermination(in.getSSLTermination()).sourceAddresses(in.getSourceAddresses())
+               .accessRules(in.getAccessRules()).metadata(in.getMetadata()).uri(in.getUri());
       }
    }
 

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/v1/functions/ConvertLB.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/v1/functions/ConvertLB.java
@@ -18,15 +18,17 @@
  */
 package org.jclouds.rackspace.cloudloadbalancers.v1.functions;
 
+import java.net.URI;
+
 import javax.annotation.Resource;
 import javax.inject.Inject;
 
 import org.jclouds.logging.Logger;
 import org.jclouds.rackspace.cloudloadbalancers.v1.domain.AccessRuleWithId;
 import org.jclouds.rackspace.cloudloadbalancers.v1.domain.LoadBalancer;
+import org.jclouds.rackspace.cloudloadbalancers.v1.domain.LoadBalancer.Builder;
 import org.jclouds.rackspace.cloudloadbalancers.v1.domain.Metadata;
 import org.jclouds.rackspace.cloudloadbalancers.v1.domain.VirtualIPWithId;
-import org.jclouds.rackspace.cloudloadbalancers.v1.domain.LoadBalancer.Builder;
 
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableSet;
@@ -37,18 +39,21 @@ import com.google.inject.assistedinject.Assisted;
  * @author Adrian Cole
  */
 public class ConvertLB implements Function<LB, LoadBalancer> {
+   private static final String LOAD_BALANCERS = "loadbalancers";
 
    public static interface Factory {
-      ConvertLB createForRegion(String region);
+      ConvertLB createForEndpointAndRegion(URI endpoint, String region);
    }
 
    @Resource
    protected Logger logger = Logger.NULL;
 
    private final String region;
+   private final URI endpoint;
 
    @Inject
-   ConvertLB(@Assisted String region) {
+   ConvertLB(@Assisted URI endpoint, @Assisted String region) {
+      this.endpoint = endpoint;
       this.region = region.toUpperCase();
    }
 
@@ -85,6 +90,10 @@ public class ConvertLB implements Function<LB, LoadBalancer> {
             builder.metadata(new Metadata());
          else
             builder.metadata(ParseMetadata.transformCLBMetadataToMetadata(lb.metadata));
+         
+         int indexOfLB = endpoint.toString().lastIndexOf(LOAD_BALANCERS); 
+         String path = endpoint.toString().substring(0, indexOfLB + LOAD_BALANCERS.length()); 
+         builder.uri(URI.create(path + "/" + lb.id));
 
          return builder.build();
       }

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/v1/functions/ParseLoadBalancer.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/v1/functions/ParseLoadBalancer.java
@@ -21,6 +21,7 @@ package org.jclouds.rackspace.cloudloadbalancers.v1.functions;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
+import java.net.URI;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -63,12 +64,14 @@ public class ParseLoadBalancer implements Function<HttpResponse, LoadBalancer>, 
 
    @Override
    public ParseLoadBalancer setContext(HttpRequest request) {
-      return setRegion(request.getEndpoint().getHost().substring(0, request.getEndpoint().getHost().indexOf('.')));
+      return setEndpointAndRegion(request.getEndpoint());
    }
 
-   ParseLoadBalancer setRegion(String region) {
-      this.convertLB = factory.createForRegion(region);
+   ParseLoadBalancer setEndpointAndRegion(URI endpoint) {
+      String region = endpoint.getHost().substring(0, endpoint.getHost().indexOf('.'));
+      
+      this.convertLB = factory.createForEndpointAndRegion(endpoint, region);
+      
       return this;
    }
-
 }

--- a/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/v1/functions/ParseLoadBalancers.java
+++ b/apis/rackspace-cloudloadbalancers/src/main/java/org/jclouds/rackspace/cloudloadbalancers/v1/functions/ParseLoadBalancers.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.jclouds.openstack.v2_0.options.PaginationOptions.Builder.marker;
 
 import java.beans.ConstructorProperties;
+import java.net.URI;
 
 import javax.inject.Inject;
 
@@ -76,11 +77,14 @@ public class ParseLoadBalancers implements Function<HttpResponse, IterableWithMa
 
    @Override
    public ParseLoadBalancers setContext(HttpRequest request) {
-      return setRegion(request.getEndpoint().getHost().substring(0, request.getEndpoint().getHost().indexOf('.')));
+      return setEndpointAndRegion(request.getEndpoint());
    }
 
-   ParseLoadBalancers setRegion(String region) {
-      this.convertLB = factory.createForRegion(region);
+   ParseLoadBalancers setEndpointAndRegion(URI endpoint) {
+      String region = endpoint.getHost().substring(0, endpoint.getHost().indexOf('.'));
+      
+      this.convertLB = factory.createForEndpointAndRegion(endpoint, region);
+      
       return this;
    }
 

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/v1/functions/ParseLoadBalancerTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/v1/functions/ParseLoadBalancerTest.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.rackspace.cloudloadbalancers.v1.functions;
 
+import java.net.URI;
+
 import org.jclouds.date.internal.SimpleDateFormatDateService;
 import org.jclouds.http.HttpResponse;
 import org.jclouds.json.BaseItemParserTest;
@@ -96,7 +98,8 @@ public class ParseLoadBalancerTest extends BaseItemParserTest<LoadBalancer> {
             .clusterName("c1.dfw1")
             .created(new SimpleDateFormatDateService().iso8601SecondsDateParse("2010-11-30T03:23:42Z"))
             .updated(new SimpleDateFormatDateService().iso8601SecondsDateParse("2010-11-30T03:23:44Z"))
-            .metadata(metadata).build();
+            .metadata(metadata)
+            .uri(URI.create("https://dfw.loadbalancers.api.rackspacecloud.com/v1.0/123123/loadbalancers/2000")).build();
    }
 
    // add factory binding as this is not default
@@ -115,6 +118,6 @@ public class ParseLoadBalancerTest extends BaseItemParserTest<LoadBalancer> {
 
    @Override
    protected Function<HttpResponse, LoadBalancer> parser(Injector i) {
-      return i.getInstance(ParseLoadBalancer.class).setRegion("DFW");
+      return i.getInstance(ParseLoadBalancer.class).setEndpointAndRegion(URI.create("https://dfw.loadbalancers.api.rackspacecloud.com/v1.0/123123/loadbalancers/2000"));
    }
 }

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/v1/functions/ParseLoadBalancerWhenDeletedTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/v1/functions/ParseLoadBalancerWhenDeletedTest.java
@@ -18,6 +18,8 @@
  */
 package org.jclouds.rackspace.cloudloadbalancers.v1.functions;
 
+import java.net.URI;
+
 import org.jclouds.date.internal.SimpleDateFormatDateService;
 import org.jclouds.http.HttpResponse;
 import org.jclouds.json.BaseItemParserTest;
@@ -48,7 +50,8 @@ public class ParseLoadBalancerWhenDeletedTest extends BaseItemParserTest<LoadBal
    public LoadBalancer expected() {
       return LoadBalancer.builder().region("LON").id(4865).name("adriancole-LON").status(Status.DELETED).nodeCount(0)
             .created(new SimpleDateFormatDateService().iso8601SecondsDateParse("2011-12-05T18:03:23Z"))
-            .updated(new SimpleDateFormatDateService().iso8601SecondsDateParse("2011-12-05T18:04:04Z")).build();
+            .updated(new SimpleDateFormatDateService().iso8601SecondsDateParse("2011-12-05T18:04:04Z"))
+            .uri(URI.create("https://lon.loadbalancers.api.rackspacecloud.com/v1.0/123123/loadbalancers/4865")).build();
    }
 
    // add factory binding as this is not default
@@ -67,6 +70,6 @@ public class ParseLoadBalancerWhenDeletedTest extends BaseItemParserTest<LoadBal
 
    @Override
    protected Function<HttpResponse, LoadBalancer> parser(Injector i) {
-      return i.getInstance(ParseLoadBalancer.class).setRegion("LON");
+      return i.getInstance(ParseLoadBalancer.class).setEndpointAndRegion(URI.create("https://lon.loadbalancers.api.rackspacecloud.com/v1.0/123123/loadbalancers/4865"));
    }
 }

--- a/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/v1/functions/ParseLoadBalancersTest.java
+++ b/apis/rackspace-cloudloadbalancers/src/test/java/org/jclouds/rackspace/cloudloadbalancers/v1/functions/ParseLoadBalancersTest.java
@@ -18,6 +18,7 @@
  */
 package org.jclouds.rackspace.cloudloadbalancers.v1.functions;
 
+import java.net.URI;
 import java.util.Set;
 
 import org.jclouds.collect.IterableWithMarker;
@@ -62,7 +63,8 @@ public class ParseLoadBalancersTest extends BaseIterableWithMarkerParserTest<Loa
                   .virtualIPs(ImmutableSet.of(
                         new VirtualIPWithId(VirtualIP.Type.PUBLIC, VirtualIP.IPVersion.IPV4, 403, "206.55.130.1")))
                   .created(new SimpleDateFormatDateService().iso8601SecondsDateParse("2010-11-30T03:23:42Z"))
-                  .updated(new SimpleDateFormatDateService().iso8601SecondsDateParse("2010-11-30T03:23:44Z")).build(),
+                  .updated(new SimpleDateFormatDateService().iso8601SecondsDateParse("2010-11-30T03:23:44Z"))
+                  .uri(URI.create("https://dfw.loadbalancers.api.rackspacecloud.com/v1.0/123123/loadbalancers/71")).build(),
             LoadBalancer
                   .builder()
                   .region("DFW")
@@ -76,7 +78,8 @@ public class ParseLoadBalancersTest extends BaseIterableWithMarkerParserTest<Loa
                   .virtualIPs(ImmutableSet.of(
                         new VirtualIPWithId(VirtualIP.Type.PUBLIC, VirtualIP.IPVersion.IPV4, 401, "206.55.130.2")))
                   .created(new SimpleDateFormatDateService().iso8601SecondsDateParse("2010-11-30T03:23:42Z"))
-                  .updated(new SimpleDateFormatDateService().iso8601SecondsDateParse("2010-11-30T03:23:44Z")).build());
+                  .updated(new SimpleDateFormatDateService().iso8601SecondsDateParse("2010-11-30T03:23:44Z"))
+                  .uri(URI.create("https://dfw.loadbalancers.api.rackspacecloud.com/v1.0/123123/loadbalancers/166")).build());
    }
    
    @Override
@@ -105,6 +108,6 @@ public class ParseLoadBalancersTest extends BaseIterableWithMarkerParserTest<Loa
 
    @Override
    protected Function<HttpResponse, IterableWithMarker<LoadBalancer>> parser(Injector i) {
-      return i.getInstance(ParseLoadBalancers.class).setRegion("DFW");
+      return i.getInstance(ParseLoadBalancers.class).setEndpointAndRegion(URI.create("https://dfw.loadbalancers.api.rackspacecloud.com/v1.0/123123/loadbalancers"));
    }
 }


### PR DESCRIPTION
The URIs are needed when working with the Rackspace Cloud Reverse DNS API, see http://docs.rackspace.com/cdns/api/v1.0/cdns-devguide/content/ReverseDNS-123456999.html

If we make them available in Servers and LBs, users can easily get a handle on them and pass them to the Reverse DNS API.

PR for Reverse DNS API to follow shortly.

Will want to cherry pick this into 1.6.x.
