### PR TITLE
Allow Guava MediaType for Content-Type

### DIFF
--- a/blobstore/src/main/java/org/jclouds/blobstore/domain/BlobBuilder.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/domain/BlobBuilder.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.jclouds.blobstore.domain.internal.BlobBuilderImpl;
 import org.jclouds.io.Payload;
 
+import com.google.common.net.MediaType;
 import com.google.inject.ImplementedBy;
 
 /**
@@ -108,6 +109,8 @@ public interface BlobBuilder {
       PayloadBlobBuilder contentLength(long contentLength);
 
       PayloadBlobBuilder contentMD5(byte[] md5);
+
+      PayloadBlobBuilder contentType(MediaType contentType);
 
       PayloadBlobBuilder contentType(String contentType);
 

--- a/blobstore/src/main/java/org/jclouds/blobstore/domain/internal/BlobBuilderImpl.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/domain/internal/BlobBuilderImpl.java
@@ -37,6 +37,7 @@ import org.jclouds.io.Payloads;
 import org.jclouds.io.payloads.PhantomPayload;
 
 import com.google.common.collect.Maps;
+import com.google.common.net.MediaType;
 
 /**
  * @author Adrian Cole
@@ -188,6 +189,11 @@ public class BlobBuilderImpl implements BlobBuilder {
       public PayloadBlobBuilder contentMD5(byte[] md5) {
          payload.getContentMetadata().setContentMD5(md5);
          return this;
+      }
+
+      @Override
+      public PayloadBlobBuilder contentType(MediaType contentType) {
+         return contentType(contentType.toString());
       }
 
       @Override


### PR DESCRIPTION
This promotes type-safety.  Keep the String interface for unknown
content types.
