### PR TITLE
Add random delay to avoid thundering herd problem

### DIFF
--- a/core/src/main/java/org/jclouds/http/handlers/BackoffLimitedRetryHandler.java
+++ b/core/src/main/java/org/jclouds/http/handlers/BackoffLimitedRetryHandler.java
@@ -21,6 +21,7 @@ package org.jclouds.http.handlers;
 import static org.jclouds.http.HttpUtils.releasePayload;
 
 import java.io.IOException;
+import java.util.Random;
 
 import javax.annotation.Resource;
 import javax.inject.Named;
@@ -128,6 +129,9 @@ public class BackoffLimitedRetryHandler implements HttpRetryHandler, IOException
    public void imposeBackoffExponentialDelay(long period, long maxPeriod, int pow, int failureCount, int max,
             String commandDescription) {
       long delayMs = (long) (period * Math.pow(failureCount, pow));
+      // Add random delay to avoid thundering herd problem when multiple
+      // simultaneous failed requests retry after sleeping for the same delay.
+      delayMs += new Random().nextInt((int) (delayMs / 5));
       delayMs = delayMs > maxPeriod ? maxPeriod : delayMs;
       logger.debug("Retry %d/%d: delaying for %d ms: %s", failureCount, max, delayMs, commandDescription);
       try {


### PR DESCRIPTION
When issuing many simultaneous requests to Synaptic Atmos I observed:

HTTP/1.1 failed with code 500, error: AtmosError
[code=1040, message=The server is busy. Please try again.]

Previously all clients slept for fixed intervals and thus retried
around the same time.  This commit adds a random delay which should
better distribute load on the provider.
